### PR TITLE
Fix path-based test auth cookie

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
@@ -52,6 +52,7 @@ public static class PortalAuthApplicationBuilderExtensions
         endpoints.MapPost(PortalAuthDefaults.LogoutPath, async (HttpContext httpContext) =>
         {
             await httpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+            DeleteLegacyPathScopedCookies(httpContext);
             return Results.Redirect(ResolveLoginPath(httpContext));
         });
 
@@ -74,5 +75,27 @@ public static class PortalAuthApplicationBuilderExtensions
     {
         var normalized = path.Trim().TrimEnd('/');
         return normalized.StartsWith("/", StringComparison.Ordinal) ? normalized : $"/{normalized}";
+    }
+
+    private static void DeleteLegacyPathScopedCookies(HttpContext httpContext)
+    {
+        var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
+        var cookieDomain = configuration[PortalAuthDefaults.CookieDomainConfigKey];
+        var paths = new[] { "/portal", "/warehouse", httpContext.Request.PathBase.Value }
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => NormalizePath(path!))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var path in paths)
+        {
+            httpContext.Response.Cookies.Delete(PortalAuthDefaults.CookieName, new CookieOptions
+            {
+                Domain = string.IsNullOrWhiteSpace(cookieDomain) ? null : cookieDomain,
+                Path = path,
+                HttpOnly = true,
+                Secure = true,
+                SameSite = SameSiteMode.Lax
+            });
+        }
     }
 }

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthServiceCollectionExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthServiceCollectionExtensions.cs
@@ -34,6 +34,7 @@ public static class PortalAuthServiceCollectionExtensions
                 options.AccessDeniedPath = PortalAuthDefaults.AccessDeniedPath;
                 options.Cookie.Name = PortalAuthDefaults.CookieName;
                 options.Cookie.Domain = ResolveCookieDomain(configuration);
+                options.Cookie.Path = "/";
                 options.Cookie.HttpOnly = true;
                 options.Cookie.SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax;
                 options.Cookie.SecurePolicy = environment.IsDevelopment()

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -226,6 +226,7 @@ static bool IsAnonymousPortalPath(PathString path)
 {
     return path.StartsWithSegments("/login.html", StringComparison.OrdinalIgnoreCase) ||
            path.StartsWithSegments("/auth/login", StringComparison.OrdinalIgnoreCase) ||
+           path.StartsWithSegments("/auth/logout", StringComparison.OrdinalIgnoreCase) ||
            path.StartsWithSegments("/styles.css", StringComparison.OrdinalIgnoreCase) ||
            path.StartsWithSegments("/script.js", StringComparison.OrdinalIgnoreCase) ||
            path.StartsWithSegments("/favicon.ico", StringComparison.OrdinalIgnoreCase) ||


### PR DESCRIPTION
## Summary
- set the shared portal auth cookie path to `/` for path-based test hosting
- clean up legacy `/portal` and `/warehouse` scoped auth cookies on logout
- allow `/portal/auth/logout` to reach the logout endpoint instead of the anonymous redirect middleware

## Validation
- `dotnet build src\Modules\Portal\LKvitai.MES.Modules.Portal.WebUI\LKvitai.MES.Modules.Portal.WebUI.csproj --no-restore`
- `dotnet build src\Modules\Warehouse\LKvitai.MES.Modules.Warehouse.WebUI\LKvitai.MES.Modules.Warehouse.WebUI.csproj --no-restore`

## Why
`mes-test.lauresta.com` now hosts Portal and Warehouse under different paths on the same host. The auth cookie must be root-scoped so both apps see and clear the same session cookie.