### PR TITLE
fix: fix mobile menu visibility — remove position:sticky override and…

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
@@ -15,7 +15,7 @@
     <MudMainContent>
         <header class="app-topbar">
             <div class="app-topbar-left">
-                <button class="btn btn-link app-topbar-hamburger d-md-none"
+                <button class="btn btn-link app-topbar-hamburger"
                         @onclick="ToggleDrawer" aria-label="Toggle menu">
                     <i class="bi bi-list"></i>
                 </button>
@@ -38,7 +38,7 @@
 </MudLayout>
 
 @code {
-    private bool _drawerOpen = true;
+    private bool _drawerOpen;
 
     private void ToggleDrawer()
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor.css
@@ -1,9 +1,17 @@
 .sidebar {
     flex-shrink: 0;
     overflow-y: auto;
-    max-height: 100vh;
-    position: sticky;
-    top: 0;
+}
+
+/* Desktop only: sticky sidebar when MudBlazor renders persistent drawer.
+   MudBlazor Breakpoint.Md = 960px — below that the drawer is overlay,
+   and position:sticky would break overlay positioning (needs position:fixed). */
+@media (min-width: 960px) {
+    .sidebar {
+        max-height: 100vh;
+        position: sticky;
+        top: 0;
+    }
 }
 
 .app-topbar {
@@ -72,4 +80,13 @@
     padding: 0.125rem 0.375rem;
     line-height: 1;
     text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+}
+
+/* Hide hamburger on desktop — matches MudBlazor Breakpoint.Md (960px) */
+@media (min-width: 960px) {
+    .app-topbar-hamburger {
+        display: none;
+    }
 }


### PR DESCRIPTION
… align breakpoints

The MudBlazor responsive drawer was broken on mobile due to two issues:

1. Scoped CSS `position: sticky` on `.sidebar` overrode MudBlazor's `position: fixed` for overlay mode (scoped selector has higher specificity). Moved sticky positioning to a desktop-only media query matching MudBlazor's Md breakpoint (960px).

2. Hamburger button used Bootstrap's `d-md-none` (768px) while MudBlazor uses Breakpoint.Md (960px), leaving a 768–960px gap where the drawer was overlay but the toggle was hidden. Replaced with custom CSS at the correct 960px breakpoint.

Also defaulted `_drawerOpen` to false so the overlay doesn't flash on mobile page load.

https://claude.ai/code/session_01JLnUvniChUcydxqEYZB9rA