### PR TITLE
Flatten log dir to /opt/lkvitai-mes/logs (drop per-service subdirs)

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -74,45 +74,46 @@ jobs:
           set -euo pipefail
           # All four containers (api / webui / portal-api / portal-webui)
           # run as the standard .NET 8 `app` user (uid 1654, gid 1654 — see
-          # their Dockerfiles). Every host bind-mount referenced by
+          # their Dockerfiles). The two host bind-mounts referenced by
           # docker-compose.test.yml must therefore be writable by that uid,
           # otherwise the runtime fails on first write:
-          #   * /app/auth-keys → DataProtection key ring (Portal+Warehouse
-          #     WebUI). Missing writability → CryptographicException →
-          #     login redirect loop on /Error.
-          #   * /app/logs (warehouse-api) → Serilog daily-rolled
-          #     warehouse-YYYYMMDD.log file sink.
-          #   * /app/logs (portal-webui) → Serilog daily-rolled
-          #     portal-YYYYMMDD.log file sink.
-          # Defaults below mirror the ${VAR:-default} fall-throughs in
+          #   * /app/auth-keys (WebUI) → DataProtection key ring. Missing
+          #     writability → CryptographicException → login redirect loop.
+          #   * /app/logs (warehouse-api + portal-webui share one host dir)
+          #     → Serilog daily-rolled warehouse-YYYYMMDD.log /
+          #     portal-YYYYMMDD.log file sinks; filename prefixes already
+          #     disambiguate so no per-service subdir is needed.
+          # Defaults mirror the ${VAR:-default} fall-throughs in
           # docker-compose.test.yml so a fresh self-hosted runner can come
           # up cold without any manual chmod/chown.
           AUTH_KEYS_DIR="${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}"
-          API_LOGS_DIR="${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}"
-          PORTAL_WEBUI_LOGS_DIR="${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}"
+          LOGS_DIR="${LOGS_DIR:-/opt/lkvitai-mes/logs}"
 
           # The runner user (`actions-runner`) does not have passwordless
-          # sudo, so we cannot `sudo chown` from the host shell. The Docker
-          # daemon already runs as root, so we use a throwaway pinned
-          # alpine container as the privileged delegate to chown/chmod the
-          # bind-mount directories. mkdir is fine from the runner user
-          # because /opt/lkvitai-mes/ is already writable by it (existing
-          # warehouse-api log files there are owned by actions-runner).
-          mkdir -p "$AUTH_KEYS_DIR" "$API_LOGS_DIR" "$PORTAL_WEBUI_LOGS_DIR"
+          # sudo, and may not have write access under /opt/lkvitai-mes/
+          # for every subdir. Try to mkdir best-effort (so a fully fresh
+          # host gets the dirs created when possible) but tolerate failures
+          # when the dirs already exist root-owned — the Docker chown right
+          # after is the real fixer. If the dirs neither exist nor can be
+          # created, `docker run -v` will fail loudly with a clear error.
+          mkdir -p "$AUTH_KEYS_DIR" 2>/dev/null || true
+          mkdir -p "$LOGS_DIR" 2>/dev/null || true
 
           # auth-keys → 0700 (private DataProtection material).
-          # log dirs  → 0755 so a future read-only Vector mount can tail.
+          # logs      → 0755 so a future read-only Vector mount can tail.
           docker run --rm \
             --user 0:0 \
             -v "$AUTH_KEYS_DIR:/mnt/auth-keys" \
-            -v "$API_LOGS_DIR:/mnt/api-logs" \
-            -v "$PORTAL_WEBUI_LOGS_DIR:/mnt/portal-logs" \
+            -v "$LOGS_DIR:/mnt/logs" \
             alpine:3.20 \
             sh -eu -c '
-              chown -R 1654:1654 /mnt/auth-keys /mnt/api-logs /mnt/portal-logs
+              chown -R 1654:1654 /mnt/auth-keys /mnt/logs
               chmod 700 /mnt/auth-keys
-              chmod 755 /mnt/api-logs /mnt/portal-logs
+              chmod 755 /mnt/logs
             '
+        env:
+          AUTH_KEYS_DIR: ${{ vars.AUTH_KEYS_DIR }}
+          LOGS_DIR: ${{ vars.LOGS_DIR }}
 
       - name: Ensure test PostgreSQL container exists and is running
         run: |

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -12,7 +12,7 @@ services:
       ConnectionStrings__WarehouseDb: ${WAREHOUSE_DB_CONNECTION}
       SkipSchemaValidation: "true"
     volumes:
-      - ${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}:/app/logs
+      - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
     networks:
       - lkvitai-mes_prod
     healthcheck:
@@ -71,7 +71,7 @@ services:
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
-      - ${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}:/app/logs
+      - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
     networks:
       - lkvitai-mes_prod
     depends_on:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -22,7 +22,7 @@ services:
       ITEMIMAGES__CACHEMAXAGESECONDS: "${ITEMIMAGES__CACHEMAXAGESECONDS:-86400}"
       ITEMIMAGES__MODEL_PATH: "${ITEMIMAGES__MODEL_PATH:-/models/item-image-model.onnx}"
     volumes:
-      - ${API_LOGS_DIR:-/opt/lkvitai-mes/logs/api}:/app/logs
+      - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
       - ${CLIP_MODEL_DIR:-/opt/lkvitai-mes/models}:/models:ro
     networks:
       - lkvitai-mes_default
@@ -82,7 +82,7 @@ services:
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
-      - ${PORTAL_WEBUI_LOGS_DIR:-/opt/lkvitai-mes/logs/portal-webui}:/app/logs
+      - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
     networks:
       - lkvitai-mes_default
     depends_on:

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -10,8 +10,9 @@ var builder = WebApplication.CreateBuilder(args);
 
 // Configure Serilog — mirrors src/Modules/Warehouse/.../Warehouse.Api/Program.cs.
 // File sink writes daily-rolled portal-YYYYMMDD.log under /app/logs, which is
-// bind-mounted to /opt/lkvitai-mes/logs/portal-webui on the test/prod hosts so
-// logs survive container restarts and are pickable by Vector.
+// bind-mounted to a single shared /opt/lkvitai-mes/logs on the test/prod hosts.
+// Warehouse.Api writes warehouse-YYYYMMDD.log into the same host dir; the
+// filename prefix is the only thing distinguishing the two log streams.
 const string structuredLogTemplate =
     "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] [TraceParent:{TraceParent}] [TraceId:{TraceId}] [CorrelationId:{CorrelationId}] [Req:{RequestMethod} {RequestPath}] {Message:lj}{NewLine}{Exception}";
 


### PR DESCRIPTION
Follow-up to merged PR #54. The `Ensure host bind-mount directories exist with correct ownership` step that landed in #54 still fails on the self-hosted runner:

```
mkdir: cannot create directory '/opt/lkvitai-mes/logs/portal-webui': Permission denied
Error: Process completed with exit code 1.
```

The `actions-runner` user does not have write access under `/opt/lkvitai-mes/logs/`. The pre-existing `/opt/lkvitai-mes/logs/api/` only exists because somebody manually created it once. Per-service log subdirs were unnecessary anyway — Warehouse and Portal already write distinct filename prefixes (`warehouse-YYYYMMDD.log` vs `portal-YYYYMMDD.log`).

## Change

Collapse all log host paths to a single shared `/opt/lkvitai-mes/logs/`.

- **`docker-compose.test.yml` + `docker-compose.prod.yml`** — both `warehouse-api` and `portal-webui` services now bind-mount the same host path `${LOGS_DIR:-/opt/lkvitai-mes/logs}` into `/app/logs`. The old `API_LOGS_DIR` and `PORTAL_WEBUI_LOGS_DIR` env-var fall-throughs are gone.
- **`.github/workflows/deploy-test.yml`** — bind-mount-prep step now handles just two host paths (auth-keys + the flat logs dir), and `mkdir -p` is best-effort (`2>/dev/null || true`) so a pre-existing root-owned dir doesn't fail the step. The Docker chown right after is the real ownership fixer; if a target dir genuinely doesn't exist and can't be created, `docker run -v` will fail loudly at volume-mount time. Step-level env block exposes `vars.AUTH_KEYS_DIR` / `vars.LOGS_DIR` if set, otherwise defaults match compose.
- **`src/Modules/Portal/.../Program.cs`** — stale comment referencing the per-service `/opt/lkvitai-mes/logs/portal-webui` path updated to describe the flat shared layout. No behavioural change.

End state per host:

| Host path                                     | mode | owner       | who writes                                                |
|-----------------------------------------------|------|-------------|-----------------------------------------------------------|
| `${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}` | 0700 | `1654:1654` | DataProtection (Portal+Warehouse WebUI)                   |
| `${LOGS_DIR:-/opt/lkvitai-mes/logs}`           | 0755 | `1654:1654` | warehouse-api → `warehouse-*.log`, portal-webui → `portal-*.log` |

### Serilog sink templates (no change)

Both `Program.cs` files already configure relative paths that resolve under `/app/logs`:

- `src/Modules/Warehouse/.../Warehouse.Api/Program.cs` → `WriteTo.File("logs/warehouse-.log", …)`
- `src/Modules/Portal/.../Portal.WebUI/Program.cs` → `WriteTo.File("logs/portal-.log", …)`

Filename prefixes are the only thing distinguishing the two streams; we simply removed the redundant subdir on the host side.

## Test plan

- [ ] Workflow → confirm *Ensure host bind-mount directories exist with correct ownership* runs green (no `mkdir: Permission denied`).
- [ ] On the test host: `ls -la /opt/lkvitai-mes/logs` shows `drwxr-xr-x` owned by `1654:1654`. After traffic, the same dir contains both `warehouse-YYYYMMDD.log` and `portal-YYYYMMDD.log` files (each owned by `1654:1654`).
- [ ] Portal login at `https://mes-test.lauresta.com` still works end-to-end.

## Why a separate PR

PR #54 had already merged to `main` (and triggered the very deploy run that reported this failure) before the failure surfaced; the current branch is needed to land the actual fix.

## Out of scope (heads-up)

- `deploy/vector/vector.test.victorialogs.yaml` and `docs/ops/vector-test-log-collection.md` still reference the old `/opt/lkvitai-mes/logs/api/` subdir. Vector is shipped/managed separately and was not in the spec for this PR — but next time Vector gets re-applied to the test host its `file` source pattern will need to change to `/var/log/lkvitai-mes/logs/{warehouse,portal}-*.log` (or whatever the new ro-mount target ends up being). Worth a tiny follow-up PR right after this lands.

Made with [Cursor](https://cursor.com)