### PR TITLE
[codex] Deploy production releases automatically

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -100,6 +100,36 @@ jobs:
       - name: Pull production images
         run: docker compose -f docker-compose.prod.yml pull
 
+      - name: Apply EF Core migrations to production DB
+        run: |
+          if [ -z "${WAREHOUSE_DB_CONNECTION}" ]; then
+            echo "::error::WAREHOUSE_DB_CONNECTION is missing. Set it in GitHub Environment 'prod'."
+            exit 1
+          fi
+
+          docker rm -f lkvitai-mes-prod-migration 2>/dev/null || true
+
+          docker run --rm --name lkvitai-mes-prod-migration \
+            --network "$DOCKER_NETWORK_NAME" \
+            --user "$(id -u):$(id -g)" \
+            -v "${{ github.workspace }}:/src" \
+            -w /src \
+            -e HOME=/tmp \
+            -e DOTNET_CLI_HOME=/tmp/.dotnet \
+            -e "ConnectionStrings__WarehouseDb=$WAREHOUSE_DB_CONNECTION" \
+            mcr.microsoft.com/dotnet/sdk:8.0 \
+            bash -c '
+              set -e
+              dotnet tool install --global dotnet-ef
+              export PATH="$PATH:/tmp/.dotnet/.dotnet/tools"
+              dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj -c Release
+              dotnet ef database update \
+                --project src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure \
+                --startup-project src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api \
+                --no-build \
+                --configuration Release
+            '
+
       - name: Deploy production containers
         run: docker compose -f docker-compose.prod.yml up -d
 

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -1,0 +1,143 @@
+name: Release to Production
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: warehouse-api
+            dockerfile: src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/lkvitai-mes-warehouse-api
+          - name: warehouse-webui
+            dockerfile: src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/lkvitai-mes-warehouse-webui
+          - name: portal-api
+            dockerfile: src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/lkvitai-mes-portal-api
+          - name: portal-webui
+            dockerfile: src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
+            image: ghcr.io/${{ github.repository_owner }}/lkvitai-mes-portal-webui
+
+    steps:
+      - name: Validate release tag
+        run: |
+          if ! printf '%s' "${{ github.event.release.tag_name }}" | grep -Eq '^v?[0-9]+(\.[0-9]+){1,2}([.-][0-9A-Za-z.-]+)?$'; then
+            echo "::error::Release tag '${{ github.event.release.tag_name }}' is not a Docker-safe version tag. Use tags like v0.1.1 or 0.1.1."
+            exit 1
+          fi
+
+      - name: Checkout release code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ matrix.image }}
+          tags: |
+            type=raw,value=${{ github.event.release.tag_name }}
+            type=sha,prefix=,format=long
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=release-${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=release-${{ matrix.name }}
+
+  deploy-prod:
+    needs: build-and-push
+    runs-on: [self-hosted, lkvitai-apps]
+    environment: prod
+    env:
+      IMAGE_TAG: ${{ github.event.release.tag_name }}
+      DOCKER_NETWORK_NAME: ${{ vars.DOCKER_NETWORK_NAME || 'lkvitai-mes_prod' }}
+      WAREHOUSE_DB_CONNECTION: ${{ secrets.WAREHOUSE_DB_CONNECTION }}
+      WAREHOUSE_API_BASE_URL: ${{ vars.WAREHOUSE_API_BASE_URL }}
+    steps:
+      - name: Checkout release code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Ensure deploy Docker network exists
+        run: |
+          docker network inspect "$DOCKER_NETWORK_NAME" >/dev/null 2>&1 || \
+            docker network create "$DOCKER_NETWORK_NAME"
+
+      - name: Pull production images
+        run: docker compose -f docker-compose.prod.yml pull
+
+      - name: Deploy production containers
+        run: docker compose -f docker-compose.prod.yml up -d
+
+      - name: Wait for Warehouse API health
+        run: |
+          echo "Waiting for production Warehouse API to become healthy..."
+          for i in $(seq 1 30); do
+            if docker exec lkvitai-mes-warehouse-api-prod curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Warehouse API is healthy!"
+              exit 0
+            fi
+            echo "  attempt $i/30 - not ready yet"
+            sleep 5
+          done
+          echo "Warehouse API failed to become healthy within 150s"
+          docker compose -f docker-compose.prod.yml logs api --tail 50
+          exit 1
+
+      - name: Wait for Portal API health
+        run: |
+          echo "Waiting for production Portal API to become healthy..."
+          for i in $(seq 1 30); do
+            if docker exec lkvitai-mes-portal-api-prod curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Portal API is healthy!"
+              exit 0
+            fi
+            echo "  attempt $i/30 - not ready yet"
+            sleep 5
+          done
+          echo "Portal API failed to become healthy within 150s"
+          docker compose -f docker-compose.prod.yml logs portal-api --tail 50
+          exit 1
+
+      - name: Deployment summary
+        run: |
+          echo "## Production Release Deployment" >> $GITHUB_STEP_SUMMARY
+          echo "- **Release:** ${{ github.event.release.tag_name }}" >> $GITHUB_STEP_SUMMARY
+          echo "- **Image tag:** $IMAGE_TAG" >> $GITHUB_STEP_SUMMARY
+          echo "- **Portal API:** lkvitai-apps:5011" >> $GITHUB_STEP_SUMMARY
+          echo "- **Portal WebUI:** lkvitai-apps:5010" >> $GITHUB_STEP_SUMMARY
+          docker compose -f docker-compose.prod.yml ps >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -6,11 +6,13 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     strategy:
       matrix:
         include:
@@ -36,15 +38,15 @@ jobs:
           fi
 
       - name: Checkout release code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -52,7 +54,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051
         with:
           images: ${{ matrix.image }}
           tags: |
@@ -60,7 +62,7 @@ jobs:
             type=sha,prefix=,format=long
 
       - name: Build and push ${{ matrix.name }} image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -74,6 +76,9 @@ jobs:
     needs: build-and-push
     runs-on: [self-hosted, lkvitai-apps]
     environment: prod
+    permissions:
+      contents: read
+      packages: read
     env:
       IMAGE_TAG: ${{ github.event.release.tag_name }}
       DOCKER_NETWORK_NAME: ${{ vars.DOCKER_NETWORK_NAME || 'lkvitai-mes_prod' }}
@@ -81,12 +86,12 @@ jobs:
       WAREHOUSE_API_BASE_URL: ${{ vars.WAREHOUSE_API_BASE_URL }}
     steps:
       - name: Checkout release code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}


### PR DESCRIPTION
## Summary

Adds a release-driven production deployment workflow.

## Behavior

When a GitHub Release is published, the new workflow:

1. Validates that the release tag is Docker-safe, e.g. `v0.1.1`.
2. Checks out the release tag.
3. Builds and pushes all application images with that release tag.
4. Deploys the same release tag to the `lkvitai-apps` self-hosted runner.
5. Waits for Warehouse API and Portal API health checks.

## Operational flow

- Go to GitHub Releases.
- Click **New release**.
- Create/select a tag like `v0.1.1`, targeting `main`.
- Click **Publish release**.
- GitHub Actions runs `Release to Production` and deploys that tag to prod.

## Notes

The existing manual `Deploy to Production` workflow remains available as a fallback.

## Validation

- Parsed `.github/workflows/release-prod.yml` as YAML.
- `git diff --check`.