### PR TITLE
Fix portal login on test by giving auth-keys to the runtime user

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -69,6 +69,18 @@ jobs:
           docker network inspect "$DOCKER_NETWORK_NAME" >/dev/null 2>&1 || \
             docker network create "$DOCKER_NETWORK_NAME"
 
+      - name: Ensure auth-keys directory exists with correct ownership
+        run: |
+          # The Portal/Warehouse WebUI containers run as the standard .NET 8
+          # `app` user (uid 1654, gid 1654 — see their Dockerfiles). The
+          # bind-mount target /app/auth-keys must be writable by that user so
+          # ASP.NET Core DataProtection can persist its key ring; otherwise
+          # cookie SignInAsync throws CryptographicException and login fails.
+          AUTH_KEYS_DIR="${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}"
+          sudo mkdir -p "$AUTH_KEYS_DIR"
+          sudo chown -R 1654:1654 "$AUTH_KEYS_DIR"
+          sudo chmod 700 "$AUTH_KEYS_DIR"
+
       - name: Ensure test PostgreSQL container exists and is running
         run: |
           if docker ps -a --format '{{.Names}}' | grep -Fx "$DB_CONTAINER_NAME" >/dev/null; then

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Dockerfile
@@ -20,12 +20,12 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-COPY --from=build /app/publish .
-
-RUN chown -R appuser:appuser /app
-USER appuser
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# This is the standard .NET 8 convention; the host bind-mount for
+# /app/auth-keys must be chowned to 1654:1654 so DataProtection can
+# persist its key ring (see deploy-test.yml).
+COPY --from=build --chown=app:app /app/publish .
+USER app
 
 EXPOSE 8080
 

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -136,14 +136,27 @@ app.MapPost("/auth/login", async (
         claims.Add(new Claim(ClaimTypes.Role, role));
     }
 
-    await httpContext.SignInAsync(
-        CookieAuthenticationDefaults.AuthenticationScheme,
-        new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)),
-        new AuthenticationProperties
-        {
-            IsPersistent = false,
-            ExpiresUtc = login.ExpiresAt
-        });
+    try
+    {
+        await httpContext.SignInAsync(
+            CookieAuthenticationDefaults.AuthenticationScheme,
+            new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)),
+            new AuthenticationProperties
+            {
+                IsPersistent = false,
+                ExpiresUtc = login.ExpiresAt
+            });
+    }
+    catch (Exception ex) when (ex is System.Security.Cryptography.CryptographicException or InvalidOperationException)
+    {
+        // DataProtection failure (e.g. unable to persist/read the key ring,
+        // missing/locked auth-keys directory). Surface a clear error code
+        // instead of letting the exception bubble into UseExceptionHandler,
+        // which would re-execute as /Error and trigger the cookie challenge
+        // → /login.html?returnUrl=%2FError redirect loop.
+        logger.LogError(ex, "Portal login: failed to issue auth cookie for {Username}", login.Username);
+        return RedirectToLogin(returnUrl, "server");
+    }
 
     logger.LogInformation("Portal login successful for {Username}", login.Username);
     return Results.Redirect(returnUrl);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
@@ -26,17 +26,12 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
-# Create non-root user
-RUN groupadd -r appuser && useradd -r -g appuser appuser
-
-# Copy published files
-COPY --from=build /app/publish .
-
-# Change ownership to non-root user
-RUN chown -R appuser:appuser /app
-
-# Switch to non-root user
-USER appuser
+# Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
+# This is the standard .NET 8 convention; the host bind-mount for
+# /app/auth-keys must be chowned to 1654:1654 so DataProtection can
+# persist its key ring (see deploy-test.yml).
+COPY --from=build --chown=app:app /app/publish .
+USER app
 
 # Expose port
 EXPOSE 8080


### PR DESCRIPTION
## Why login still 302s to `/login.html?returnUrl=%2FError`

PR #50 fixed the inter-container HTTPS redirect, and PR #51 wrapped the
HttpClient call so transport errors no longer masquerade as `/Error`.
Login still fails on Test for `admin/Admin123!` because the next step in
the handler — `httpContext.SignInAsync(...)` — throws a
`CryptographicException` and there was no catch around it.

Root cause: the WebUI containers bind-mount `/opt/lkvitai-mes/auth-keys`
into `/app/auth-keys` for ASP.NET Core DataProtection key persistence so
the cookie issued by the Portal is decryptable by the Warehouse and vice
versa. The deploy-test workflow never created that host directory, so on
the very first login attempt DataProtection tries to write the initial
key, the kernel denies the write because the runtime user can't access
the host's root-owned directory, the cookie issuance throws, and
`UseExceptionHandler("/Error")` re-executes the request as `/Error`.
The cookie challenge for that path then redirects to
`/login.html?returnUrl=%2FError` — which is exactly the symptom the HAR
showed.

## What this PR changes

1. **`deploy-test.yml`**: new step "Ensure auth-keys directory exists
   with correct ownership" creates `${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}`
   if missing and `chown`s it to `1654:1654` (mode 0700) so the
   container's standard `app` user can write the key ring.
2. **Both WebUI Dockerfiles**: drop the custom `appuser` (uid 999) and
   reuse the base `aspnet:8.0` image's standard `app` user (uid 1654).
   This gives a stable, predictable uid that the deploy step's `chown`
   targets and matches the .NET 8 convention.
3. **`Portal.WebUI/Program.cs`**: defensive `try/catch` around
   `SignInAsync` for `CryptographicException` and
   `InvalidOperationException`. If DataProtection ever misbehaves again
   (key rotation issue, lost mount, etc.) we now surface it as
   `?error=server` on the login page with a structured log line
   instead of the confusing `/Error` redirect loop.

## Test plan

- [ ] Merge → wait for `Deploy to Test` workflow → confirm "Ensure
      auth-keys directory exists" step runs green.
- [ ] `curl -isS -X POST -H 'Content-Type: application/x-www-form-urlencoded' \
       --data 'username=admin&password=Admin123!&returnUrl=/' \
       https://mes-test.lauresta.com/auth/login` returns `302` to `/`
      and a `Set-Cookie: LKvitai.MES.Portal=...` header.
- [ ] Same curl with a wrong password returns `302` to
      `/login.html?error=invalid&returnUrl=%2F`.
- [ ] Log in via the browser at https://mes-test.lauresta.com/login.html
      with `admin/Admin123!` lands on the portal home and the auth
      cookie is set on `.mes-test.lauresta.com`.

Made with [Cursor](https://cursor.com)