### PR TITLE
Fix desktop sidebar default visibility

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
@@ -38,7 +38,7 @@
 </MudLayout>
 
 @code {
-    private bool _drawerOpen;
+    private bool _drawerOpen = true;
 
     private void ToggleDrawer()
     {


### PR DESCRIPTION
### Motivation
- The left navigation was not visible by default at desktop widths; the sidebar should be shown immediately on wide viewports.

### Description
- Initialize the MudDrawer to open by default by setting `private bool _drawerOpen = true;` in `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor`, keeping the existing responsive/hamburger toggle behavior unchanged.

### Testing
- Attempted `dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj` but `dotnet` is not installed in the environment so the build could not be executed, and an automated Playwright screenshot against `http://localhost:5000` failed with `ERR_EMPTY_RESPONSE` because the application server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a5f074f9d08333a8fb3134e13d385b)