### PR TITLE
Improve image-search relevance by replacing hash embeddings and filtering weak matches

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
@@ -13,6 +13,7 @@ public sealed class ItemImageOptions
     public int MaxUploadMb { get; init; } = 5;
     public int CacheMaxAgeSeconds { get; init; } = 86400;
     public string? ModelPath { get; init; }
+    public double MinSearchScore { get; init; } = 0.35d;
 
     public static ItemImageOptions FromConfiguration(IConfiguration configuration)
     {
@@ -28,7 +29,8 @@ public sealed class ItemImageOptions
             SecretKey = ReadValue(section, "SecretKey", "ITEMIMAGES__SECRETKEY"),
             MaxUploadMb = int.TryParse(ReadValue(section, "MaxUploadMb", "ITEMIMAGES__MAXUPLOADMB"), out var maxUploadMb) ? maxUploadMb : 5,
             CacheMaxAgeSeconds = int.TryParse(ReadValue(section, "CacheMaxAgeSeconds", "ITEMIMAGES__CACHEMAXAGESECONDS"), out var cacheTtlSeconds) ? cacheTtlSeconds : 86400,
-            ModelPath = ReadValue(section, "ModelPath", "ITEMIMAGES__MODEL_PATH")
+            ModelPath = ReadValue(section, "ModelPath", "ITEMIMAGES__MODEL_PATH"),
+            MinSearchScore = double.TryParse(ReadValue(section, "MinSearchScore", "ITEMIMAGES__MIN_SEARCH_SCORE"), out var minSearchScore) ? minSearchScore : 0.35d
         };
     }
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace LKvitai.MES.Modules.Warehouse.Api.Configuration;
 
 public sealed class ItemImageOptions
@@ -13,7 +15,9 @@ public sealed class ItemImageOptions
     public int MaxUploadMb { get; init; } = 5;
     public int CacheMaxAgeSeconds { get; init; } = 86400;
     public string? ModelPath { get; init; }
-    public double MinSearchScore { get; init; } = 0.35d;
+    public double MinSearchScore { get; init; } = DefaultMinSearchScore;
+
+    public const double DefaultMinSearchScore = 0.35d;
 
     public static ItemImageOptions FromConfiguration(IConfiguration configuration)
     {
@@ -30,9 +34,16 @@ public sealed class ItemImageOptions
             MaxUploadMb = int.TryParse(ReadValue(section, "MaxUploadMb", "ITEMIMAGES__MAXUPLOADMB"), out var maxUploadMb) ? maxUploadMb : 5,
             CacheMaxAgeSeconds = int.TryParse(ReadValue(section, "CacheMaxAgeSeconds", "ITEMIMAGES__CACHEMAXAGESECONDS"), out var cacheTtlSeconds) ? cacheTtlSeconds : 86400,
             ModelPath = ReadValue(section, "ModelPath", "ITEMIMAGES__MODEL_PATH"),
-            MinSearchScore = double.TryParse(ReadValue(section, "MinSearchScore", "ITEMIMAGES__MIN_SEARCH_SCORE"), out var minSearchScore) ? minSearchScore : 0.35d
+            MinSearchScore = ParseDoubleOrDefault(
+                ReadValue(section, "MinSearchScore", "ITEMIMAGES__MIN_SEARCH_SCORE"),
+                DefaultMinSearchScore)
         };
     }
+
+    private static double ParseDoubleOrDefault(string raw, double fallback)
+        => double.TryParse(raw, NumberStyles.Float, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : fallback;
 
     private static string ReadValue(
         IConfigurationSection section,

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageEmbeddingService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageEmbeddingService.cs
@@ -11,8 +11,13 @@ public interface IItemImageEmbeddingService
 
 public sealed class ItemImageEmbeddingService : IItemImageEmbeddingService
 {
-    private const int HistogramBinsPerChannel = 8;
-    private const int EmbeddingLength = HistogramBinsPerChannel * HistogramBinsPerChannel * HistogramBinsPerChannel;
+    private const int HistogramBinsRed = 4;
+    private const int HistogramBinsGreen = 4;
+    private const int HistogramBinsBlue = 8;
+    private const int SpatialCellsX = 2;
+    private const int SpatialCellsY = 2;
+    private const int HistogramBinsPerCell = HistogramBinsRed * HistogramBinsGreen * HistogramBinsBlue;
+    private const int EmbeddingLength = SpatialCellsX * SpatialCellsY * HistogramBinsPerCell;
 
     public async Task<float[]> ComputeEmbeddingAsync(Stream imageStream, CancellationToken cancellationToken = default)
     {
@@ -26,28 +31,41 @@ public sealed class ItemImageEmbeddingService : IItemImageEmbeddingService
                     Position = AnchorPositionMode.Center
                 }));
 
-        var pixels = new Rgba32[32 * 32];
-        image.CopyPixelDataTo(pixels);
-
         var embedding = new float[EmbeddingLength];
-        foreach (var pixel in pixels)
+        var width = image.Width;
+        var height = image.Height;
+        var cellWidth = Math.Max(1, width / SpatialCellsX);
+        var cellHeight = Math.Max(1, height / SpatialCellsY);
+
+        for (var y = 0; y < height; y++)
         {
-            var alpha = pixel.A / 255f;
-            var redBin = ToHistogramBin(pixel.R);
-            var greenBin = ToHistogramBin(pixel.G);
-            var blueBin = ToHistogramBin(pixel.B);
-            var bucket = (redBin * HistogramBinsPerChannel * HistogramBinsPerChannel) +
-                         (greenBin * HistogramBinsPerChannel) +
-                         blueBin;
-            embedding[bucket] += MathF.Max(0.05f, alpha);
+            var cellY = Math.Min(SpatialCellsY - 1, y / cellHeight);
+            for (var x = 0; x < width; x++)
+            {
+                var cellX = Math.Min(SpatialCellsX - 1, x / cellWidth);
+                var pixel = image[x, y];
+                var alpha = pixel.A / 255f;
+
+                var redBin = ToHistogramBin(pixel.R, HistogramBinsRed);
+                var greenBin = ToHistogramBin(pixel.G, HistogramBinsGreen);
+                var blueBin = ToHistogramBin(pixel.B, HistogramBinsBlue);
+
+                var cellIndex = (cellY * SpatialCellsX) + cellX;
+                var localBucket = (redBin * HistogramBinsGreen * HistogramBinsBlue) +
+                                  (greenBin * HistogramBinsBlue) +
+                                  blueBin;
+                var globalBucket = (cellIndex * HistogramBinsPerCell) + localBucket;
+
+                embedding[globalBucket] += MathF.Max(0.05f, alpha);
+            }
         }
 
         NormalizeInPlace(embedding);
         return embedding;
     }
 
-    private static int ToHistogramBin(byte channel)
-        => Math.Min(HistogramBinsPerChannel - 1, channel * HistogramBinsPerChannel / 256);
+    private static int ToHistogramBin(byte channel, int bins)
+        => Math.Min(bins - 1, channel * bins / 256);
 
     private static void NormalizeInPlace(float[] values)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageEmbeddingService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageEmbeddingService.cs
@@ -1,4 +1,3 @@
-using System.Security.Cryptography;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using SixLabors.ImageSharp.Processing;
@@ -12,6 +11,9 @@ public interface IItemImageEmbeddingService
 
 public sealed class ItemImageEmbeddingService : IItemImageEmbeddingService
 {
+    private const int HistogramBinsPerChannel = 8;
+    private const int EmbeddingLength = HistogramBinsPerChannel * HistogramBinsPerChannel * HistogramBinsPerChannel;
+
     public async Task<float[]> ComputeEmbeddingAsync(Stream imageStream, CancellationToken cancellationToken = default)
     {
         using var image = await Image.LoadAsync<Rgba32>(imageStream, cancellationToken);
@@ -27,26 +29,25 @@ public sealed class ItemImageEmbeddingService : IItemImageEmbeddingService
         var pixels = new Rgba32[32 * 32];
         image.CopyPixelDataTo(pixels);
 
-        var bytes = new byte[pixels.Length * 4];
-        for (var i = 0; i < pixels.Length; i++)
+        var embedding = new float[EmbeddingLength];
+        foreach (var pixel in pixels)
         {
-            var offset = i * 4;
-            bytes[offset] = pixels[i].R;
-            bytes[offset + 1] = pixels[i].G;
-            bytes[offset + 2] = pixels[i].B;
-            bytes[offset + 3] = pixels[i].A;
-        }
-
-        var digest = SHA512.HashData(bytes);
-        var embedding = new float[512];
-        for (var i = 0; i < embedding.Length; i++)
-        {
-            embedding[i] = (digest[i % digest.Length] / 255f) * 2f - 1f;
+            var alpha = pixel.A / 255f;
+            var redBin = ToHistogramBin(pixel.R);
+            var greenBin = ToHistogramBin(pixel.G);
+            var blueBin = ToHistogramBin(pixel.B);
+            var bucket = (redBin * HistogramBinsPerChannel * HistogramBinsPerChannel) +
+                         (greenBin * HistogramBinsPerChannel) +
+                         blueBin;
+            embedding[bucket] += MathF.Max(0.05f, alpha);
         }
 
         NormalizeInPlace(embedding);
         return embedding;
     }
+
+    private static int ToHistogramBin(byte channel)
+        => Math.Min(HistogramBinsPerChannel - 1, channel * HistogramBinsPerChannel / 256);
 
     private static void NormalizeInPlace(float[] values)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
@@ -61,6 +61,8 @@ public sealed record ItemImageSearchResultDto(
 
 public sealed class ItemPhotoService : IItemPhotoService
 {
+    private const double MinimumSearchScore = 0.35d;
+
     private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "image/jpeg",
@@ -366,7 +368,12 @@ public sealed class ItemPhotoService : IItemPhotoService
             }
         }
 
-        results.AddRange(perItem.Values.OrderByDescending(x => x.Score).Take(20));
+        results.AddRange(
+            perItem.Values
+                .Where(x => x.Score >= MinimumSearchScore)
+                .OrderByDescending(x => x.Score)
+                .Take(20));
+
         return results;
     }
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
@@ -61,8 +61,6 @@ public sealed record ItemImageSearchResultDto(
 
 public sealed class ItemPhotoService : IItemPhotoService
 {
-    private const double MinimumSearchScore = 0.35d;
-
     private static readonly HashSet<string> AllowedContentTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "image/jpeg",
@@ -94,6 +92,20 @@ public sealed class ItemPhotoService : IItemPhotoService
         => _storageService.EnsureAvailableAsync(cancellationToken);
 
     public int CacheMaxAgeSeconds => Math.Max(1, _storageService.Options.CacheMaxAgeSeconds);
+
+    private double MinimumSearchScore
+    {
+        get
+        {
+            var configured = _storageService.Options.MinSearchScore;
+            if (double.IsNaN(configured) || double.IsInfinity(configured))
+            {
+                return 0.35d;
+            }
+
+            return Math.Clamp(configured, 0d, 1d);
+        }
+    }
 
     public async Task<IReadOnlyList<ItemPhotoDto>> ListAsync(int itemId, CancellationToken cancellationToken = default)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs
@@ -100,7 +100,7 @@ public sealed class ItemPhotoService : IItemPhotoService
             var configured = _storageService.Options.MinSearchScore;
             if (double.IsNaN(configured) || double.IsInfinity(configured))
             {
-                return 0.35d;
+                return ItemImageOptions.DefaultMinSearchScore;
             }
 
             return Math.Clamp(configured, 0d, 1d);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
@@ -137,7 +137,8 @@
     "SecretKey": "",
     "MaxUploadMb": 5,
     "CacheMaxAgeSeconds": 86400,
-    "ModelPath": ""
+    "ModelPath": "",
+    "MinSearchScore": 0.35
   },
   "Compliance": {
     "TransactionExport": {

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
@@ -11,9 +11,9 @@ public class ItemImageEmbeddingServiceTests
     public async Task ComputeEmbeddingAsync_ForSimilarImages_ShouldProduceHigherCosineSimilarityThanDifferentImages()
     {
         var sut = new ItemImageEmbeddingService();
-        await using var baseImage = BuildSolidImage(new Rgba32(20, 180, 200));
-        await using var similarImage = BuildSolidImage(new Rgba32(25, 170, 205));
-        await using var differentImage = BuildSolidImage(new Rgba32(210, 30, 30));
+        using var baseImage = BuildSolidImage(new Rgba32(20, 180, 200));
+        using var similarImage = BuildSolidImage(new Rgba32(25, 170, 205));
+        using var differentImage = BuildSolidImage(new Rgba32(210, 30, 30));
 
         var baseEmbedding = await sut.ComputeEmbeddingAsync(baseImage);
         var similarEmbedding = await sut.ComputeEmbeddingAsync(similarImage);
@@ -29,9 +29,9 @@ public class ItemImageEmbeddingServiceTests
     public async Task ComputeEmbeddingAsync_WhenColorLayoutDiffers_ShouldLowerSimilarity()
     {
         var sut = new ItemImageEmbeddingService();
-        await using var reference = BuildSplitImage(left: new Rgba32(25, 25, 25), right: new Rgba32(220, 220, 220));
-        await using var sameLayout = BuildSplitImage(left: new Rgba32(30, 30, 30), right: new Rgba32(215, 215, 215));
-        await using var swappedLayout = BuildSplitImage(left: new Rgba32(220, 220, 220), right: new Rgba32(25, 25, 25));
+        using var reference = BuildSplitImage(left: new Rgba32(25, 25, 25), right: new Rgba32(220, 220, 220));
+        using var sameLayout = BuildSplitImage(left: new Rgba32(30, 30, 30), right: new Rgba32(215, 215, 215));
+        using var swappedLayout = BuildSplitImage(left: new Rgba32(220, 220, 220), right: new Rgba32(25, 25, 25));
 
         var referenceEmbedding = await sut.ComputeEmbeddingAsync(reference);
         var sameLayoutEmbedding = await sut.ComputeEmbeddingAsync(sameLayout);
@@ -45,11 +45,11 @@ public class ItemImageEmbeddingServiceTests
             $"Expected same layout ({sameLayoutScore}) > swapped layout ({swappedLayoutScore})");
     }
 
-    private static async Task<MemoryStream> BuildSolidImage(Rgba32 color)
+    private static MemoryStream BuildSolidImage(Rgba32 color)
     {
         using var image = new Image<Rgba32>(32, 32, color);
         var stream = new MemoryStream();
-        await image.SaveAsPngAsync(stream);
+        image.SaveAsPng(stream);
         stream.Position = 0;
         return stream;
     }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
@@ -25,11 +25,48 @@ public class ItemImageEmbeddingServiceTests
         Assert.True(similarScore > differentScore, $"Expected similar ({similarScore}) > different ({differentScore})");
     }
 
+    [Fact]
+    public async Task ComputeEmbeddingAsync_WhenColorLayoutDiffers_ShouldLowerSimilarity()
+    {
+        var sut = new ItemImageEmbeddingService();
+        await using var reference = BuildSplitImage(left: new Rgba32(25, 25, 25), right: new Rgba32(220, 220, 220));
+        await using var sameLayout = BuildSplitImage(left: new Rgba32(30, 30, 30), right: new Rgba32(215, 215, 215));
+        await using var swappedLayout = BuildSplitImage(left: new Rgba32(220, 220, 220), right: new Rgba32(25, 25, 25));
+
+        var referenceEmbedding = await sut.ComputeEmbeddingAsync(reference);
+        var sameLayoutEmbedding = await sut.ComputeEmbeddingAsync(sameLayout);
+        var swappedLayoutEmbedding = await sut.ComputeEmbeddingAsync(swappedLayout);
+
+        var sameLayoutScore = CosineSimilarity(referenceEmbedding, sameLayoutEmbedding);
+        var swappedLayoutScore = CosineSimilarity(referenceEmbedding, swappedLayoutEmbedding);
+
+        Assert.True(
+            sameLayoutScore > swappedLayoutScore,
+            $"Expected same layout ({sameLayoutScore}) > swapped layout ({swappedLayoutScore})");
+    }
+
     private static async Task<MemoryStream> BuildSolidImage(Rgba32 color)
     {
         using var image = new Image<Rgba32>(32, 32, color);
         var stream = new MemoryStream();
         await image.SaveAsPngAsync(stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static MemoryStream BuildSplitImage(Rgba32 left, Rgba32 right)
+    {
+        using var image = new Image<Rgba32>(32, 32);
+        for (var y = 0; y < image.Height; y++)
+        {
+            for (var x = 0; x < image.Width; x++)
+            {
+                image[x, y] = x < image.Width / 2 ? left : right;
+            }
+        }
+
+        var stream = new MemoryStream();
+        image.SaveAsPng(stream);
         stream.Position = 0;
         return stream;
     }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs
@@ -1,0 +1,47 @@
+using LKvitai.MES.Modules.Warehouse.Api.Services;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.PixelFormats;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class ItemImageEmbeddingServiceTests
+{
+    [Fact]
+    public async Task ComputeEmbeddingAsync_ForSimilarImages_ShouldProduceHigherCosineSimilarityThanDifferentImages()
+    {
+        var sut = new ItemImageEmbeddingService();
+        await using var baseImage = BuildSolidImage(new Rgba32(20, 180, 200));
+        await using var similarImage = BuildSolidImage(new Rgba32(25, 170, 205));
+        await using var differentImage = BuildSolidImage(new Rgba32(210, 30, 30));
+
+        var baseEmbedding = await sut.ComputeEmbeddingAsync(baseImage);
+        var similarEmbedding = await sut.ComputeEmbeddingAsync(similarImage);
+        var differentEmbedding = await sut.ComputeEmbeddingAsync(differentImage);
+
+        var similarScore = CosineSimilarity(baseEmbedding, similarEmbedding);
+        var differentScore = CosineSimilarity(baseEmbedding, differentEmbedding);
+
+        Assert.True(similarScore > differentScore, $"Expected similar ({similarScore}) > different ({differentScore})");
+    }
+
+    private static async Task<MemoryStream> BuildSolidImage(Rgba32 color)
+    {
+        using var image = new Image<Rgba32>(32, 32, color);
+        var stream = new MemoryStream();
+        await image.SaveAsPngAsync(stream);
+        stream.Position = 0;
+        return stream;
+    }
+
+    private static double CosineSimilarity(float[] a, float[] b)
+    {
+        double dot = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+        }
+
+        return dot;
+    }
+}

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageOptionsTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageOptionsTests.cs
@@ -1,0 +1,38 @@
+using LKvitai.MES.Modules.Warehouse.Api.Configuration;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class ItemImageOptionsTests
+{
+    [Fact]
+    public void FromConfiguration_WhenMinSearchScoreIsValidInvariantNumber_ShouldParseValue()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ItemImages:MinSearchScore"] = "0.75"
+            })
+            .Build();
+
+        var options = ItemImageOptions.FromConfiguration(configuration);
+
+        Assert.Equal(0.75d, options.MinSearchScore, 6);
+    }
+
+    [Fact]
+    public void FromConfiguration_WhenMinSearchScoreIsInvalid_ShouldUseDefault()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["ItemImages:MinSearchScore"] = "invalid"
+            })
+            .Build();
+
+        var options = ItemImageOptions.FromConfiguration(configuration);
+
+        Assert.Equal(ItemImageOptions.DefaultMinSearchScore, options.MinSearchScore, 6);
+    }
+}


### PR DESCRIPTION
### Motivation
- The previous image embedding used a `SHA512` hash of raw pixels stretched into a 512‑dim vector which produced pseudo-random distances and caused unrelated low‑score matches to surface. 
- When the catalog is sparse this allowed very weak hits (e.g. ~18%) to be returned, degrading user experience on the `/search-by-image` flow. 
- The change aims to make embeddings reflect visual similarity and to suppress low‑confidence results.

### Description
- Replaced the SHA512/hash-based embedding with a normalized RGB histogram embedding in `ItemImageEmbeddingService` using an `8x8x8` histogram (512 dims) so visually similar images map closer in vector space, implemented in `ComputeEmbeddingAsync` and helper `ToHistogramBin` (file `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageEmbeddingService.cs`).
- Added a minimum score gate (`MinimumSearchScore = 0.35`) in `ItemPhotoService.SearchByImageAsync` and filter results with `Where(x => x.Score >= MinimumSearchScore)` to suppress weak/unreliable matches (file `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemPhotoService.cs`).
- Added a unit test `ItemImageEmbeddingServiceTests` that verifies similar solid‑color images produce a higher cosine similarity than a clearly different image (file `tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs`).

### Testing
- Added the unit test `tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ItemImageEmbeddingServiceTests.cs` which exercises `ItemImageEmbeddingService.ComputeEmbeddingAsync` and compares cosine similarity for similar vs different images. 
- Attempted to run the new test with `dotnet test --filter ItemImageEmbeddingServiceTests` but the environment does not have the `dotnet` CLI installed so the test run failed with `bash: command not found: dotnet`.
- Other automated integration/unit test suites in the repository were not executed in this environment; changes are covered by the new unit test and will need CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a57d5eb5288333bc91c358f84bdaba)