### PR TITLE
Add health check endpoint to Warehouse WebUI

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -249,6 +249,21 @@ jobs:
           docker compose -f docker-compose.test.yml logs portal-api --tail 50
           exit 1
 
+      - name: Wait for Warehouse WebUI health
+        run: |
+          echo "Waiting for Warehouse WebUI to become healthy..."
+          for i in $(seq 1 30); do
+            if docker exec lkvitai-mes-warehouse-webui curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+              echo "Warehouse WebUI is healthy!"
+              exit 0
+            fi
+            echo "  attempt $i/30 — not ready yet"
+            sleep 5
+          done
+          echo "Warehouse WebUI failed to become healthy within 150s"
+          docker compose -f docker-compose.test.yml logs webui --tail 50
+          exit 1
+
       - name: Seed master data
         run: |
           docker exec -i "$DB_CONTAINER_NAME" \

--- a/.github/workflows/deploy-traefik-dynamic.yml
+++ b/.github/workflows/deploy-traefik-dynamic.yml
@@ -34,8 +34,12 @@ jobs:
           fi
 
           grep -q 'Host(`mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
+          grep -q 'Host(`portal.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
+          grep -q 'Host(`warehouse.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`api.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
+          grep -q 'Host(`portal.mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
+          grep -q 'Host(`warehouse.mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
           grep -q 'Host(`api.mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
 
       - name: Install dynamic config on Traefik VPS

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -50,6 +50,12 @@ services:
       - lkvitai-mes_default
     depends_on:
       - api
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
 
   portal-api:
     image: ghcr.io/lauresta/lkvitai-mes-portal-api:${IMAGE_TAG:-latest}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Program.cs
@@ -70,6 +70,8 @@ app.UseAuthentication();
 app.UseWarehouseDevAuth();
 app.UseAuthorization();
 
+app.MapGet("/health", () => Results.Ok());
+
 app.MapPortalLogout();
 
 // Photo proxy: in production nginx routes /api/* to the API directly.


### PR DESCRIPTION
## Summary
This PR adds a health check endpoint to the Warehouse WebUI service and integrates it into the deployment and testing infrastructure.

## Key Changes
- **Warehouse WebUI health endpoint**: Added a `/health` GET endpoint to `Program.cs` that returns a 200 OK response, enabling service health monitoring
- **Docker health check**: Configured a health check in `docker-compose.test.yml` for the webui service with 15s intervals and 30s startup grace period
- **CI/CD integration**: 
  - Added a "Wait for Warehouse WebUI health" step in the deploy-test workflow to verify the service is healthy before proceeding with tests
  - Added validation checks in deploy-traefik-dynamic workflow to ensure Traefik routing rules include the warehouse subdomain for both production and test environments (`warehouse.mes.lauresta.com` and `warehouse.mes-test.lauresta.com`)

## Implementation Details
- The health check endpoint is minimal and non-blocking, simply returning an OK status
- The Docker health check uses curl with a 5-second timeout and allows up to 5 retries before marking the container unhealthy
- The CI/CD health check waits up to 150 seconds (30 attempts × 5 seconds) for the service to become healthy, with detailed logging of attempts and container logs on failure

https://claude.ai/code/session_01FQPqpec2zQPsgi3FMZMJF4