### PR TITLE
Delete root-scoped legacy portal cookies

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/PortalAuthApplicationBuilderExtensions.cs
@@ -65,7 +65,7 @@ public static class PortalAuthApplicationBuilderExtensions
 
         var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
         var configuredCookieDomain = configuration[PortalAuthDefaults.CookieDomainConfigKey];
-        var paths = new[] { "/portal", "/warehouse", httpContext.Request.PathBase.Value }
+        var paths = new[] { "/", "/portal", "/warehouse", httpContext.Request.PathBase.Value }
             .Where(path => !string.IsNullOrWhiteSpace(path))
             .Select(path => NormalizePath(path!))
             .Distinct(StringComparer.OrdinalIgnoreCase);


### PR DESCRIPTION
## Summary
- include root path when deleting legacy portal auth cookies on login/logout
- clears old domain-scoped / cookies that can coexist with the new host-only auth cookie and keep Safari/Blazor in a login loop

## Verification
- dotnet build src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/LKvitai.MES.BuildingBlocks.PortalAuth.csproj --no-restore
- dotnet build src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/LKvitai.MES.Modules.Portal.WebUI.csproj --no-restore
- dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj --no-restore