### PR TITLE
Fix DB container network alias persistence in deploy test workflow

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -72,14 +72,15 @@ jobs:
               "$DB_CONTAINER_IMAGE"
           fi
 
-      - name: Ensure DB container is on deploy network
+      - name: Ensure DB container is on deploy network with 'pg' alias
         run: |
-          if ! docker network inspect "$DOCKER_NETWORK_NAME" \
-               --format '{{range .Containers}}{{.Name}} {{end}}' \
-               | grep -q "$DB_CONTAINER_NAME"; then
-            echo "Connecting $DB_CONTAINER_NAME to $DOCKER_NETWORK_NAME with alias pg..."
-            docker network connect --alias pg "$DOCKER_NETWORK_NAME" "$DB_CONTAINER_NAME"
-          fi
+          # Always disconnect + reconnect to guarantee the 'pg' alias is present.
+          # The alias can be lost after Docker daemon restarts or network recreation,
+          # and the previous logic skipped reconnection when the container was already
+          # on the network — even if the alias was missing.
+          docker network disconnect "$DOCKER_NETWORK_NAME" "$DB_CONTAINER_NAME" 2>/dev/null || true
+          echo "Connecting $DB_CONTAINER_NAME to $DOCKER_NETWORK_NAME with alias pg..."
+          docker network connect --alias pg "$DOCKER_NETWORK_NAME" "$DB_CONTAINER_NAME"
 
       - name: Pull new images
         run: docker compose -f docker-compose.test.yml pull


### PR DESCRIPTION
## Summary
Modified the deploy test workflow to ensure the database container's 'pg' network alias is always present, even after Docker daemon restarts or network recreation.

## Key Changes
- Changed from conditional connection logic to always disconnect and reconnect the DB container to the deploy network
- This guarantees the 'pg' alias is properly set on every workflow run
- Added error suppression for the disconnect command to handle cases where the container isn't currently on the network

## Implementation Details
The previous implementation only connected the container if it wasn't already on the network. However, the 'pg' alias can be lost after Docker daemon restarts or network recreation, while the container remains attached to the network. The new approach:
- Always disconnects the container from the network first (with error suppression)
- Then reconnects it with the 'pg' alias explicitly specified
- This ensures the alias is present regardless of the container's previous network state

https://claude.ai/code/session_01Fb3cwJL41nP2Bu6g1YT9rn