### PR TITLE
Robustify portal login against upstream outages

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -76,18 +76,33 @@ app.MapPost("/auth/login", async (
     var returnUrl = NormalizeReturnUrl(form["returnUrl"].ToString());
 
     var client = factory.CreateClient("WarehouseApi");
-    var response = await client.PostAsJsonAsync(
-        "api/auth/login",
-        new PortalLoginRequest(username, password),
-        cancellationToken);
 
-    if (!response.IsSuccessStatusCode)
+    HttpResponseMessage response;
+    PortalLoginResponse? login;
+    try
     {
-        logger.LogWarning("Portal login rejected for {Username}", username);
+        response = await client.PostAsJsonAsync(
+            "api/auth/login",
+            new PortalLoginRequest(username, password),
+            cancellationToken);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            logger.LogWarning("Portal login rejected for {Username} (status {Status})", username, (int)response.StatusCode);
+            return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
+        }
+
+        login = await response.Content.ReadFromJsonAsync<PortalLoginResponse>(cancellationToken: cancellationToken);
+    }
+    catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
+    {
+        // Don't let transport/serialization issues bubble up to UseExceptionHandler -
+        // that would surface as a generic /Error redirect and look like wrong creds.
+        // Surface a clean "invalid" page and keep the real reason in the logs.
+        logger.LogError(ex, "Portal login call to Warehouse API failed for {Username}", username);
         return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
     }
 
-    var login = await response.Content.ReadFromJsonAsync<PortalLoginResponse>(cancellationToken: cancellationToken);
     if (login is null || string.IsNullOrWhiteSpace(login.Token))
     {
         logger.LogWarning("Portal login failed because API returned an empty token for {Username}", username);

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -85,28 +85,42 @@ app.MapPost("/auth/login", async (
             "api/auth/login",
             new PortalLoginRequest(username, password),
             cancellationToken);
+    }
+    catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+    {
+        logger.LogError(ex, "Portal login could not reach Warehouse API for {Username}", username);
+        return RedirectToLogin(returnUrl, "unreachable");
+    }
 
-        if (!response.IsSuccessStatusCode)
-        {
-            logger.LogWarning("Portal login rejected for {Username} (status {Status})", username, (int)response.StatusCode);
-            return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
-        }
+    if ((int)response.StatusCode is 401 or 403)
+    {
+        logger.LogWarning("Portal login rejected for {Username} (status {Status})", username, (int)response.StatusCode);
+        return RedirectToLogin(returnUrl, "invalid");
+    }
 
+    if (!response.IsSuccessStatusCode)
+    {
+        logger.LogError(
+            "Portal login: Warehouse API returned unexpected status {Status} for {Username}",
+            (int)response.StatusCode,
+            username);
+        return RedirectToLogin(returnUrl, "server");
+    }
+
+    try
+    {
         login = await response.Content.ReadFromJsonAsync<PortalLoginResponse>(cancellationToken: cancellationToken);
     }
-    catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException or System.Text.Json.JsonException)
+    catch (Exception ex) when (ex is System.Text.Json.JsonException or HttpRequestException or TaskCanceledException)
     {
-        // Don't let transport/serialization issues bubble up to UseExceptionHandler -
-        // that would surface as a generic /Error redirect and look like wrong creds.
-        // Surface a clean "invalid" page and keep the real reason in the logs.
-        logger.LogError(ex, "Portal login call to Warehouse API failed for {Username}", username);
-        return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
+        logger.LogError(ex, "Portal login: failed to read Warehouse API response for {Username}", username);
+        return RedirectToLogin(returnUrl, "server");
     }
 
     if (login is null || string.IsNullOrWhiteSpace(login.Token))
     {
-        logger.LogWarning("Portal login failed because API returned an empty token for {Username}", username);
-        return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
+        logger.LogError("Portal login: Warehouse API returned an empty token for {Username}", username);
+        return RedirectToLogin(returnUrl, "server");
     }
 
     var claims = new List<Claim>
@@ -141,6 +155,13 @@ app.MapBlazorHub();
 app.MapFallbackToFile("index.html");
 
 await app.RunAsync();
+
+static IResult RedirectToLogin(string returnUrl, string error)
+{
+    var encodedReturn = Uri.EscapeDataString(returnUrl);
+    var encodedError = Uri.EscapeDataString(error);
+    return Results.Redirect($"/login.html?error={encodedError}&returnUrl={encodedReturn}");
+}
 
 static bool IsAnonymousPortalPath(PathString path)
 {

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/login.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/login.html
@@ -17,7 +17,7 @@
         </div>
       </div>
 
-      <p class="login-error" id="login-error" hidden>Invalid username or password.</p>
+      <p class="login-error" id="login-error" role="alert" hidden></p>
 
       <form class="login-form" action="/auth/login" method="post">
         <input id="return-url" type="hidden" name="returnUrl" value="/">
@@ -43,7 +43,20 @@
     if (returnUrl && returnUrl.startsWith("/") && !returnUrl.startsWith("//")) {
       document.querySelector("#return-url").value = returnUrl;
     }
-    document.querySelector("#login-error").hidden = params.get("error") !== "invalid";
+
+    const errorMessages = {
+      invalid: "Invalid username or password.",
+      unreachable: "Could not reach the authentication server. Please try again in a moment.",
+      server: "Authentication server returned an error. Contact an administrator if it keeps happening.",
+    };
+    const errorEl = document.querySelector("#login-error");
+    const errorCode = params.get("error");
+    if (errorCode && Object.prototype.hasOwnProperty.call(errorMessages, errorCode)) {
+      errorEl.textContent = errorMessages[errorCode];
+      errorEl.hidden = false;
+    } else {
+      errorEl.hidden = true;
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
Stacked on #50 (already merged). Two follow-ups so a real backend outage no longer looks like "Invalid username or password" on the portal login page.

## Commits

- `b9462ad` Wrap `POST /auth/login` call to Warehouse API in try/catch (`HttpRequestException` / `TaskCanceledException` / `JsonException`) so transport failures do not bubble up to `UseExceptionHandler("/Error")` — that was the exact symptom on mes-test.lauresta.com before #50: a 302 to `/login.html?returnUrl=/Error` with no clue why.
- `8edc88c` Classify failures into three error codes:
  - `invalid` — Warehouse API returned 401/403 or empty token
  - `unreachable` — `HttpRequestException` / `TaskCanceledException` (DNS, TLS, connect timeout)
  - `server` — 5xx, unexpected non-success status, JSON parse error
  
  `login.html` maps each code to a user-friendly banner via `role="alert"`. Real cause still goes to Serilog at Error/Warning with `{Username}` / `{Status}` context.

## Test plan

- [ ] Build & unit tests green in CI.
- [ ] On Test, stop `lkvitai-mes-warehouse-api`, submit login → banner says "Could not reach the authentication server", Serilog has `HttpRequestException`.
- [ ] Wrong password → banner says "Invalid username or password".
- [ ] Correct `admin / Admin123!` → cookie issued, redirect to `returnUrl`.

Made with [Cursor](https://cursor.com)