### PR TITLE
Fix deploy-test: replace sudo chown with Docker (no passwordless sudo on runner)

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Ensure host bind-mount directories exist with correct ownership
         run: |
+          set -euo pipefail
           # All four containers (api / webui / portal-api / portal-webui)
           # run as the standard .NET 8 `app` user (uid 1654, gid 1654 — see
           # their Dockerfiles). Every host bind-mount referenced by
@@ -90,17 +91,28 @@ jobs:
           API_LOGS_DIR="${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}"
           PORTAL_WEBUI_LOGS_DIR="${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}"
 
-          # auth-keys holds private DataProtection material → 0700.
-          sudo mkdir -p "$AUTH_KEYS_DIR"
-          sudo chown -R 1654:1654 "$AUTH_KEYS_DIR"
-          sudo chmod 700 "$AUTH_KEYS_DIR"
+          # The runner user (`actions-runner`) does not have passwordless
+          # sudo, so we cannot `sudo chown` from the host shell. The Docker
+          # daemon already runs as root, so we use a throwaway pinned
+          # alpine container as the privileged delegate to chown/chmod the
+          # bind-mount directories. mkdir is fine from the runner user
+          # because /opt/lkvitai-mes/ is already writable by it (existing
+          # warehouse-api log files there are owned by actions-runner).
+          mkdir -p "$AUTH_KEYS_DIR" "$API_LOGS_DIR" "$PORTAL_WEBUI_LOGS_DIR"
 
-          # log dirs are 0755 so a future read-only Vector mount can tail.
-          for dir in "$API_LOGS_DIR" "$PORTAL_WEBUI_LOGS_DIR"; do
-            sudo mkdir -p "$dir"
-            sudo chown -R 1654:1654 "$dir"
-            sudo chmod 755 "$dir"
-          done
+          # auth-keys → 0700 (private DataProtection material).
+          # log dirs  → 0755 so a future read-only Vector mount can tail.
+          docker run --rm \
+            --user 0:0 \
+            -v "$AUTH_KEYS_DIR:/mnt/auth-keys" \
+            -v "$API_LOGS_DIR:/mnt/api-logs" \
+            -v "$PORTAL_WEBUI_LOGS_DIR:/mnt/portal-logs" \
+            alpine:3.20 \
+            sh -eu -c '
+              chown -R 1654:1654 /mnt/auth-keys /mnt/api-logs /mnt/portal-logs
+              chmod 700 /mnt/auth-keys
+              chmod 755 /mnt/api-logs /mnt/portal-logs
+            '
 
       - name: Ensure test PostgreSQL container exists and is running
         run: |


### PR DESCRIPTION
Follow-up to merged PR #52. The *Ensure host bind-mount directories exist with correct ownership* step that landed in #52 fails on the self-hosted runner because `actions-runner` does not have passwordless sudo:

```
sudo: a terminal is required to read the password; either use the -S option to read from standard input or configure an askpass helper
sudo: a password is required
Error: Process completed with exit code 1.
```

We can't grant passwordless sudo out of band, so the workflow itself stops requiring sudo.

## Change

`.github/workflows/deploy-test.yml` — drop `sudo` entirely from the bind-mount-prep step. `mkdir -p` runs as the runner user (the existing warehouse-api logs in `/opt/lkvitai-mes/logs/api/` are already owned by `actions-runner`, confirming write access). The privileged `chown`/`chmod` work is delegated to a single throwaway pinned `alpine:3.20` container with `--user 0:0` that mounts all three target dirs at once. End state is identical to what #52 intended:

| Host path                                                  | mode | owner |
|------------------------------------------------------------|------|-------|
| `${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}`             | 0700 | 1654:1654 |
| `${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}`               | 0755 | 1654:1654 |
| `${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}` | 0755 | 1654:1654 |

`set -euo pipefail` added at the top of the step so any non-zero exit from `mkdir` or the alpine container fails the workflow loudly.

## Test plan

- [ ] Merge → workflow runs → *Ensure host bind-mount directories exist with correct ownership* step is green (no `sudo: a password is required`).
- [ ] On the test host, `ls -la /opt/lkvitai-mes/{auth-keys,logs/api,logs/portal-webui}` shows owner `1654:1654`, modes `drwx------`, `drwxr-xr-x`, `drwxr-xr-x` respectively.
- [ ] The Portal login flow that #52 was about still works end-to-end.

## Why a separate PR

#52 had already merged to `main` (and triggered this very deploy run) by the time the failure surfaced; this commit was added to the same branch shortly after but has no home until it gets its own PR. This is the smallest possible follow-up.

Made with [Cursor](https://cursor.com)