### PR TITLE
Implement responsive drawer navigation with hamburger menu

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -24,6 +24,8 @@ jobs:
       ITEMIMAGES__USESSL: ${{ vars.ITEMIMAGES__USESSL }}
       ITEMIMAGES__ACCESSKEY: ${{ secrets.ITEMIMAGES__ACCESSKEY }}
       ITEMIMAGES__SECRETKEY: ${{ secrets.ITEMIMAGES__SECRETKEY }}
+      ITEMIMAGES__MODEL_PATH: ${{ vars.ITEMIMAGES__MODEL_PATH }}
+      CLIP_MODEL_DIR: ${{ vars.CLIP_MODEL_DIR }}
 
     steps:
       - name: Fail fast if TEST_DB_PASSWORD is missing

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,8 +19,10 @@ services:
       ITEMIMAGES__SECRETKEY: "${ITEMIMAGES__SECRETKEY}"
       ITEMIMAGES__MAXUPLOADMB: "${ITEMIMAGES__MAXUPLOADMB:-5}"
       ITEMIMAGES__CACHEMAXAGESECONDS: "${ITEMIMAGES__CACHEMAXAGESECONDS:-86400}"
+      ITEMIMAGES__MODEL_PATH: "/models/item-image-model.onnx"
     volumes:
       - ${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}:/app/logs
+      - ${CLIP_MODEL_DIR:-/tmp/models}:/models:ro
     networks:
       - lkvitai-mes_default
     healthcheck:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,7 +19,7 @@ services:
       ITEMIMAGES__SECRETKEY: "${ITEMIMAGES__SECRETKEY}"
       ITEMIMAGES__MAXUPLOADMB: "${ITEMIMAGES__MAXUPLOADMB:-5}"
       ITEMIMAGES__CACHEMAXAGESECONDS: "${ITEMIMAGES__CACHEMAXAGESECONDS:-86400}"
-      ITEMIMAGES__MODEL_PATH: "/models/item-image-model.onnx"
+      ITEMIMAGES__MODEL_PATH: "${ITEMIMAGES__MODEL_PATH:-/models/item-image-model.onnx}"
     volumes:
       - ${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}:/app/logs
       - ${CLIP_MODEL_DIR:-/tmp/models}:/models:ro

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
@@ -4,15 +4,21 @@
 <MudLayout>
     <MudDrawer Class="sidebar bg-dark text-white"
                Variant="DrawerVariant.Responsive"
+               Breakpoint="Breakpoint.Md"
                Width="250px"
                Elevation="1"
-               Open="true">
+               @bind-Open="_drawerOpen"
+               ClipMode="DrawerClipMode.Never">
         <NavMenu />
     </MudDrawer>
 
     <MudMainContent>
         <header class="app-topbar">
             <div class="app-topbar-left">
+                <button class="btn btn-link app-topbar-hamburger d-md-none"
+                        @onclick="ToggleDrawer" aria-label="Toggle menu">
+                    <i class="bi bi-list"></i>
+                </button>
                 <img src="https://avatars.githubusercontent.com/u/233164040?s=40&v=4"
                      alt="LKvitai" class="app-topbar-mark" />
                 <h6 class="app-topbar-title mb-0">LKvitai.MES Warehouse</h6>
@@ -30,3 +36,12 @@
         </main>
     </MudMainContent>
 </MudLayout>
+
+@code {
+    private bool _drawerOpen = true;
+
+    private void ToggleDrawer()
+    {
+        _drawerOpen = !_drawerOpen;
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor.css
@@ -51,10 +51,6 @@
 }
 
 @media (max-width: 768px) {
-    .sidebar {
-        display: none;
-    }
-
     .app-topbar {
         padding: 0 0.75rem;
         min-height: 52px;
@@ -68,4 +64,12 @@
     .app-topbar-title {
         font-size: 0.95rem;
     }
+}
+
+.app-topbar-hamburger {
+    color: #1f2f46;
+    font-size: 1.5rem;
+    padding: 0.125rem 0.375rem;
+    line-height: 1;
+    text-decoration: none;
 }


### PR DESCRIPTION
## Summary
Refactored the sidebar navigation to be responsive on mobile devices by implementing a toggleable drawer with a hamburger menu button that appears on smaller screens.

## Key Changes
- **Drawer responsiveness**: Added `Breakpoint="Breakpoint.Md"` and `@bind-Open="_drawerOpen"` to the MudDrawer component to make it responsive and controllable via state
- **Hamburger menu button**: Added a new hamburger button in the top bar that only displays on mobile (`d-md-none` class) and toggles the drawer open/closed
- **Drawer clip mode**: Changed `ClipMode` to `DrawerClipMode.Never` to prevent the drawer from overlaying content
- **Component logic**: Added `@code` block with `_drawerOpen` state variable and `ToggleDrawer()` method to manage drawer visibility
- **CSS updates**: 
  - Removed the `display: none` rule for `.sidebar` in the mobile media query (now handled by responsive drawer)
  - Added styling for `.app-topbar-hamburger` button with appropriate color, sizing, and spacing

## Implementation Details
The drawer now intelligently responds to screen size breakpoints while maintaining full functionality. Users can manually toggle the drawer on mobile devices using the hamburger button, providing better control over screen real estate on smaller viewports.

https://claude.ai/code/session_01Jjds2wo4W1T8sogWHLYh8Z