### PR TITLE
Use path-based routing for test environment

### DIFF
--- a/.github/workflows/deploy-traefik-dynamic.yml
+++ b/.github/workflows/deploy-traefik-dynamic.yml
@@ -36,7 +36,13 @@ jobs:
           grep -q 'Host(`mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`api.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
-          grep -q 'Host(`api.mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
+          grep -q 'PathPrefix(`/api/portal`)' deploy/traefik/dynamic/mes-test.yml
+          grep -q 'PathPrefix(`/api/warehouse`)' deploy/traefik/dynamic/mes-test.yml
+
+          if grep -Eq 'Host\(`(portal|warehouse|api)\.mes-test\.lauresta\.com`\)' deploy/traefik/dynamic/mes-test.yml; then
+            echo "::error::Test routing must stay path-based under mes-test.lauresta.com."
+            exit 1
+          fi
 
       - name: Install dynamic config on Traefik VPS
         run: |

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -102,7 +102,7 @@ jobs:
         run: |
           nohup dotnet run --project src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj --configuration Release --no-build --urls http://127.0.0.1:5124 > webui.log 2>&1 &
           for i in {1..60}; do
-            if curl -fsS http://127.0.0.1:5124/available-stock > /dev/null; then
+            if curl -fsS http://127.0.0.1:5124/warehouse/available-stock > /dev/null; then
               echo "WebUI is ready"
               exit 0
             fi
@@ -115,6 +115,7 @@ jobs:
           ASPNETCORE_ENVIRONMENT: Development
           WarehouseApi__BaseUrl: http://127.0.0.1:5001
           WarehouseWebUi__DevAuthEnabled: "true"
+          PathBase: /warehouse
 
       - name: Run E2E tests
         run: dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/LKvitai.MES.Tests.Warehouse.E2E.csproj --configuration Release --no-build --logger "console;verbosity=detailed"

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -24,13 +24,17 @@ api.mes.lauresta.com/warehouse   -> http://10.11.12.9:5001
 Test VM `lkvitai-test`:
 
 ```text
-mes-test.lauresta.com                 -> http://10.11.12.15:5010
-portal.mes-test.lauresta.com          -> http://10.11.12.15:5010
-warehouse.mes-test.lauresta.com       -> http://10.11.12.15:5000
-api.mes-test.lauresta.com/portal      -> http://10.11.12.15:5011
-api.mes-test.lauresta.com/warehouse   -> http://10.11.12.15:5001
+mes-test.lauresta.com/portal          -> http://10.11.12.15:5010
+mes-test.lauresta.com/warehouse       -> http://10.11.12.15:5000
+mes-test.lauresta.com/api/portal      -> http://10.11.12.15:5011
+mes-test.lauresta.com/api/warehouse   -> http://10.11.12.15:5001
 ```
 
-API routers strip the module prefix before forwarding. For example,
+Production API routers strip the module prefix before forwarding. For example,
 `https://api.mes.lauresta.com/warehouse/api/auth/login` reaches the Warehouse API
 as `/api/auth/login`.
+
+Test routing intentionally stays path-based under `https://mes-test.lauresta.com`
+because Cloudflare Universal SSL does not cover deep subdomains such as
+`*.mes-test.lauresta.com`. Test API routers strip `/api/portal` and
+`/api/warehouse` before forwarding.

--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -24,6 +24,7 @@ api.mes.lauresta.com/warehouse   -> http://10.11.12.9:5001
 Test VM `lkvitai-test`:
 
 ```text
+mes-test.lauresta.com/                 -> redirects to /portal/
 mes-test.lauresta.com/portal          -> http://10.11.12.15:5010
 mes-test.lauresta.com/warehouse       -> http://10.11.12.15:5000
 mes-test.lauresta.com/api/portal      -> http://10.11.12.15:5011

--- a/deploy/traefik/dynamic/mes-test.yml
+++ b/deploy/traefik/dynamic/mes-test.yml
@@ -3,6 +3,7 @@ http:
     mes-test-portal-root:
       rule: "Host(`mes-test.lauresta.com`) && Path(`/`)"
       entryPoints: [websecure]
+      middlewares: [mes-test-redirect-root-to-portal]
       service: mes-test-portal-webui
       priority: 10
       tls:
@@ -43,6 +44,12 @@ http:
         certResolver: letsencrypt
 
   middlewares:
+    mes-test-redirect-root-to-portal:
+      redirectRegex:
+        regex: "^https://mes-test\\.lauresta\\.com/$"
+        replacement: "https://mes-test.lauresta.com/portal/"
+        permanent: false
+
     mes-test-strip-api-portal:
       stripPrefix:
         prefixes: [/api/portal]

--- a/deploy/traefik/dynamic/mes-test.yml
+++ b/deploy/traefik/dynamic/mes-test.yml
@@ -1,52 +1,55 @@
 http:
   routers:
     mes-test-portal-root:
-      rule: "Host(`mes-test.lauresta.com`)"
+      rule: "Host(`mes-test.lauresta.com`) && Path(`/`)"
       entryPoints: [websecure]
       service: mes-test-portal-webui
+      priority: 10
       tls:
         certResolver: letsencrypt
 
     mes-test-portal:
-      rule: "Host(`portal.mes-test.lauresta.com`)"
+      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/portal`)"
       entryPoints: [websecure]
       service: mes-test-portal-webui
+      priority: 100
       tls:
         certResolver: letsencrypt
 
     mes-test-warehouse:
-      rule: "Host(`warehouse.mes-test.lauresta.com`)"
+      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/warehouse`)"
       entryPoints: [websecure]
       service: mes-test-warehouse-webui
+      priority: 100
       tls:
         certResolver: letsencrypt
 
     mes-test-api-portal:
-      rule: "Host(`api.mes-test.lauresta.com`) && PathPrefix(`/portal`)"
+      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/portal`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-portal]
       service: mes-test-portal-api
-      priority: 100
+      priority: 200
       tls:
         certResolver: letsencrypt
 
     mes-test-api-warehouse:
-      rule: "Host(`api.mes-test.lauresta.com`) && PathPrefix(`/warehouse`)"
+      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/warehouse`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-warehouse]
       service: mes-test-warehouse-api
-      priority: 100
+      priority: 200
       tls:
         certResolver: letsencrypt
 
   middlewares:
     mes-test-strip-api-portal:
       stripPrefix:
-        prefixes: [/portal]
+        prefixes: [/api/portal]
 
     mes-test-strip-api-warehouse:
       stripPrefix:
-        prefixes: [/warehouse]
+        prefixes: [/api/warehouse]
 
   services:
     mes-test-portal-webui:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -42,7 +42,8 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Test
       WarehouseApi__BaseUrl: "http://lkvitai-mes-warehouse-api:8080"
-      PortalAuth__CookieDomain: ".mes-test.lauresta.com"
+      PathBase: "/warehouse"
+      PortalAuth__LoginBasePath: "/portal"
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
@@ -78,8 +79,8 @@ services:
       ASPNETCORE_ENVIRONMENT: Test
       PortalApi__BaseUrl: "http://lkvitai-mes-portal-api:8080"
       WarehouseApi__BaseUrl: "http://lkvitai-mes-warehouse-api:8080"
-      WarehouseWebUi__BaseUrl: "https://warehouse.mes-test.lauresta.com"
-      PortalAuth__CookieDomain: ".mes-test.lauresta.com"
+      WarehouseWebUi__BaseUrl: "https://mes-test.lauresta.com/warehouse"
+      PathBase: "/portal"
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace LKvitai.MES.BuildingBlocks.PortalAuth;
@@ -50,9 +52,27 @@ public static class PortalAuthApplicationBuilderExtensions
         endpoints.MapPost(PortalAuthDefaults.LogoutPath, async (HttpContext httpContext) =>
         {
             await httpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            return Results.Redirect(PortalAuthDefaults.LoginPath);
+            return Results.Redirect(ResolveLoginPath(httpContext));
         });
 
         return endpoints;
+    }
+
+    private static string ResolveLoginPath(HttpContext httpContext)
+    {
+        var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
+        var configuredBasePath = configuration[PortalAuthDefaults.LoginBasePathConfigKey];
+        if (!string.IsNullOrWhiteSpace(configuredBasePath))
+        {
+            return $"{NormalizePath(configuredBasePath)}{PortalAuthDefaults.LoginPath}";
+        }
+
+        return $"{httpContext.Request.PathBase}{PortalAuthDefaults.LoginPath}";
+    }
+
+    private static string NormalizePath(string path)
+    {
+        var normalized = path.Trim().TrimEnd('/');
+        return normalized.StartsWith("/", StringComparison.Ordinal) ? normalized : $"/{normalized}";
     }
 }

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthDefaults.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthDefaults.cs
@@ -18,6 +18,7 @@ public static class PortalAuthDefaults
 
     public const string DataProtectionKeysPathConfigKey = "PortalAuth:DataProtectionKeysPath";
     public const string CookieDomainConfigKey = "PortalAuth:CookieDomain";
+    public const string LoginBasePathConfigKey = "PortalAuth:LoginBasePath";
 
     /// <summary>
     /// Default relative path for DataProtection keys. Resolved against

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthServiceCollectionExtensions.cs
@@ -34,6 +34,11 @@ public static class PortalAuthServiceCollectionExtensions
                 options.AccessDeniedPath = PortalAuthDefaults.AccessDeniedPath;
                 options.Cookie.Name = PortalAuthDefaults.CookieName;
                 options.Cookie.Domain = ResolveCookieDomain(configuration);
+                options.Cookie.HttpOnly = true;
+                options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax;
+                options.Cookie.SecurePolicy = environment.IsDevelopment()
+                    ? Microsoft.AspNetCore.Http.CookieSecurePolicy.SameAsRequest
+                    : Microsoft.AspNetCore.Http.CookieSecurePolicy.Always;
                 options.SlidingExpiration = true;
                 options.ExpireTimeSpan = PortalAuthDefaults.CookieLifetime;
             });

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -29,7 +29,19 @@ builder.Services.AddHttpClient("WarehouseApi", (sp, client) =>
 
 var app = builder.Build();
 
+app.UsePathBase(ResolvePathBase(app.Configuration));
 app.UsePortalSecureHosting(app.Environment);
+
+app.Use(async (context, next) =>
+{
+    if (context.Request.PathBase.HasValue && !context.Request.Path.HasValue)
+    {
+        context.Response.Redirect($"{context.Request.PathBase}/");
+        return;
+    }
+
+    await next();
+});
 
 app.UseRouting();
 app.UseAuthentication();
@@ -45,7 +57,7 @@ app.Use(async (context, next) =>
     }
 
     var returnUrl = context.Request.PathBase + context.Request.Path + context.Request.QueryString;
-    context.Response.Redirect($"/login.html?returnUrl={Uri.EscapeDataString(returnUrl)}");
+    context.Response.Redirect(BuildLocalUrl(context, "/login.html", $"returnUrl={Uri.EscapeDataString(returnUrl)}"));
 });
 
 app.Use(async (context, next) =>
@@ -84,14 +96,14 @@ app.MapPost("/auth/login", async (
     if (!response.IsSuccessStatusCode)
     {
         logger.LogWarning("Portal login rejected for {Username}", username);
-        return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
+        return Results.Redirect(BuildLocalUrl(httpContext, "/login.html", $"error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}"));
     }
 
     var login = await response.Content.ReadFromJsonAsync<PortalLoginResponse>(cancellationToken: cancellationToken);
     if (login is null || string.IsNullOrWhiteSpace(login.Token))
     {
         logger.LogWarning("Portal login failed because API returned an empty token for {Username}", username);
-        return Results.Redirect($"/login.html?error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}");
+        return Results.Redirect(BuildLocalUrl(httpContext, "/login.html", $"error=invalid&returnUrl={Uri.EscapeDataString(returnUrl)}"));
     }
 
     var claims = new List<Claim>
@@ -152,6 +164,18 @@ static string NormalizeReturnUrl(string? returnUrl)
         : "/";
 }
 
+static PathString ResolvePathBase(IConfiguration configuration)
+{
+    var configured = configuration["PathBase"];
+    return string.IsNullOrWhiteSpace(configured) ? PathString.Empty : new PathString(configured.TrimEnd('/'));
+}
+
+static string BuildLocalUrl(HttpContext context, string path, string? query = null)
+{
+    var localPath = $"{context.Request.PathBase}{path}";
+    return string.IsNullOrWhiteSpace(query) ? localPath : $"{localPath}?{query}";
+}
+
 static Uri EnsureTrailingSlash(Uri uri)
 {
     var builder = new UriBuilder(uri);
@@ -191,7 +215,7 @@ static string ResolveWarehouseWebUiBaseUrl(HttpContext context)
 
     if (host.Equals("mes-test.lauresta.com", StringComparison.OrdinalIgnoreCase))
     {
-        return $"{scheme}://warehouse.mes-test.lauresta.com";
+        return $"{scheme}://mes-test.lauresta.com/warehouse";
     }
 
     return $"{scheme}://warehouse.{host}";

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LKvitai.MES - Portal</title>
-  <link rel="stylesheet" href="/styles.css?v=0.1.5">
+  <link rel="stylesheet" href="styles.css?v=0.1.5">
 </head>
 <body>
   <div class="app-shell">
@@ -45,7 +45,7 @@
         <div class="user-block__avatar">RM</div>
         <div>
           <div class="user-block__name">Signed in</div>
-          <form action="/auth/logout" method="post">
+          <form action="auth/logout" method="post">
             <button class="link-button" type="submit">Logout</button>
           </form>
         </div>
@@ -168,6 +168,6 @@
   </div>
 
   <output class="toast" id="toast" aria-live="polite" hidden></output>
-  <script src="/script.js?v=0.1.5"></script>
+  <script src="script.js?v=0.1.5"></script>
 </body>
 </html>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/login.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/login.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Login - LKvitai.MES</title>
-  <link rel="stylesheet" href="/styles.css?v=0.1.5">
+  <link rel="stylesheet" href="styles.css?v=0.1.5">
 </head>
 <body class="login-page">
   <main class="login-shell">
@@ -19,7 +19,7 @@
 
       <p class="login-error" id="login-error" hidden>Invalid username or password.</p>
 
-      <form class="login-form" action="/auth/login" method="post">
+      <form class="login-form" action="auth/login" method="post">
         <input id="return-url" type="hidden" name="returnUrl" value="/">
 
         <label>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ApiKeys.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ApiKeys.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/api-keys"
+@page "/admin/api-keys"
 @using System.Globalization
 @inject ApiKeysClient ApiKeysClient
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ApprovalRules.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ApprovalRules.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/approval-rules"
+@page "/admin/approval-rules"
 @inject AdminConfigurationClient AdminConfigurationClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/AuditLogs.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/AuditLogs.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/audit-logs"
+@page "/admin/audit-logs"
 @inject AuditLogsClient AuditLogsClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Backups.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Backups.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/backups"
+@page "/admin/backups"
 @inject BackupsClient BackupsClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/DisasterRecoveryDrills.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/DisasterRecoveryDrills.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/dr-drills"
+@page "/admin/dr-drills"
 @inject DisasterRecoveryClient DisasterRecoveryClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/GdprErasure.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/GdprErasure.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/gdpr-erasure"
+@page "/admin/gdpr-erasure"
 @inject GdprClient GdprClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/LayoutEditor.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/LayoutEditor.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/layout-editor"
+@page "/admin/layout-editor"
 @using System.Text.Json
 @inject LayoutEditorClient LayoutEditorClient
 @inject StockClient StockClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/lots"
+@page "/admin/lots"
 @inject LotsClient LotsClient
 @using System.Diagnostics
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ReasonCodes.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/ReasonCodes.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/reason-codes"
+@page "/admin/reason-codes"
 @inject AdminConfigurationClient AdminConfigurationClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/RetentionPolicies.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/RetentionPolicies.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/retention-policies"
+@page "/admin/retention-policies"
 @inject RetentionPoliciesClient RetentionPoliciesClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Roles.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Roles.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/roles"
+@page "/admin/roles"
 @inject AdminConfigurationClient AdminConfigurationClient
 @inject AdminUsersClient AdminUsersClient
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/SerialNumbers.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/SerialNumbers.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/serial-numbers"
+@page "/admin/serial-numbers"
 @inject SerialNumbersClient SerialNumbersClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Settings.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Settings.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/settings"
+@page "/admin/settings"
 @inject AdminConfigurationClient AdminConfigurationClient
 @inject ToastService ToastService
 @inject IConfiguration Configuration

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/UnitsOfMeasure.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/UnitsOfMeasure.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/uom"
+@page "/admin/uom"
 @inject UomClient UomClient
 
 <PageTitle>Units of Measure - LKvitai.MES</PageTitle>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminSlots.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminSlots.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/admin/slots"
+@page "/admin/slots"
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @using Microsoft.AspNetCore.WebUtilities
 @inject MasterDataAdminClient AdminClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Configuration.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Configuration.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/agnum/config"
+@page "/agnum/config"
 @using System.ComponentModel.DataAnnotations
 @using System.Text.RegularExpressions
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Reconciliation.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Reconciliation.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/agnum/reconcile"
+@page "/agnum/reconcile"
 @using System.Globalization
 @using System.Text
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AllocationDashboard.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AllocationDashboard.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/sales/allocations"
+@page "/sales/allocations"
 @inject SalesOrdersClient SalesOrdersClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ComplianceDashboard.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ComplianceDashboard.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/compliance/dashboard"
+@page "/compliance/dashboard"
 @inject ReportsClient ReportsClient
 @inject ToastService Toast
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ComplianceLotTrace.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ComplianceLotTrace.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/compliance/lot-trace"
+@page "/compliance/lot-trace"
 @inject ReportsClient ReportsClient
 @inject ToastService ToastService
 @inject IJSRuntime JavaScript

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CrossDock.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CrossDock.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/cross-dock"
+@page "/cross-dock"
 @inject AdvancedWarehouseClient AdvancedClient
 @inject ToastService ToastService
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Discrepancies.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Discrepancies.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/cycle-counts/{Id:guid}/discrepancies"
+@page "/cycle-counts/{Id:guid}/discrepancies"
 @inject CycleCountsClient CycleCountsClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Execute.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Execute.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/cycle-counts/{Id:guid}/execute"
+@page "/cycle-counts/{Id:guid}/execute"
 @inject CycleCountsClient CycleCountsClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/List.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/List.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/cycle-counts"
+@page "/cycle-counts"
 @inject CycleCountsClient CycleCountsClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Schedule.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/CycleCounts/Schedule.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/cycle-counts/schedule"
+@page "/cycle-counts/schedule"
 @inject CycleCountsClient CycleCountsClient
 @inject MasterDataAdminClient MasterDataAdminClient
 @inject NavigationManager NavigationManager

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipmentCreate.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipmentCreate.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/inbound/shipments/create"
+@page "/inbound/shipments/create"
 @inject ReceivingClient ReceivingClient
 @inject MasterDataAdminClient MasterDataAdminClient
 @inject NavigationManager NavigationManager

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipmentDetail.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipmentDetail.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/inbound/shipments/{Id:int}"
+@page "/inbound/shipments/{Id:int}"
 @inject ReceivingClient ReceivingClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipments.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/InboundShipments.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/inbound/shipments"
+@page "/inbound/shipments"
 @inject ReceivingClient ReceivingClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Labels.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Labels.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/labels"
+@page "/labels"
 @using System.Text.Json
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundDispatch.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundDispatch.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/outbound/dispatch"
+@page "/outbound/dispatch"
 @inject OutboundClient OutboundClient
 @inject ToastService ToastService
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundOrderDetail.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundOrderDetail.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/outbound/orders/{Id:guid}"
+@page "/outbound/orders/{Id:guid}"
 @inject OutboundClient OutboundClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundOrders.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/OutboundOrders.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/outbound/orders"
+@page "/outbound/orders"
 @implements IDisposable
 @inject OutboundClient OutboundClient
 @inject NavigationManager NavigationManager

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/PackingStation.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/PackingStation.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/outbound/pack/{OrderId:guid}"
+@page "/outbound/pack/{OrderId:guid}"
 @inject OutboundClient OutboundClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/PickingTasks.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/PickingTasks.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/picking/tasks"
+@page "/picking/tasks"
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @inject PickingTasksClient PickingTasksClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Putaway.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Putaway.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/putaway"
+@page "/putaway"
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @inject PutawayClient PutawayClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ReceivingQc.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/ReceivingQc.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/inbound/qc"
+@page "/inbound/qc"
 @inject ReceivingClient ReceivingClient
 @inject ToastService ToastService
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Rmas.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Rmas.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/rmas"
+@page "/rmas"
 @inject AdvancedWarehouseClient AdvancedClient
 @inject ToastService ToastService
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrderCreate.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrderCreate.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/sales/orders/create"
+@page "/sales/orders/create"
 @inject SalesOrdersClient SalesOrdersClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrderDetail.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrderDetail.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/sales/orders/{Id:guid}"
+@page "/sales/orders/{Id:guid}"
 @inject SalesOrdersClient SalesOrdersClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrders.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SalesOrders.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/sales/orders"
+@page "/sales/orders"
 @inject SalesOrdersClient SalesOrdersClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockAdjustments.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockAdjustments.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/stock/adjustments"
+@page "/stock/adjustments"
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @inject AdjustmentsClient AdjustmentsClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockDashboard.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockDashboard.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/stock/dashboard"
+@page "/stock/dashboard"
 @inject ReportsClient ReportsClient
 @inject IJSRuntime JavaScript
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockLocationBalance.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockLocationBalance.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/stock/location-balance"
+@page "/stock/location-balance"
 @inject StockClient StockClient
 @inject ToastService ToastService
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/Create.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/Create.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/transfers/create"
+@page "/transfers/create"
 @inject TransfersClient TransfersClient
 @inject MasterDataAdminClient MasterDataAdminClient
 @inject StockClient StockApiClient

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/Execute.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/Execute.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/transfers/{Id:guid}/execute"
+@page "/transfers/{Id:guid}/execute"
 @inject TransfersClient TransfersClient
 @inject MasterDataAdminClient MasterDataAdminClient
 @inject NavigationManager NavigationManager

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/List.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Transfers/List.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/transfers"
+@page "/transfers"
 @inject TransfersClient TransfersClient
 @inject NavigationManager NavigationManager
 @inject ToastService ToastService

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/AdjustCost.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/AdjustCost.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/valuation/adjust-cost"
+@page "/valuation/adjust-cost"
 @using System.ComponentModel.DataAnnotations
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/ApplyLandedCost.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/ApplyLandedCost.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/valuation/apply-landed-cost"
+@page "/valuation/apply-landed-cost"
 @using System.ComponentModel.DataAnnotations
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/Dashboard.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/Dashboard.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/valuation/dashboard"
+@page "/valuation/dashboard"
 @using System.Globalization
 @using System.Text
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/WriteDown.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Valuation/WriteDown.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/valuation/write-down"
+@page "/valuation/write-down"
 @using System.ComponentModel.DataAnnotations
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
@@ -1,5 +1,5 @@
-@page "/warehouse/visualization/3d"
-@page "/warehouse/visualization/2d"
+@page "/visualization/3d"
+@page "/visualization/2d"
 @implements IAsyncDisposable
 @using System.Globalization
 @using Microsoft.AspNetCore.Components.Web

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/WarehouseLocationDetail.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/WarehouseLocationDetail.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/locations/{Id:int}"
+@page "/locations/{Id:int}"
 
 <PageTitle>Location Details</PageTitle>
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/WavePicking.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/WavePicking.razor
@@ -1,4 +1,4 @@
-@page "/warehouse/waves"
+@page "/waves"
 @inject AdvancedWarehouseClient AdvancedClient
 @inject ToastService ToastService
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Program.cs
@@ -62,6 +62,7 @@ builder.Services.AddScoped<ToastService>();
 
 var app = builder.Build();
 
+app.UsePathBase(ResolvePathBase(app.Configuration));
 app.UsePortalSecureHosting(app.Environment);
 
 app.UseStaticFiles();
@@ -104,3 +105,9 @@ app.MapBlazorHub();
 app.MapFallbackToPage("/_Host");
 
 app.Run();
+
+static PathString ResolvePathBase(IConfiguration configuration)
+{
+    var configured = configuration["PathBase"];
+    return string.IsNullOrWhiteSpace(configured) ? PathString.Empty : new PathString(configured.TrimEnd('/'));
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
@@ -29,7 +29,7 @@
                     <div class="app-topbar-right">
                         <span class="app-topbar-env text-muted small">@Environment.EnvironmentName</span>
                         <span class="app-topbar-user small">@auth.User.Identity?.Name</span>
-                        <form action="/auth/logout" method="post" class="m-0">
+                        <form action="auth/logout" method="post" class="m-0">
                             <button class="btn btn-outline-secondary btn-sm app-topbar-login" type="submit">Logout</button>
                         </form>
                     </div>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/RedirectToLogin.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/RedirectToLogin.razor
@@ -1,4 +1,5 @@
 @inject NavigationManager Navigation
+@inject IConfiguration Configuration
 
 @code {
     protected override void OnAfterRender(bool firstRender)
@@ -9,7 +10,23 @@
         }
 
         var relative = Navigation.ToBaseRelativePath(Navigation.Uri);
-        var returnUrl = string.IsNullOrWhiteSpace(relative) ? "/dashboard" : $"/{relative}";
-        Navigation.NavigateTo($"/login.html?returnUrl={Uri.EscapeDataString(returnUrl)}", replace: true);
+        var warehouseBasePath = NormalizePath(Configuration["PathBase"], "/warehouse");
+        var portalLoginBasePath = NormalizePath(Configuration["PortalAuth:LoginBasePath"], "/portal");
+        var returnUrl = string.IsNullOrWhiteSpace(relative)
+            ? $"{warehouseBasePath}/dashboard"
+            : $"{warehouseBasePath}/{relative.TrimStart('/')}";
+
+        Navigation.NavigateTo($"{portalLoginBasePath}/login.html?returnUrl={Uri.EscapeDataString(returnUrl)}", replace: true);
+    }
+
+    private static string NormalizePath(string? configured, string fallback)
+    {
+        if (string.IsNullOrWhiteSpace(configured))
+        {
+            return fallback;
+        }
+
+        var normalized = configured.Trim().TrimEnd('/');
+        return normalized.StartsWith("/", StringComparison.Ordinal) ? normalized : $"/{normalized}";
     }
 }


### PR DESCRIPTION
## Summary
- move the test public surface to path-based routing under `https://mes-test.lauresta.com`
- remove reliance on deep test subdomains for portal, warehouse, and APIs
- configure Portal and Warehouse WebUIs for path-base hosting at `/portal` and `/warehouse`
- route test APIs through `/api/portal` and `/api/warehouse` with Traefik prefix stripping
- update shared portal auth redirects/cookie settings for same-host path-based hosting
- update Traefik docs and deploy validation to prevent deep test subdomains from returning

## Validation
- `dotnet build src\Modules\Portal\LKvitai.MES.Modules.Portal.WebUI\LKvitai.MES.Modules.Portal.WebUI.csproj --no-restore`
- `dotnet build src\Modules\Warehouse\LKvitai.MES.Modules.Warehouse.WebUI\LKvitai.MES.Modules.Warehouse.WebUI.csproj --no-restore`
- `rg -n 'portal\.mes-test\.lauresta\.com|warehouse\.mes-test\.lauresta\.com|api\.mes-test\.lauresta\.com' . -S`

## Notes
- `docker compose -f docker-compose.test.yml config --quiet` was not run locally because Docker is not installed in this environment.
- After deployment, validate `/`, `/portal`, `/warehouse`, `/api/portal`, and `/api/warehouse` on `https://mes-test.lauresta.com`.