### PR TITLE
Fix portal login on Test: DataProtection key persistence + Dockerfile/log hardening

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -69,30 +69,38 @@ jobs:
           docker network inspect "$DOCKER_NETWORK_NAME" >/dev/null 2>&1 || \
             docker network create "$DOCKER_NETWORK_NAME"
 
-      - name: Ensure auth-keys directory exists with correct ownership
+      - name: Ensure host bind-mount directories exist with correct ownership
         run: |
-          # The Portal/Warehouse WebUI containers run as the standard .NET 8
-          # `app` user (uid 1654, gid 1654 — see their Dockerfiles). The
-          # bind-mount target /app/auth-keys must be writable by that user so
-          # ASP.NET Core DataProtection can persist its key ring; otherwise
-          # cookie SignInAsync throws CryptographicException and login fails.
+          # All four containers (api / webui / portal-api / portal-webui)
+          # run as the standard .NET 8 `app` user (uid 1654, gid 1654 — see
+          # their Dockerfiles). Every host bind-mount referenced by
+          # docker-compose.test.yml must therefore be writable by that uid,
+          # otherwise the runtime fails on first write:
+          #   * /app/auth-keys → DataProtection key ring (Portal+Warehouse
+          #     WebUI). Missing writability → CryptographicException →
+          #     login redirect loop on /Error.
+          #   * /app/logs (warehouse-api) → Serilog daily-rolled
+          #     warehouse-YYYYMMDD.log file sink.
+          #   * /app/logs (portal-webui) → Serilog daily-rolled
+          #     portal-YYYYMMDD.log file sink.
+          # Defaults below mirror the ${VAR:-default} fall-throughs in
+          # docker-compose.test.yml so a fresh self-hosted runner can come
+          # up cold without any manual chmod/chown.
           AUTH_KEYS_DIR="${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}"
+          API_LOGS_DIR="${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}"
+          PORTAL_WEBUI_LOGS_DIR="${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}"
+
+          # auth-keys holds private DataProtection material → 0700.
           sudo mkdir -p "$AUTH_KEYS_DIR"
           sudo chown -R 1654:1654 "$AUTH_KEYS_DIR"
           sudo chmod 700 "$AUTH_KEYS_DIR"
 
-      - name: Ensure portal-webui logs directory exists with correct ownership
-        run: |
-          # Portal.WebUI mirrors the Warehouse.Api Serilog file sink and writes
-          # daily-rolled portal-YYYYMMDD.log files into /app/logs, which is
-          # bind-mounted to /opt/lkvitai-mes/logs/portal-webui by default.
-          # The container runs as `app` (uid 1654, gid 1654) so the host dir
-          # must be writable by that uid, otherwise the file sink silently
-          # fails on first write.
-          PORTAL_WEBUI_LOGS_DIR="${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}"
-          sudo mkdir -p "$PORTAL_WEBUI_LOGS_DIR"
-          sudo chown -R 1654:1654 "$PORTAL_WEBUI_LOGS_DIR"
-          sudo chmod 755 "$PORTAL_WEBUI_LOGS_DIR"
+          # log dirs are 0755 so a future read-only Vector mount can tail.
+          for dir in "$API_LOGS_DIR" "$PORTAL_WEBUI_LOGS_DIR"; do
+            sudo mkdir -p "$dir"
+            sudo chown -R 1654:1654 "$dir"
+            sudo chmod 755 "$dir"
+          done
 
       - name: Ensure test PostgreSQL container exists and is running
         run: |

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -69,6 +69,18 @@ jobs:
           docker network inspect "$DOCKER_NETWORK_NAME" >/dev/null 2>&1 || \
             docker network create "$DOCKER_NETWORK_NAME"
 
+      - name: Ensure auth-keys directory exists with correct ownership
+        run: |
+          # The Portal/Warehouse WebUI containers run as the standard .NET 8
+          # `app` user (uid 1654, gid 1654 — see their Dockerfiles). The
+          # bind-mount target /app/auth-keys must be writable by that user so
+          # ASP.NET Core DataProtection can persist its key ring; otherwise
+          # cookie SignInAsync throws CryptographicException and login fails.
+          AUTH_KEYS_DIR="${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}"
+          sudo mkdir -p "$AUTH_KEYS_DIR"
+          sudo chown -R 1654:1654 "$AUTH_KEYS_DIR"
+          sudo chmod 700 "$AUTH_KEYS_DIR"
+
       - name: Ensure test PostgreSQL container exists and is running
         run: |
           if docker ps -a --format '{{.Names}}' | grep -Fx "$DB_CONTAINER_NAME" >/dev/null; then

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -81,6 +81,19 @@ jobs:
           sudo chown -R 1654:1654 "$AUTH_KEYS_DIR"
           sudo chmod 700 "$AUTH_KEYS_DIR"
 
+      - name: Ensure portal-webui logs directory exists with correct ownership
+        run: |
+          # Portal.WebUI mirrors the Warehouse.Api Serilog file sink and writes
+          # daily-rolled portal-YYYYMMDD.log files into /app/logs, which is
+          # bind-mounted to /opt/lkvitai-mes/logs/portal-webui by default.
+          # The container runs as `app` (uid 1654, gid 1654) so the host dir
+          # must be writable by that uid, otherwise the file sink silently
+          # fails on first write.
+          PORTAL_WEBUI_LOGS_DIR="${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}"
+          sudo mkdir -p "$PORTAL_WEBUI_LOGS_DIR"
+          sudo chown -R 1654:1654 "$PORTAL_WEBUI_LOGS_DIR"
+          sudo chmod 755 "$PORTAL_WEBUI_LOGS_DIR"
+
       - name: Ensure test PostgreSQL container exists and is running
         run: |
           if docker ps -a --format '{{.Names}}' | grep -Fx "$DB_CONTAINER_NAME" >/dev/null; then

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -71,6 +71,7 @@ services:
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
+      - ${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}:/app/logs
     networks:
       - lkvitai-mes_prod
     depends_on:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -82,6 +82,7 @@ services:
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
+      - ${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}:/app/logs
     networks:
       - lkvitai-mes_default
     depends_on:

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Dockerfile
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Dockerfile
@@ -19,16 +19,18 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
+# curl is needed for the docker-compose healthcheck.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
-    && rm -rf /var/lib/apt/lists/* \
-    && groupadd -r appuser \
-    && useradd -r -g appuser appuser
+    && rm -rf /var/lib/apt/lists/*
 
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# Standard .NET 8 convention. Published binaries deliberately stay
+# root-owned (read+exec for `app`, no write) — Sonar docker:S6504. Any
+# writable directory the runtime needs (auth-keys, logs, …) is provided
+# via host bind-mounts whose ownership is set in deploy-test.yml.
 COPY --from=build /app/publish .
-
-RUN chown -R appuser:appuser /app
-USER appuser
+USER app
 
 EXPOSE 8080
 

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
@@ -21,10 +21,12 @@ FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
 # Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
-# This is the standard .NET 8 convention; the host bind-mount for
-# /app/auth-keys must be chowned to 1654:1654 so DataProtection can
-# persist its key ring (see deploy-test.yml).
-COPY --from=build --chown=app:app /app/publish .
+# This is the standard .NET 8 convention; the host bind-mounts for
+# /app/auth-keys and /app/logs must be chowned to 1654:1654 so
+# DataProtection can persist its key ring and Serilog can write log
+# files (see deploy-test.yml). Published binaries deliberately stay
+# root-owned (read-only for the runtime user, Sonar docker:S6504).
+COPY --from=build /app/publish .
 USER app
 
 EXPOSE 8080

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
@@ -20,12 +20,12 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-COPY --from=build /app/publish .
-
-RUN chown -R appuser:appuser /app
-USER appuser
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# This is the standard .NET 8 convention; the host bind-mount for
+# /app/auth-keys must be chowned to 1654:1654 so DataProtection can
+# persist its key ring (see deploy-test.yml).
+COPY --from=build --chown=app:app /app/publish .
+USER app
 
 EXPOSE 8080
 

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj
@@ -7,6 +7,11 @@
     <AssemblyName>LKvitai.MES.Modules.Portal.WebUI</AssemblyName>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Serilog.AspNetCore" />
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.File" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.PortalAuth\LKvitai.MES.BuildingBlocks.PortalAuth.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -136,14 +136,27 @@ app.MapPost("/auth/login", async (
         claims.Add(new Claim(ClaimTypes.Role, role));
     }
 
-    await httpContext.SignInAsync(
-        CookieAuthenticationDefaults.AuthenticationScheme,
-        new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)),
-        new AuthenticationProperties
-        {
-            IsPersistent = false,
-            ExpiresUtc = login.ExpiresAt
-        });
+    try
+    {
+        await httpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)),
+            new AuthenticationProperties
+            {
+                IsPersistent = false,
+                ExpiresUtc = login.ExpiresAt
+            });
+    }
+    catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or InvalidOperationException)
+    {
+        // DataProtection failure (e.g. unable to persist/read the key ring,
+        // missing/locked auth-keys directory). Surface a clear error code
+        // instead of letting the exception bubble into UseExceptionHandler,
+        // which would re-execute as /Error and trigger the cookie challenge
+        // → /login.html?returnUrl=%2FError redirect loop.
+        logger.LogError(ex, "Portal login: failed to issue auth cookie for {Username}", login.Username);
+        return RedirectToLogin(returnUrl, "server");
+    }
 
     logger.LogInformation("Portal login successful for {Username}", login.Username);
     return Results.Redirect(returnUrl);

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -3,8 +3,35 @@ using LKvitai.MES.BuildingBlocks.PortalAuth;
 using LKvitai.MES.Modules.Portal.WebUI.Auth;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Serilog;
+using Serilog.Events;
 
 var builder = WebApplication.CreateBuilder(args);
+
+// Configure Serilog — mirrors src/Modules/Warehouse/.../Warehouse.Api/Program.cs.
+// File sink writes daily-rolled portal-YYYYMMDD.log under /app/logs, which is
+// bind-mounted to /opt/lkvitai-mes/logs/portal-webui on the test/prod hosts so
+// logs survive container restarts and are pickable by Vector.
+const string structuredLogTemplate =
+    "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [TraceParent:{TraceParent}] [TraceId:{TraceId}] [CorrelationId:{CorrelationId}] [Req:{RequestMethod} {RequestPath}] {Message:lj}{NewLine}{Exception}";
+
+var loggerConfiguration = new LoggerConfiguration()
+    .ReadFrom.Configuration(builder.Configuration)
+    .MinimumLevel.Information()
+    .Filter.ByExcluding(logEvent => logEvent.Level is LogEventLevel.Debug or LogEventLevel.Verbose)
+    .MinimumLevel.Override("Microsoft", LogEventLevel.Warning)
+    .MinimumLevel.Override("System", LogEventLevel.Warning)
+    .Enrich.FromLogContext()
+    .WriteTo.Console(outputTemplate: structuredLogTemplate)
+    .WriteTo.File(
+        "logs/portal-.log",
+        rollingInterval: RollingInterval.Day,
+        retainedFileCountLimit: 14,
+        outputTemplate: structuredLogTemplate);
+
+Log.Logger = loggerConfiguration.CreateLogger();
+
+builder.Host.UseSerilog();
 
 builder.Services.AddRazorPages();
 builder.Services.AddServerSideBlazor();
@@ -30,6 +57,12 @@ builder.Services.AddHttpClient("WarehouseApi", (sp, client) =>
 var app = builder.Build();
 
 app.UsePortalSecureHosting(app.Environment);
+
+app.UseSerilogRequestLogging(options =>
+{
+    options.MessageTemplate =
+        "HTTP request completed. StatusCode={StatusCode}, ElapsedMs={Elapsed:0.0000}";
+});
 
 app.UseRouting();
 app.UseAuthentication();

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -142,8 +142,8 @@
           <section class="panel">
             <header class="panel__plain-head"><h2>Support</h2></header>
             <div class="panel__body">
-              <p>IT helpdesk &middot; <span class="mono">ext. 2410</span></p>
-              <p>MES team &middot; <a href="mailto:mes@lauresta.com">mes@lauresta.com</a></p>
+              <p>MES helpdesk sms &middot; <span class="mono">+37062454321</span></p>
+              <p>MES team &middot; <a href="mailto:developa@lauresta.lt">developa@lauresta.lt</a></p>
             </div>
           </section>
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Dockerfile
@@ -42,20 +42,16 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-# Install curl for health checks
+# curl is needed for the docker-compose healthcheck.
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-# Copy published files
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# Standard .NET 8 convention. Published binaries deliberately stay
+# root-owned (read+exec for `app`, no write) — Sonar docker:S6504. The
+# host bind-mount for /app/logs is chowned to 1654:1654 by deploy-test.yml
+# so Serilog's file sink can write daily-rolled warehouse-YYYYMMDD.log.
 COPY --from=build /app/publish .
-
-# Change ownership to non-root user
-RUN chown -R appuser:appuser /app
-
-# Switch to non-root user
-USER appuser
+USER app
 
 # Expose port
 EXPOSE 8080

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
@@ -29,8 +29,10 @@ WORKDIR /app
 # Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
 # This is the standard .NET 8 convention; the host bind-mount for
 # /app/auth-keys must be chowned to 1654:1654 so DataProtection can
-# persist its key ring (see deploy-test.yml).
-COPY --from=build --chown=app:app /app/publish .
+# persist its key ring (see deploy-test.yml). Published binaries
+# deliberately stay root-owned (read-only for the runtime user,
+# Sonar docker:S6504).
+COPY --from=build /app/publish .
 USER app
 
 # Expose port

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
@@ -26,17 +26,12 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-# Create non-root user
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-# Copy published files
-COPY --from=build /app/publish .
-
-# Change ownership to non-root user
-RUN chown -R appuser:appuser /app
-
-# Switch to non-root user
-USER appuser
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# This is the standard .NET 8 convention; the host bind-mount for
+# /app/auth-keys must be chowned to 1654:1654 so DataProtection can
+# persist its key ring (see deploy-test.yml).
+COPY --from=build --chown=app:app /app/publish .
+USER app
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
Closes #53.

## Root cause

After PR #50 (HTTPS-redirect tweak) and PR #51 (try/catch around the Warehouse API call) were deployed to Test, login on `mes-test.lauresta.com` was still broken: `POST /auth/login` → 302 → `/login.html?returnUrl=%2FError`, with the cookie-challenge `cache-control: no-cache,no-store; expires:-1; pragma:no-cache` headers visible in the HAR.

Live container logs from `lkvitai-mes-portal-webui` revealed the actual failure:

```
fail: Microsoft.AspNetCore.DataProtection.KeyManagement.KeyRingProvider[48]
      System.UnauthorizedAccessException: Access to the path '/app/auth-keys/426429ac-….tmp' is denied.
       ---> System.IO.IOException: Permission denied
fail: Microsoft.AspNetCore.Diagnostics.ExceptionHandlerMiddleware[1]
      System.Security.Cryptography.CryptographicException: An error occurred while trying to encrypt the provided data...
        at CookieAuthenticationHandler.HandleSignInAsync(...)
        at Program.<>c.<<<Main>$>b__0_4>d.MoveNext() in /src/Modules/Portal/.../Program.cs:line 139
```

So:

1. The Warehouse API call **succeeds (200)**.
2. `httpContext.SignInAsync(...)` tries to encrypt the cookie payload via DataProtection.
3. DataProtection has no existing key → tries to persist a fresh one to `/app/auth-keys/<guid>.tmp` → **`UnauthorizedAccessException`**.
4. PR #51's try/catch only covered `HttpRequestException`/`TaskCanceledException`/`JsonException`, so the cryptographic exception bubbled up.
5. `UseExceptionHandler("/Error")` re-executed as `/Error` → cookie middleware redirected to `/login.html?returnUrl=%2FError`. Result: redirect loop, no useful surface signal.

The `/app/auth-keys` mount is required because Portal and Warehouse share auth cookies via the `.mes-test.lauresta.com` cookie domain — both containers need to read/write the same DataProtection key ring so cookies round-trip across subdomains.

### Why uid 1654 specifically

Empirically against `mcr.microsoft.com/dotnet/aspnet:8.0`:

```
$ docker run --rm mcr.microsoft.com/dotnet/aspnet:8.0 id app
uid=1654(app) gid=1654(app) groups=1654(app)
```

The four containers' Dockerfiles **bypassed** that standard `app` user and created their own with `groupadd -r appuser && useradd -r -g appuser appuser`. The `-r` flag picks the next free system uid, which on Debian-12 ends up at **999, not 1654**. So neither was 1654 the right chown target nor was 999 — the runtime was a moving target.

## Fix — auth-keys (commits b979a57 + e5e2deb)

- **`.github/workflows/deploy-test.yml`** prepares `${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}` before `docker compose up`: `mkdir -p` + `chown 1654:1654` + `chmod 700` (private DataProtection material).
- **`src/Modules/Portal/.../Program.cs`** wraps `SignInAsync` in a try/catch for `CryptographicException`/`InvalidOperationException` that logs the real cause and redirects via the existing `RedirectToLogin(returnUrl, "server")` helper instead of bubbling into `UseExceptionHandler`. Defense in depth — any future DataProtection misconfiguration shows up as `?error=server` on the login page with a structured log line, not a redirect loop.

## Fix — Dockerfile alignment, all four images (commits b979a57 + 9d7a9a1 + da2dd39)

All four service Dockerfiles now follow the same pattern:

```dockerfile
FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
WORKDIR /app
# (Api images only) curl for healthcheck:
RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
COPY --from=build /app/publish .
USER app
```

Notable removals:

| Removed                                              | Why |
|------------------------------------------------------|-----|
| `groupadd -r appuser && useradd -r -g appuser appuser` | Replaced by base image's built-in `app` user (uid 1654) — stable, predictable, .NET 8 convention. |
| `RUN chown -R appuser:appuser /app`                  | Same security concern as Sonar `docker:S6504` (runtime user owns its own binaries). Now binaries stay root-owned (mode 644/755), runtime user has read+exec only. |
| `--chown=app:app` on `COPY --from=build /app/publish .` | Sonar `docker:S6504` (High, Authentication). Same write-on-binaries reasoning. WebUI commit added it briefly; this PR removed it. |

Files: `Portal.WebUI/Dockerfile`, `Warehouse.WebUI/Dockerfile`, `Portal.Api/Dockerfile`, `Warehouse.Api/Dockerfile`.

Net effect: predictable uid 1654 across all four containers; binaries are read-only for the runtime user; any directory the app needs to write to (auth-keys, logs) is exclusively a host bind-mount whose ownership is set in `deploy-test.yml`.

## Fix — log dir bootstrap (commits 95f9afe + ae06ba7)

While Sonar was looking at the Dockerfiles, the user noticed that `/opt/lkvitai-mes/logs/api/` already collects daily-rolled `warehouse-YYYYMMDD.log` files (≈3 MB/day) but the Portal WebUI had no equivalent — only stdout. Two parts:

1. **Portal.WebUI gains the same Serilog file-sink setup as Warehouse.Api.**
   - `LKvitai.MES.Modules.Portal.WebUI.csproj` picks up `Serilog.AspNetCore` / `Serilog.Sinks.Console` / `Serilog.Sinks.File` (already centrally versioned in `Directory.Packages.props`, no `Version=`).
   - `Program.cs` mirrors the Warehouse.Api Serilog setup line-for-line: same `structuredLogTemplate`, same `MinimumLevel` filters, daily file sink at `logs/portal-YYYYMMDD.log` with 14-day retention, plus `UseSerilogRequestLogging` for HTTP lines.
   - `docker-compose.test.yml` + `docker-compose.prod.yml` add the bind-mount `${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}:/app/logs` on the `portal-webui` service.

2. **`deploy-test.yml` prepares all three host bind-mount directories from cold.** The previous incarnation of the workflow only chowned `/opt/lkvitai-mes/auth-keys`; the warehouse logs dir relied on a one-off manual chmod. The final state is a single step *Ensure host bind-mount directories exist with correct ownership* covering:

| Host path                                  | mode | purpose |
|--------------------------------------------|------|---------|
| `${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}` | 700 | DataProtection key ring (Portal + Warehouse WebUI) |
| `${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}`   | 755 | Warehouse.Api Serilog file sink |
| `${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}` | 755 | Portal.WebUI Serilog file sink |

All three are chowned to `1654:1654`. After this PR a fresh self-hosted runner host can run `Deploy to Test` from cold with no manual chmod.

## Other changes folded in

- Commit `966b2b0` — small cosmetic update to the Portal landing-page "Support" panel: `IT helpdesk · ext. 2410` → `MES helpdesk sms · +37062454321`, `MES team · mes@lauresta.com` → `MES team · developa@lauresta.lt`. Unrelated to the auth fix; bundled because it's the same area of the codebase.

## Test plan

- [ ] Workflow → confirm the new *Ensure host bind-mount directories exist with correct ownership* step is green.
- [ ] On the test host: `ls -la /opt/lkvitai-mes/auth-keys` shows `drwx------` owned by `1654:1654`. `ls -la /opt/lkvitai-mes/logs/api /opt/lkvitai-mes/logs/portal-webui` show `drwxr-xr-x` owned by `1654:1654`.
- [ ] At `https://mes-test.lauresta.com`, log in with `admin / Admin123!`. Expected: 302 to the original `returnUrl`, auth cookie set on `.mes-test.lauresta.com`, no redirect loop.
- [ ] After login, `ls /opt/lkvitai-mes/auth-keys` shows at least one `key-<guid>.xml` file owned by `1654:1654`.
- [ ] After traffic, `ls /opt/lkvitai-mes/logs/api` shows `warehouse-YYYYMMDD.log` and `ls /opt/lkvitai-mes/logs/portal-webui` shows `portal-YYYYMMDD.log`, both owned by `1654:1654`.
- [ ] Negative path: with the auth-keys volume intentionally `chmod 500` on the host, login redirects to `/login.html?error=server&returnUrl=…` and the Portal logs contain a single `Portal login: failed to issue auth cookie for admin` `Error` line with the underlying `CryptographicException`/`UnauthorizedAccessException` stack — proof the new try/catch is doing its job.
- [ ] SonarCloud on this PR shows zero new Hotspots (was: 2 docker:S6504 High, both cleared by 9d7a9a1 + da2dd39).

## PR chain

- #50 — HTTPS-redirect for Warehouse API on Test.
- #51 — try/catch around the Warehouse API call in the Portal login handler.
- ~~#53~~ — superseded by this PR (closed).
- **#52 (this PR)** — fix the actual reason login was still failing after #50 + #51, plus the related Dockerfile/log-host hardening.
