### PR TITLE
Support warehouse doors in 3D layout

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
+using System.Text.Json;
 using LKvitai.MES.Modules.Warehouse.Api.ErrorHandling;
 using LKvitai.MES.Modules.Warehouse.Api.Security;
 using LKvitai.MES.Modules.Warehouse.Application.Ports;
@@ -34,6 +35,12 @@ public sealed class WarehouseVisualizationController : ControllerBase
     private static readonly string[] AllowedZoneTypes = ["RECEIVING", "STORAGE", "SHIPPING", "QUARANTINE"];
     private static readonly HashSet<string> AllowedZoneTypeSet =
         new(AllowedZoneTypes, StringComparer.OrdinalIgnoreCase);
+
+    private static readonly JsonSerializerOptions RackJsonOptions = new()
+    {
+        WriteIndented = true,
+        PropertyNameCaseInsensitive = true
+    };
 
     private static readonly IReadOnlyDictionary<string, string> StatusPalette =
         new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
@@ -152,6 +159,45 @@ public sealed class WarehouseVisualizationController : ControllerBase
         layout.LengthMeters = decimal.Round(request.LengthMeters, 2, MidpointRounding.AwayFromZero);
         layout.HeightMeters = decimal.Round(request.HeightMeters, 2, MidpointRounding.AwayFromZero);
         layout.UpdatedAt = DateTimeOffset.UtcNow;
+
+        if (request.Doors is not null)
+        {
+            RackLayoutDocument existingRackLayout;
+            try
+            {
+                existingRackLayout = _rackLayoutValidator.Parse(layout.RacksJson);
+            }
+            catch (Exception ex)
+            {
+                return ValidationFailure($"Rack config JSON could not be parsed before updating doors: {ex.Message}");
+            }
+
+            var mergedRackLayout = existingRackLayout with
+            {
+                WarehouseCode = normalizedWarehouseCode,
+                Doors = request.Doors
+                    .Select(x => new WarehouseDoorDefinition(
+                        x.Id.Trim(),
+                        x.Type.Trim(),
+                        x.Wall.Trim().ToUpperInvariant(),
+                        x.OffsetFromLeft,
+                        x.Width,
+                        x.Height,
+                        x.Bottom,
+                        string.IsNullOrWhiteSpace(x.Label) ? null : x.Label.Trim()))
+                    .ToList()
+            };
+
+            var rackLayoutValidation = _rackLayoutValidator.Validate(layout, mergedRackLayout);
+            if (!rackLayoutValidation.IsValid)
+            {
+                return ValidationFailure(JoinValidationErrors(rackLayoutValidation.Errors));
+            }
+
+            layout.RacksJson = ShouldStoreRackLayout(mergedRackLayout)
+                ? JsonSerializer.Serialize(mergedRackLayout, RackJsonOptions)
+                : null;
+        }
 
         if (isExistingLayout)
         {
@@ -536,6 +582,17 @@ public sealed class WarehouseVisualizationController : ControllerBase
                     new VisualizationCoordinateResponse(x.X, x.Y, x.Z),
                     new VisualizationRackDimensionsResponse(x.Width, x.Length, x.Height)))
                 .ToList(),
+            rackLayout.GetDoors()
+                .Select(x => new VisualizationDoorResponse(
+                    x.Id,
+                    x.Type,
+                    x.Wall.Trim().ToUpperInvariant(),
+                    x.OffsetFromLeft,
+                    x.Width,
+                    x.Height,
+                    x.Bottom,
+                    x.Label))
+                .ToList(),
             layout.Zones
                 .OrderBy(x => x.ZoneType)
                 .Select(x => new VisualizationZoneResponse(
@@ -667,8 +724,10 @@ public sealed class WarehouseVisualizationController : ControllerBase
         return StatusPalette.GetValueOrDefault(status, StatusPalette[LowStatus]);
     }
 
-    private static LayoutResponse MapLayout(WarehouseLayout layout)
+    private LayoutResponse MapLayout(WarehouseLayout layout)
     {
+        var rackLayout = _rackLayoutValidator.Parse(layout.RacksJson);
+
         return new LayoutResponse(
             layout.Id,
             layout.WarehouseCode,
@@ -686,9 +745,23 @@ public sealed class WarehouseVisualizationController : ControllerBase
                     x.Y2,
                     x.Color))
                 .ToList(),
+            rackLayout.GetDoors()
+                .Select(x => new DoorResponse(
+                    x.Id,
+                    x.Type,
+                    x.Wall,
+                    x.OffsetFromLeft,
+                    x.Width,
+                    x.Height,
+                    x.Bottom,
+                    x.Label))
+                .ToList(),
             layout.RacksJson,
             layout.UpdatedAt);
     }
+
+    private static bool ShouldStoreRackLayout(RackLayoutDocument document)
+        => document.GetRacks().Count > 0 || document.GetDoors().Count > 0;
 
     private static List<Location> ResolveVisualizationLocations(IReadOnlyList<Location> locations)
     {
@@ -780,7 +853,8 @@ public sealed class WarehouseVisualizationController : ControllerBase
         decimal WidthMeters,
         decimal LengthMeters,
         decimal HeightMeters,
-        IReadOnlyList<UpsertZoneRequest> Zones);
+        IReadOnlyList<UpsertZoneRequest> Zones,
+        IReadOnlyList<UpsertDoorRequest>? Doors = null);
 
     public sealed record UpsertZoneRequest(
         string Type,
@@ -790,6 +864,16 @@ public sealed class WarehouseVisualizationController : ControllerBase
         decimal Y2,
         string Color);
 
+    public sealed record UpsertDoorRequest(
+        string Id,
+        string Type,
+        string Wall,
+        decimal OffsetFromLeft,
+        decimal Width,
+        decimal Height,
+        decimal Bottom,
+        string? Label);
+
     public sealed record LayoutResponse(
         Guid Id,
         string WarehouseCode,
@@ -797,6 +881,7 @@ public sealed class WarehouseVisualizationController : ControllerBase
         decimal LengthMeters,
         decimal HeightMeters,
         IReadOnlyList<ZoneResponse> Zones,
+        IReadOnlyList<DoorResponse> Doors,
         string? RacksJson,
         DateTimeOffset UpdatedAt);
 
@@ -809,11 +894,22 @@ public sealed class WarehouseVisualizationController : ControllerBase
         decimal Y2,
         string Color);
 
+    public sealed record DoorResponse(
+        string Id,
+        string Type,
+        string Wall,
+        decimal OffsetFromLeft,
+        decimal Width,
+        decimal Height,
+        decimal Bottom,
+        string? Label);
+
     public sealed record Visualization3dResponse(
         VisualizationWarehouseResponse Warehouse,
         IReadOnlyList<VisualizationBinResponse> Bins,
         IReadOnlyList<VisualizationRackResponse> Racks,
         IReadOnlyList<VisualizationSlotResponse> Slots,
+        IReadOnlyList<VisualizationDoorResponse> Doors,
         IReadOnlyList<VisualizationZoneResponse> Zones);
 
     public sealed record VisualizationWarehouseResponse(
@@ -886,6 +982,16 @@ public sealed class WarehouseVisualizationController : ControllerBase
         bool Occupied,
         VisualizationCoordinateResponse Origin,
         VisualizationRackDimensionsResponse Dimensions);
+
+    public sealed record VisualizationDoorResponse(
+        string Id,
+        string Type,
+        string Wall,
+        decimal OffsetFromLeft,
+        decimal Width,
+        decimal Height,
+        decimal Bottom,
+        string? Label);
 
     public sealed record VisualizationHandlingUnitResponse(
         Guid Id,

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Visualization/RackLayoutModels.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Visualization/RackLayoutModels.cs
@@ -5,11 +5,13 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Visualization;
 
 public sealed record RackLayoutDocument(
     [property: JsonPropertyName("warehouseCode")] string? WarehouseCode,
-    [property: JsonPropertyName("racks")] IReadOnlyList<RackRowDefinition>? Racks)
+    [property: JsonPropertyName("racks")] IReadOnlyList<RackRowDefinition>? Racks,
+    [property: JsonPropertyName("doors")] IReadOnlyList<WarehouseDoorDefinition>? Doors)
 {
-    public static RackLayoutDocument Empty { get; } = new(null, Array.Empty<RackRowDefinition>());
+    public static RackLayoutDocument Empty { get; } = new(null, Array.Empty<RackRowDefinition>(), Array.Empty<WarehouseDoorDefinition>());
 
     public IReadOnlyList<RackRowDefinition> GetRacks() => Racks ?? Array.Empty<RackRowDefinition>();
+    public IReadOnlyList<WarehouseDoorDefinition> GetDoors() => Doors ?? Array.Empty<WarehouseDoorDefinition>();
 }
 
 public sealed record RackRowDefinition(
@@ -40,6 +42,16 @@ public sealed record RackDimensionsDefinition(
 public sealed record RackLevelDefinition(
     [property: JsonPropertyName("index")] int Index,
     [property: JsonPropertyName("heightFromBase")] decimal HeightFromBase);
+
+public sealed record WarehouseDoorDefinition(
+    [property: JsonPropertyName("id")] string Id,
+    [property: JsonPropertyName("type")] string Type,
+    [property: JsonPropertyName("wall")] string Wall,
+    [property: JsonPropertyName("offsetFromLeft")] decimal OffsetFromLeft,
+    [property: JsonPropertyName("width")] decimal Width,
+    [property: JsonPropertyName("height")] decimal Height,
+    [property: JsonPropertyName("bottom")] decimal Bottom,
+    [property: JsonPropertyName("label")] string? Label);
 
 public sealed record VisualizationRackModel(
     string Id,

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Visualization/RackLayoutValidator.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Visualization/RackLayoutValidator.cs
@@ -18,6 +18,23 @@ public sealed class RackLayoutValidator
         "Custom"
     ];
 
+    private static readonly HashSet<string> AllowedDoorTypes =
+    [
+        "DockDoor",
+        "PedestrianDoor",
+        "Gate",
+        "EmergencyExit",
+        "Custom"
+    ];
+
+    private static readonly HashSet<string> AllowedWalls =
+    [
+        "N",
+        "S",
+        "E",
+        "W"
+    ];
+
     public RackLayoutDocument Parse(string? racksJson)
     {
         if (string.IsNullOrWhiteSpace(racksJson))
@@ -51,10 +68,81 @@ public sealed class RackLayoutValidator
             ValidateRack(layout, rack, errors);
         }
 
+        ValidateDoors(layout, document.GetDoors(), errors);
+
         ValidatePairings(racks, errors);
         ValidateOverlap(racks, errors);
 
         return new RackLayoutValidationResult(errors.Count == 0, errors);
+    }
+
+    private static void ValidateDoors(
+        WarehouseLayout layout,
+        IReadOnlyList<WarehouseDoorDefinition> doors,
+        ICollection<string> errors)
+    {
+        var duplicateDoorIds = doors
+            .GroupBy(x => x.Id, StringComparer.OrdinalIgnoreCase)
+            .Where(x => x.Count() > 1)
+            .Select(x => x.Key)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        foreach (var doorId in duplicateDoorIds)
+        {
+            errors.Add($"Door id '{doorId}' must be unique within the warehouse.");
+        }
+
+        foreach (var door in doors)
+        {
+            ValidateDoor(layout, door, errors);
+        }
+    }
+
+    private static void ValidateDoor(
+        WarehouseLayout layout,
+        WarehouseDoorDefinition door,
+        ICollection<string> errors)
+    {
+        if (string.IsNullOrWhiteSpace(door.Id))
+        {
+            errors.Add("Each door requires a non-empty id.");
+        }
+
+        if (!AllowedDoorTypes.Contains(door.Type))
+        {
+            errors.Add($"Door '{door.Id}' has unsupported type '{door.Type}'.");
+        }
+
+        var normalizedWall = door.Wall.Trim().ToUpperInvariant();
+        if (!AllowedWalls.Contains(normalizedWall))
+        {
+            errors.Add($"Door '{door.Id}' wall must be one of: N, S, E, W.");
+            return;
+        }
+
+        if (door.Width <= 0 || door.Height <= 0)
+        {
+            errors.Add($"Door '{door.Id}' width and height must be greater than zero.");
+        }
+
+        if (door.OffsetFromLeft < 0 || door.Bottom < 0)
+        {
+            errors.Add($"Door '{door.Id}' offsetFromLeft and bottom must be non-negative.");
+        }
+
+        var wallLength = normalizedWall is "N" or "S"
+            ? layout.WidthMeters
+            : layout.LengthMeters;
+        if (door.OffsetFromLeft + door.Width > wallLength)
+        {
+            errors.Add($"Door '{door.Id}' exceeds wall '{normalizedWall}' bounds.");
+        }
+
+        if (door.Bottom + door.Height > layout.HeightMeters)
+        {
+            errors.Add($"Door '{door.Id}' exceeds the warehouse height.");
+        }
     }
 
     private static void ValidateRack(WarehouseLayout layout, RackRowDefinition rack, ICollection<string> errors)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/LayoutEditorDtos.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/LayoutEditorDtos.cs
@@ -7,6 +7,7 @@ public sealed record WarehouseLayoutDto(
     decimal LengthMeters,
     decimal HeightMeters,
     IReadOnlyList<WarehouseLayoutZoneDto> Zones,
+    IReadOnlyList<WarehouseLayoutDoorDto> Doors,
     string? RacksJson,
     DateTimeOffset UpdatedAt);
 
@@ -19,12 +20,23 @@ public sealed record WarehouseLayoutZoneDto(
     decimal Y2,
     string Color);
 
+public sealed record WarehouseLayoutDoorDto(
+    string Id,
+    string Type,
+    string Wall,
+    decimal OffsetFromLeft,
+    decimal Width,
+    decimal Height,
+    decimal Bottom,
+    string? Label);
+
 public sealed record UpdateWarehouseLayoutRequestDto(
     string WarehouseCode,
     decimal WidthMeters,
     decimal LengthMeters,
     decimal HeightMeters,
-    IReadOnlyList<UpdateWarehouseLayoutZoneRequestDto> Zones);
+    IReadOnlyList<UpdateWarehouseLayoutZoneRequestDto> Zones,
+    IReadOnlyList<UpdateWarehouseLayoutDoorRequestDto>? Doors = null);
 
 public sealed record WarehouseRackConfigDto(
     string WarehouseCode,
@@ -41,3 +53,13 @@ public sealed record UpdateWarehouseLayoutZoneRequestDto(
     decimal X2,
     decimal Y2,
     string Color);
+
+public sealed record UpdateWarehouseLayoutDoorRequestDto(
+    string Id,
+    string Type,
+    string Wall,
+    decimal OffsetFromLeft,
+    decimal Width,
+    decimal Height,
+    decimal Bottom,
+    string? Label);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/VisualizationDtos.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/VisualizationDtos.cs
@@ -5,6 +5,7 @@ public sealed record Visualization3dDto(
     IReadOnlyList<VisualizationBinDto> Bins,
     IReadOnlyList<VisualizationRackDto> Racks,
     IReadOnlyList<VisualizationSlotDto> Slots,
+    IReadOnlyList<VisualizationDoorDto> Doors,
     IReadOnlyList<VisualizationZoneDto> Zones);
 
 public sealed record VisualizationWarehouseDto(
@@ -83,6 +84,16 @@ public sealed record VisualizationHandlingUnitDto(
     string Lpn,
     string Sku,
     decimal Qty);
+
+public sealed record VisualizationDoorDto(
+    string Id,
+    string Type,
+    string Wall,
+    decimal OffsetFromLeft,
+    decimal Width,
+    decimal Height,
+    decimal Bottom,
+    string? Label);
 
 public sealed record VisualizationZoneDto(
     string Type,

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/LayoutEditor.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/LayoutEditor.razor
@@ -165,9 +165,18 @@ else
         {
             var parsed = ParseAndValidate(_layoutJson, _warehouseCode);
             var updated = await LayoutEditorClient.UpdateLayoutAsync(parsed);
+            var normalizedRackConfigJson = NormalizeRackConfigJson(_rackConfigJson);
+            if (parsed.Doors is not null)
+            {
+                normalizedRackConfigJson = MergeDoorsIntoRackConfigJson(
+                    normalizedRackConfigJson,
+                    parsed.WarehouseCode,
+                    parsed.Doors);
+            }
+
             var rackConfig = await LayoutEditorClient.UpdateRackConfigAsync(
                 _warehouseCode,
-                new UpdateWarehouseRackConfigRequestDto(NormalizeRackConfigJson(_rackConfigJson)));
+                new UpdateWarehouseRackConfigRequestDto(normalizedRackConfigJson));
             _layoutJson = SerializeLayout(updated, _warehouseCode);
             _rackConfigJson = rackConfig.RacksJson ?? string.Empty;
             _updatedAt = updated.UpdatedAt > rackConfig.UpdatedAt ? updated.UpdatedAt : rackConfig.UpdatedAt;
@@ -202,7 +211,16 @@ else
                 zone.Y1,
                 zone.X2,
                 zone.Y2,
-                zone.Color)).ToList());
+                zone.Color)).ToList(),
+            layout.Doors.Select(door => new UpdateWarehouseLayoutDoorRequestDto(
+                door.Id,
+                door.Type,
+                door.Wall,
+                door.OffsetFromLeft,
+                door.Width,
+                door.Height,
+                door.Bottom,
+                door.Label)).ToList());
 
         return JsonSerializer.Serialize(payload, JsonOptions);
     }
@@ -231,6 +249,7 @@ else
         }
 
         var zones = model.Zones ?? Array.Empty<UpdateWarehouseLayoutZoneRequestDto>();
+        var doors = model.Doors;
         foreach (var zone in zones)
         {
             if (string.IsNullOrWhiteSpace(zone.Type))
@@ -252,7 +271,8 @@ else
         return model with
         {
             WarehouseCode = selectedWarehouseCode.Trim(),
-            Zones = zones
+            Zones = zones,
+            Doors = doors
         };
     }
 
@@ -265,6 +285,37 @@ else
 
         using var document = JsonDocument.Parse(json);
         return JsonSerializer.Serialize(document.RootElement, JsonOptions);
+    }
+
+    private static string? MergeDoorsIntoRackConfigJson(
+        string? rackConfigJson,
+        string warehouseCode,
+        IReadOnlyList<UpdateWarehouseLayoutDoorRequestDto> doors)
+    {
+        RackConfigDocument? existing = null;
+        if (!string.IsNullOrWhiteSpace(rackConfigJson))
+        {
+            existing = JsonSerializer.Deserialize<RackConfigDocument>(rackConfigJson, JsonOptions);
+        }
+
+        var merged = new RackConfigDocument(
+            string.IsNullOrWhiteSpace(existing?.WarehouseCode) ? warehouseCode : existing!.WarehouseCode,
+            existing?.Racks ?? Array.Empty<JsonElement>(),
+            doors.Select(door => new RackConfigDoorDocument(
+                door.Id,
+                door.Type,
+                door.Wall,
+                door.OffsetFromLeft,
+                door.Width,
+                door.Height,
+                door.Bottom,
+                door.Label)).ToList());
+
+        var hasRacks = merged.Racks.Count > 0;
+        var hasDoors = merged.Doors.Count > 0;
+        return hasRacks || hasDoors
+            ? JsonSerializer.Serialize(merged, JsonOptions)
+            : null;
     }
 
     private bool HasAdminRole()
@@ -289,4 +340,19 @@ else
     {
         _apiError = null;
     }
+
+    private sealed record RackConfigDocument(
+        string? WarehouseCode,
+        IReadOnlyList<JsonElement> Racks,
+        IReadOnlyList<RackConfigDoorDocument> Doors);
+
+    private sealed record RackConfigDoorDocument(
+        string Id,
+        string Type,
+        string Wall,
+        decimal OffsetFromLeft,
+        decimal Width,
+        decimal Height,
+        decimal Bottom,
+        string? Label);
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
@@ -1149,6 +1149,7 @@
             bins = GetFilteredBins(),
             racks = _model?.Racks ?? [],
             slots = _model?.Slots ?? [],
+            doors = _model?.Doors ?? [],
             zones = _model?.Zones ?? [],
             options = new
             {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js
@@ -11,6 +11,10 @@
         mediumColor: 0xfbbf24,
         fullColor: 0xf97316,
         overCapacityColor: 0xdc2626,
+        dockDoorColor: 0x1d4ed8,
+        pedestrianDoorColor: 0x64748b,
+        emergencyDoorColor: 0xdc2626,
+        gateDoorColor: 0x0f766e,
         selectionColor: 0x00c8e8,
         hoverColor: 0xffc400,
         hoverRackEmissiveColor: 0xf59e0b,
@@ -269,6 +273,14 @@
         return label.sprite;
     }
 
+    function createSmallDoorLabel(text) {
+        const label = createLabelSprite();
+        drawLabel(label.canvas, label.texture, text);
+        label.sprite.visible = true;
+        label.sprite.material.opacity = 0.82;
+        return label.sprite;
+    }
+
     function rotateLocalPoint(localX, localY, rack) {
         const radians = (Number(rack?.orientationDeg || 0) * Math.PI) / 180;
         const cos = Math.cos(radians);
@@ -336,6 +348,71 @@
         outline.rotation.x = -Math.PI / 2;
         outline.position.set(width / 2, elevation, length / 2);
         return outline;
+    }
+
+    function resolveDoorColor(type) {
+        switch (String(type || "").toLowerCase()) {
+            case "dockdoor":
+                return VISUAL_CONFIG.dockDoorColor;
+            case "pedestriandoor":
+                return VISUAL_CONFIG.pedestrianDoorColor;
+            case "emergencyexit":
+                return VISUAL_CONFIG.emergencyDoorColor;
+            case "gate":
+                return VISUAL_CONFIG.gateDoorColor;
+            default:
+                return 0x334155;
+        }
+    }
+
+    function computeDoorPlacement(door, warehouse) {
+        const w = Number(warehouse?.dimensions?.width || 0);
+        const l = Number(warehouse?.dimensions?.length || 0);
+        const wall = String(door?.wall || "").toUpperCase();
+        const offset = Number(door?.offsetFromLeft || 0);
+        const width = Number(door?.width || 0);
+        const height = Number(door?.height || 0);
+        const bottom = Number(door?.bottom || 0);
+        const thickness = 0.08;
+        const outward = 0.045;
+
+        if (w <= 0 || l <= 0 || width <= 0 || height <= 0) {
+            return null;
+        }
+
+        if (wall === "N") {
+            return {
+                box: { width, height, depth: thickness },
+                position: { x: offset + (width / 2), y: bottom + (height / 2), z: l + outward },
+                label: { x: offset + (width / 2), y: bottom + height + 0.45, z: l + 0.18 }
+            };
+        }
+
+        if (wall === "S") {
+            return {
+                box: { width, height, depth: thickness },
+                position: { x: w - offset - (width / 2), y: bottom + (height / 2), z: -outward },
+                label: { x: w - offset - (width / 2), y: bottom + height + 0.45, z: -0.18 }
+            };
+        }
+
+        if (wall === "W") {
+            return {
+                box: { width: thickness, height, depth: width },
+                position: { x: -outward, y: bottom + (height / 2), z: offset + (width / 2) },
+                label: { x: -0.18, y: bottom + height + 0.45, z: offset + (width / 2) }
+            };
+        }
+
+        if (wall === "E") {
+            return {
+                box: { width: thickness, height, depth: width },
+                position: { x: w + outward, y: bottom + (height / 2), z: l - offset - (width / 2) },
+                label: { x: w + 0.18, y: bottom + height + 0.45, z: l - offset - (width / 2) }
+            };
+        }
+
+        return null;
     }
 
     function renderWarehouseFloor(scene, warehouse) {
@@ -413,6 +490,57 @@
             border.position.set((x1 + x2) / 2, 0.005, (y1 + y2) / 2);
             scene.add(border);
         });
+    }
+
+    function renderDoors(scene, warehouse, doors) {
+        if (!Array.isArray(doors) || doors.length === 0) {
+            return;
+        }
+
+        const group = new THREE.Group();
+        doors.forEach((door) => {
+            const placement = computeDoorPlacement(door, warehouse);
+            if (!placement) {
+                return;
+            }
+
+            const color = resolveDoorColor(door.type);
+            const doorMaterial = new THREE.MeshBasicMaterial({
+                color,
+                transparent: true,
+                opacity: 0.86,
+                depthWrite: false,
+                toneMapped: false
+            });
+            const doorMesh = new THREE.Mesh(
+                new THREE.BoxGeometry(placement.box.width, placement.box.height, placement.box.depth),
+                doorMaterial);
+            doorMesh.position.set(placement.position.x, placement.position.y, placement.position.z);
+            doorMesh.renderOrder = 3;
+            group.add(doorMesh);
+
+            const edge = new THREE.LineSegments(
+                new THREE.EdgesGeometry(doorMesh.geometry),
+                new THREE.LineBasicMaterial({
+                    color: 0x0f172a,
+                    transparent: true,
+                    opacity: 0.7,
+                    depthWrite: false,
+                    toneMapped: false
+                }));
+            doorMesh.add(edge);
+
+            const labelText = String(door.label || door.id || "").trim();
+            if (labelText) {
+                const label = createSmallDoorLabel(labelText);
+                const labelWidth = Math.max(1.8, Math.min(4.2, 1.1 + (labelText.length * 0.22)));
+                label.position.set(placement.label.x, placement.label.y, placement.label.z);
+                label.scale.set(labelWidth, 0.5, 1);
+                group.add(label);
+            }
+        });
+
+        scene.add(group);
     }
 
     function renderRackFrames(scene, racks, interactiveRackMeshes, showRackLabels) {
@@ -643,7 +771,7 @@
             });
 
             const scene = new THREE.Scene();
-            scene.background = new THREE.Color(0eef2f6);
+            scene.background = new THREE.Color(0xeef2f6);
 
             const width = Math.max(container.clientWidth, 300);
             const height = Math.max(container.clientHeight, 300);
@@ -714,6 +842,7 @@
             const bins = Array.isArray(data) ? data : (data?.bins || []);
             const racks = Array.isArray(data?.racks) ? data.racks : [];
             const slots = Array.isArray(data?.slots) ? data.slots : [];
+            const doors = Array.isArray(data?.doors) ? data.doors : [];
             const warehouse = !Array.isArray(data) ? (data?.warehouse ?? null) : null;
             const zones = !Array.isArray(data) && Array.isArray(data?.zones) ? data.zones : [];
             const renderOptions = !Array.isArray(data) ? (data?.options ?? {}) : {};
@@ -898,6 +1027,7 @@
             if (hasWarehouseDims) {
                 renderWarehouseFloor(scene, warehouse);
                 renderZones(scene, zones);
+                renderDoors(scene, warehouse, doors);
             } else {
                 const gridSize = Math.max(30, Math.ceil(maxSpan * 4));
                 const gridDivisions = Math.max(10, Math.min(80, Math.round(gridSize / 2)));


### PR DESCRIPTION
## Summary
- add `doors` array support to warehouse rack layout documents
- validate door ids, wall side, dimensions, offsets, and warehouse bounds
- expose doors through layout and 3D visualization DTOs
- render dock/pedestrian/gate/emergency doors on warehouse walls in 3D
- make Layout Editor preserve `Doors` when saving layout and rack config together
- fix invalid JS color literal in warehouse visualization background

## Verification
- `node --check src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js`
- `dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/LKvitai.MES.Tests.Warehouse.Unit.csproj -c Release`
- `dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj -c Release -o artifacts/warehouse3d-layout-doors-save-build-check`