### PR TITLE
[codex] Make Portal banner environment aware

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -22,7 +22,7 @@
         <div class="brand__mark">LK</div>
         <div>
           <div class="brand__name">LKvitai<span>.MES</span></div>
-          <div class="brand__tagline mono">Manufacturing &middot; Operations &middot; Control</div>
+          <div class="brand__tagline mono">Manufacturing &middot; Execution &middot; Standards</div>
         </div>
       </div>
 

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -44,7 +44,7 @@
       <div class="user-block">
         <div class="user-block__avatar">RM</div>
         <div>
-          <div class="user-block__name">Ricardas</div>
+          <div class="user-block__name">Lukas</div>
           <div class="user-block__role">Production Manager</div>
         </div>
       </div>
@@ -54,7 +54,7 @@
       <section class="hero">
         <div class="hero__copy">
           <div class="eyebrow mono">Portal &middot; Welcome</div>
-          <h1>Welcome back, Ricardas.</h1>
+          <h1>Welcome back, Lukas.</h1>
           <p>Warehouse is available. The remaining modules are listed on the implementation roadmap.</p>
           <div class="hero__actions">
             <a class="button button--primary" href="#">Open Warehouse <span aria-hidden="true">&rarr;</span></a>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -4,15 +4,15 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LKvitai.MES - Portal</title>
-  <link rel="stylesheet" href="styles.css?v=0.1.2">
+  <link rel="stylesheet" href="styles.css?v=0.1.3">
 </head>
 <body>
   <div class="app-shell">
-    <div class="test-strip" id="test-strip" hidden>
+    <div class="test-strip" id="test-strip">
       <div class="test-strip__main">
         <span class="icon-warning" aria-hidden="true"></span>
-        <strong>TEST ENVIRONMENT</strong>
-        <span class="test-strip__note">Data in this environment is not production data and may be reset without notice.</span>
+        <strong id="portal-banner-title">TEST ENVIRONMENT</strong>
+        <span class="test-strip__note" id="portal-banner-note">Data in this environment is not production data and may be reset without notice.</span>
       </div>
       <span class="mono test-strip__host" id="portal-host">lkvitai-test.vpn.lauresta.com</span>
     </div>
@@ -37,7 +37,7 @@
       <div class="topbar__spacer"></div>
 
       <div class="env-badge" aria-label="Environment and version">
-        <div><span class="mono">ENV</span><strong class="mono" id="portal-env">PROD</strong></div>
+        <div><span class="mono">ENV</span><strong class="mono" id="portal-env">TEST</strong></div>
         <div><span class="mono">VER</span><strong class="mono">0.1.0</strong></div>
       </div>
 
@@ -130,11 +130,11 @@
               <h2>System status</h2>
               <span><i aria-hidden="true"></i> Online</span>
             </header>
-            <div class="status-row"><span>Environment</span><strong class="mono" id="portal-status-env">PROD</strong></div>
+            <div class="status-row"><span>Environment</span><strong class="mono status-row__test" id="portal-status-env">TEST</strong></div>
             <div class="status-row"><span>Version</span><strong class="mono">0.1.0</strong></div>
             <div class="status-row"><span>Modules</span><strong class="mono">1 active / 9 total</strong></div>
             <div class="status-row"><span>Current module</span><strong>Warehouse</strong></div>
-            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-channel">prod</strong></div>
+            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-channel">test</strong></div>
           </section>
 
           <section class="panel">
@@ -148,7 +148,7 @@
           <section class="panel">
             <header class="panel__plain-head"><h2>Build</h2></header>
             <div class="status-row"><span>Version</span><strong class="mono">0.1.0</strong></div>
-            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-build-channel">prod</strong></div>
+            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-build-channel">test</strong></div>
           </section>
         </aside>
       </div>
@@ -166,6 +166,6 @@
   </div>
 
   <output class="toast" id="toast" aria-live="polite" hidden></output>
-  <script src="script.js?v=0.1.2"></script>
+  <script src="script.js?v=0.1.3"></script>
 </body>
 </html>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -4,17 +4,17 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LKvitai.MES - Portal</title>
-  <link rel="stylesheet" href="styles.css?v=0.1.1">
+  <link rel="stylesheet" href="styles.css?v=0.1.2">
 </head>
 <body>
   <div class="app-shell">
-    <div class="test-strip">
+    <div class="test-strip" id="test-strip" hidden>
       <div class="test-strip__main">
         <span class="icon-warning" aria-hidden="true"></span>
         <strong>TEST ENVIRONMENT</strong>
         <span class="test-strip__note">Data in this environment is not production data and may be reset without notice.</span>
       </div>
-      <span class="mono test-strip__host">lkvitai-test.vpn.lauresta.com</span>
+      <span class="mono test-strip__host" id="portal-host">lkvitai-test.vpn.lauresta.com</span>
     </div>
 
     <header class="topbar">
@@ -37,7 +37,7 @@
       <div class="topbar__spacer"></div>
 
       <div class="env-badge" aria-label="Environment and version">
-        <div><span class="mono">ENV</span><strong class="mono">TEST</strong></div>
+        <div><span class="mono">ENV</span><strong class="mono" id="portal-env">PROD</strong></div>
         <div><span class="mono">VER</span><strong class="mono">0.1.0</strong></div>
       </div>
 
@@ -130,11 +130,11 @@
               <h2>System status</h2>
               <span><i aria-hidden="true"></i> Online</span>
             </header>
-            <div class="status-row"><span>Environment</span><strong class="mono status-row__test">TEST</strong></div>
+            <div class="status-row"><span>Environment</span><strong class="mono" id="portal-status-env">PROD</strong></div>
             <div class="status-row"><span>Version</span><strong class="mono">0.1.0</strong></div>
             <div class="status-row"><span>Modules</span><strong class="mono">1 active / 9 total</strong></div>
             <div class="status-row"><span>Current module</span><strong>Warehouse</strong></div>
-            <div class="status-row"><span>Channel</span><strong class="mono">test</strong></div>
+            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-channel">prod</strong></div>
           </section>
 
           <section class="panel">
@@ -148,7 +148,7 @@
           <section class="panel">
             <header class="panel__plain-head"><h2>Build</h2></header>
             <div class="status-row"><span>Version</span><strong class="mono">0.1.0</strong></div>
-            <div class="status-row"><span>Channel</span><strong class="mono">test</strong></div>
+            <div class="status-row"><span>Channel</span><strong class="mono" id="portal-build-channel">prod</strong></div>
           </section>
         </aside>
       </div>
@@ -166,6 +166,6 @@
   </div>
 
   <output class="toast" id="toast" aria-live="polite" hidden></output>
-  <script src="script.js?v=0.1.1"></script>
+  <script src="script.js?v=0.1.2"></script>
 </body>
 </html>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
@@ -54,14 +54,29 @@ let activePeriod = "this";
 let toastTimer = null;
 
 const host = window.location.hostname.toLowerCase();
-const isTestEnvironment =
-  host === "localhost" ||
-  host === "127.0.0.1" ||
-  host === "10.11.12.15" ||
-  host.includes("mes-test") ||
-  host.includes("lkvitai-test");
-const portalEnvironment = isTestEnvironment ? "TEST" : "PROD";
-const portalChannel = isTestEnvironment ? "test" : "prod";
+const productionHost = "mes.lauresta.com";
+
+function isPrivateIpHost(hostname) {
+  const parts = hostname.split(".").map((part) => Number.parseInt(part, 10));
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) return false;
+
+  return (
+    parts[0] === 127 ||
+    parts[0] === 10 ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  );
+}
+
+function getEnvironment(hostname) {
+  if (hostname === productionHost) return { name: "PROD", channel: "prod", type: "prod" };
+  if (hostname === "localhost" || hostname === "::1" || isPrivateIpHost(hostname)) {
+    return { name: "DEV", channel: "dev", type: "dev" };
+  }
+  return { name: "TEST", channel: "test", type: "test" };
+}
+
+const environment = getEnvironment(host);
 
 const moduleGrid = document.querySelector("#module-grid");
 const searchInput = document.querySelector("#module-search");
@@ -74,6 +89,8 @@ const branchGrid = document.querySelector("#branch-grid");
 const newsGrid = document.querySelector("#news-grid");
 const toast = document.querySelector("#toast");
 const testStrip = document.querySelector("#test-strip");
+const portalBannerTitle = document.querySelector("#portal-banner-title");
+const portalBannerNote = document.querySelector("#portal-banner-note");
 const portalHost = document.querySelector("#portal-host");
 const portalEnv = document.querySelector("#portal-env");
 const portalStatusEnv = document.querySelector("#portal-status-env");
@@ -81,13 +98,22 @@ const portalChannelElement = document.querySelector("#portal-channel");
 const portalBuildChannel = document.querySelector("#portal-build-channel");
 
 function renderEnvironment() {
-  testStrip.hidden = !isTestEnvironment;
+  const isProduction = environment.type === "prod";
+  const isDevelopment = environment.type === "dev";
+
+  testStrip.hidden = isProduction;
+  testStrip.classList.toggle("test-strip--dev", isDevelopment);
+  portalBannerTitle.textContent = isDevelopment ? "DEV ENVIRONMENT" : "TEST ENVIRONMENT";
+  portalBannerNote.textContent = isDevelopment
+    ? "Local or private-network environment. Data may be reset without notice."
+    : "Data in this environment is not production data and may be reset without notice.";
   portalHost.textContent = window.location.host;
-  portalEnv.textContent = portalEnvironment;
-  portalStatusEnv.textContent = portalEnvironment;
-  portalStatusEnv.classList.toggle("status-row__test", isTestEnvironment);
-  portalChannelElement.textContent = portalChannel;
-  portalBuildChannel.textContent = portalChannel;
+  portalEnv.textContent = environment.name;
+  portalStatusEnv.textContent = environment.name;
+  portalStatusEnv.classList.toggle("status-row__test", environment.type === "test");
+  portalStatusEnv.classList.toggle("status-row__dev", isDevelopment);
+  portalChannelElement.textContent = environment.channel;
+  portalBuildChannel.textContent = environment.channel;
 }
 
 function svgIcon(key) {

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
@@ -53,6 +53,16 @@ const icons = {
 let activePeriod = "this";
 let toastTimer = null;
 
+const host = window.location.hostname.toLowerCase();
+const isTestEnvironment =
+  host === "localhost" ||
+  host === "127.0.0.1" ||
+  host === "10.11.12.15" ||
+  host.includes("mes-test") ||
+  host.includes("lkvitai-test");
+const portalEnvironment = isTestEnvironment ? "TEST" : "PROD";
+const portalChannel = isTestEnvironment ? "test" : "prod";
+
 const moduleGrid = document.querySelector("#module-grid");
 const searchInput = document.querySelector("#module-search");
 const emptyState = document.querySelector("#empty-state");
@@ -63,6 +73,22 @@ const dailyTotal = document.querySelector("#daily-total");
 const branchGrid = document.querySelector("#branch-grid");
 const newsGrid = document.querySelector("#news-grid");
 const toast = document.querySelector("#toast");
+const testStrip = document.querySelector("#test-strip");
+const portalHost = document.querySelector("#portal-host");
+const portalEnv = document.querySelector("#portal-env");
+const portalStatusEnv = document.querySelector("#portal-status-env");
+const portalChannelElement = document.querySelector("#portal-channel");
+const portalBuildChannel = document.querySelector("#portal-build-channel");
+
+function renderEnvironment() {
+  testStrip.hidden = !isTestEnvironment;
+  portalHost.textContent = window.location.host;
+  portalEnv.textContent = portalEnvironment;
+  portalStatusEnv.textContent = portalEnvironment;
+  portalStatusEnv.classList.toggle("status-row__test", isTestEnvironment);
+  portalChannelElement.textContent = portalChannel;
+  portalBuildChannel.textContent = portalChannel;
+}
 
 function svgIcon(key) {
   return `<svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">${icons[key] || ""}</svg>`;
@@ -189,6 +215,7 @@ searchInput.addEventListener("input", filterModules);
 document.querySelector("#available-count").textContent = modules.filter((mod) => mod.status === "active").length;
 document.querySelector("#planned-count").textContent = modules.filter((mod) => mod.status === "planned").length;
 
+renderEnvironment();
 renderModules(modules);
 renderOperations();
 renderBranches();

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
@@ -89,6 +89,14 @@ input {
   font-size: 12px;
 }
 
+.test-strip[hidden] {
+  display: none;
+}
+
+.test-strip--dev {
+  background: repeating-linear-gradient(-45deg, oklch(86% 0.09 150), oklch(86% 0.09 150) 12px, oklch(82% 0.11 150) 12px, oklch(82% 0.11 150) 24px);
+}
+
 .test-strip__main {
   display: flex;
   align-items: center;
@@ -928,6 +936,10 @@ input {
 
 .status-row__test {
   color: oklch(50% 0.16 65) !important;
+}
+
+.status-row__dev {
+  color: oklch(42% 0.14 155) !important;
 }
 
 .news {


### PR DESCRIPTION
## Summary

Makes the Portal test warning and environment labels depend on the current host.

## Behavior

- Shows the TEST warning strip only for test-like hosts:
  - `mes-test.lauresta.com`
  - hosts containing `lkvitai-test`
  - local/dev hosts such as `localhost`, `127.0.0.1`, and `10.11.12.15`
- Hides the warning strip on production hosts such as `mes.lauresta.com`.
- Updates Portal environment and channel labels to `TEST/test` or `PROD/prod` on load.
- Bumps static asset query strings to `v=0.1.2` to avoid stale Cloudflare CSS/JS cache during verification.

## Validation

- `dotnet build src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj -c Release`
- `docker build -f src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile -t lkvitai-mes-portal-webui:env-aware .`
- `git diff --check`

## Release-flow test plan

After merge to `main`, this should trigger:

1. `Build and Push Docker Images`, because `src/Modules/Portal/**` changed.
2. `Deploy to Test`, through the existing `workflow_run` trigger.
3. Manual/new GitHub Release can then test the release-driven production flow.