### PR TITLE
Clear legacy portal auth cookies on login

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
@@ -52,11 +52,39 @@ public static class PortalAuthApplicationBuilderExtensions
         endpoints.MapPost(PortalAuthDefaults.LogoutPath, async (HttpContext httpContext) =>
         {
             await httpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-            DeleteLegacyPathScopedCookies(httpContext);
+            httpContext.DeleteLegacyPortalAuthCookies();
             return Results.Redirect(ResolveLoginPath(httpContext));
         });
 
         return endpoints;
+    }
+
+    public static void DeleteLegacyPortalAuthCookies(this HttpContext httpContext)
+    {
+        ArgumentNullException.ThrowIfNull(httpContext);
+
+        var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
+        var configuredCookieDomain = configuration[PortalAuthDefaults.CookieDomainConfigKey];
+        var paths = new[] { "/portal", "/warehouse", httpContext.Request.PathBase.Value }
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Select(path => NormalizePath(path!))
+            .Distinct(StringComparer.OrdinalIgnoreCase);
+        var domains = ResolveLegacyCookieDomains(configuredCookieDomain);
+
+        foreach (var path in paths)
+        {
+            foreach (var domain in domains)
+            {
+                httpContext.Response.Cookies.Delete(PortalAuthDefaults.CookieName, new CookieOptions
+                {
+                    Domain = domain,
+                    Path = path,
+                    HttpOnly = true,
+                    Secure = true,
+                    SameSite = SameSiteMode.Lax
+                });
+            }
+        }
     }
 
     private static string ResolveLoginPath(HttpContext httpContext)
@@ -77,25 +105,16 @@ public static class PortalAuthApplicationBuilderExtensions
         return normalized.StartsWith("/", StringComparison.Ordinal) ? normalized : $"/{normalized}";
     }
 
-    private static void DeleteLegacyPathScopedCookies(HttpContext httpContext)
+    private static IEnumerable<string?> ResolveLegacyCookieDomains(string? configuredCookieDomain)
     {
-        var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
-        var cookieDomain = configuration[PortalAuthDefaults.CookieDomainConfigKey];
-        var paths = new[] { "/portal", "/warehouse", httpContext.Request.PathBase.Value }
-            .Where(path => !string.IsNullOrWhiteSpace(path))
-            .Select(path => NormalizePath(path!))
-            .Distinct(StringComparer.OrdinalIgnoreCase);
+        yield return null;
 
-        foreach (var path in paths)
+        if (!string.IsNullOrWhiteSpace(configuredCookieDomain))
         {
-            httpContext.Response.Cookies.Delete(PortalAuthDefaults.CookieName, new CookieOptions
-            {
-                Domain = string.IsNullOrWhiteSpace(cookieDomain) ? null : cookieDomain,
-                Path = path,
-                HttpOnly = true,
-                Secure = true,
-                SameSite = SameSiteMode.Lax
-            });
+            yield return configuredCookieDomain;
         }
+
+        yield return ".mes-test.lauresta.com";
+        yield return ".lauresta.com";
     }
 }

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Program.cs
@@ -184,6 +184,8 @@ app.MapPost("/auth/login", async (
 
     try
     {
+        httpContext.DeleteLegacyPortalAuthCookies();
+
         await httpContext.SignInAsync(
             CookieAuthenticationDefaults.AuthenticationScheme,
             new ClaimsPrincipal(new ClaimsIdentity(claims, CookieAuthenticationDefaults.AuthenticationScheme)),


### PR DESCRIPTION
## Summary
- Clear legacy path-scoped Portal auth cookies whenever login succeeds, before issuing the new root-scoped auth cookie.
- Reuse the same cleanup helper for logout.
- Delete old /portal and /warehouse cookies for host-only cookies and legacy domain-cookie variants so browsers stop sending duplicate LKvitai.MES.Portal values.

## Diagnosis
Safari HAR showed two LKvitai.MES.Portal cookies being sent to /warehouse/dashboard. The login response only issued the new path=/ cookie and did not expire the older path-scoped cookies, so Warehouse could still see the wrong cookie value and redirect back to /portal/login.html.

## Validation
- dotnet build src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj --no-restore
- dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj --no-restore
- curl confirmed current deployed /portal/auth/login only sets path=/ before this PR; this PR adds deletion headers for legacy /portal and /warehouse cookies.