### PR TITLE
Skip HTTPS redirect on Warehouse API in Test

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -317,7 +317,17 @@ if (app.Environment.IsDevelopment())
     app.Logger.LogWarning("Dev auth enabled - DO NOT USE IN PRODUCTION");
 }
 
-app.UseHttpsRedirection();
+// Skip HTTPS redirection in Development and Test: dev runs over plain HTTP, and
+// the Test compose stack reaches the API container over the internal http://...:8080
+// alias (Portal WebUI -> Warehouse API for /api/auth/login). With the redirect on,
+// internal callers hit a 307 to https on a port that does not exist and the
+// HttpClient throws, which is what surfaced as a generic /Error redirect on
+// mes-test.lauresta.com after deploy.
+if (!app.Environment.IsDevelopment()
+    && !app.Environment.IsEnvironment("Test"))
+{
+    app.UseHttpsRedirection();
+}
 app.UseMiddleware<CorrelationIdMiddleware>();
 app.UseSerilogRequestLogging(options =>
 {


### PR DESCRIPTION
Portal WebUI calls the Warehouse API over the internal docker network (http://lkvitai-mes-warehouse-api:8080) for /api/auth/login. With UseHttpsRedirection running unconditionally, every internal call gets a 307 to HTTPS on a port that is not bound, the HttpClient throws, and the unhandled exception drops the user on /Error - which on mes-test.lauresta.com surfaces as a redirect to
/login.html?returnUrl=/Error and the impression that admin/Admin123! does not work.

Skip the redirect in Development and Test, matching what the WebUI projects already do via UsePortalSecureHosting. Production keeps the redirect (TLS is terminated by Traefik/Cloudflare in front of the container).

Made-with: Cursor