### PR TITLE
chore(traefik): force hot-reload to retry ACME cert for warehouse.mes-test

### DIFF
--- a/deploy/traefik/dynamic/mes-test.yml
+++ b/deploy/traefik/dynamic/mes-test.yml
@@ -1,3 +1,4 @@
+# Test environment — routers, middlewares, services for *.mes-test.lauresta.com
 http:
   routers:
     mes-test-portal-root:

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Dockerfile
@@ -26,6 +26,9 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
+# curl is needed for the docker-compose healthcheck.
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+
 # Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
 # This is the standard .NET 8 convention; the host bind-mount for
 # /app/auth-keys must be chowned to 1654:1654 so DataProtection can


### PR DESCRIPTION
Triggers `deploy-traefik-dynamic` workflow so Traefik re-reads its config and retries the Let's Encrypt certificate provisioning for `warehouse.mes-test.lauresta.com` if the initial ACME HTTP-01 challenge failed or is still pending.

https://claude.ai/code/session_01FQPqpec2zQPsgi3FMZMJF4

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQPqpec2zQPsgi3FMZMJF4)_