### PR TITLE
[codex] Bust Portal static asset cache

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LKvitai.MES - Portal</title>
-  <link rel="stylesheet" href="styles.css">
+  <link rel="stylesheet" href="styles.css?v=0.1.1">
 </head>
 <body>
   <div class="app-shell">
@@ -166,6 +166,6 @@
   </div>
 
   <output class="toast" id="toast" aria-live="polite" hidden></output>
-  <script src="script.js"></script>
+  <script src="script.js?v=0.1.1"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

Adds cache-busting query strings to the Portal static CSS and JS references.

## Why

After the Portal PR was merged, Cloudflare continued serving the old `styles.css` while the HTML had already updated. That made visually-hidden accessibility text visible through the Cloudflare/Traefik route, while the direct route looked correct.

## Changes

- Changes `styles.css` to `styles.css?v=0.1.1`.
- Changes `script.js` to `script.js?v=0.1.1`.

## Validation

- `dotnet build src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj -c Release`