### PR TITLE
fix: warehouse WebUI healthcheck + curl in Dockerfile

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
@@ -26,6 +26,9 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
+# curl is needed for the docker-compose healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 # Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
 # This is the standard .NET 8 convention; the host bind-mount for
 # /app/auth-keys must be chowned to 1654:1654 so DataProtection can


### PR DESCRIPTION
## Problem

`warehouse.mes-test.lauresta.com` was unreachable ("This site can't be reached").

**Root cause:** `lkvitai-mes-warehouse-webui` container was stuck in `unhealthy` state. The deploy workflow health-checked `warehouse-api` and `portal-api` but not the WebUI containers — so a broken WebUI passed deployment silently.

The healthcheck itself failed because `mcr.microsoft.com/dotnet/aspnet:8.0` is a Debian slim image with no `curl`. The API Dockerfile had `RUN apt-get install -y curl` for exactly this reason; the WebUI Dockerfile did not.

## Changes

| File | Change |
|---|---|
| `WebUI/Program.cs` | Add `GET /health → 200 OK` endpoint |
| `WebUI/Dockerfile` | `RUN apt-get install -y --no-install-recommends curl` (matches API Dockerfile) |
| `docker-compose.test.yml` | Add healthcheck to `webui` service |
| `deploy-test.yml` | Add "Wait for Warehouse WebUI health" step after Portal API check |
| `deploy-traefik-dynamic.yml` | Validation now checks all 6 `Host()` rules (portal + warehouse + api for both envs) |

## Test plan

- [ ] Merge triggers `build-and-push` (WebUI Dockerfile changed under `src/Modules/Warehouse/**`)
- [ ] New image has `curl` installed — `docker exec lkvitai-mes-warehouse-webui curl -f http://localhost:8080/health` returns 200
- [ ] `deploy-test` passes including the new "Wait for Warehouse WebUI health" step
- [ ] `warehouse.mes-test.lauresta.com` responds in browser

https://claude.ai/code/session_01FQPqpec2zQPsgi3FMZMJF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQPqpec2zQPsgi3FMZMJF4)_