### PR TITLE
S-2 Sales: real SQL gateway over legacy weblb_* procs

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -26,6 +26,7 @@ jobs:
       ITEMIMAGES__SECRETKEY: ${{ secrets.ITEMIMAGES__SECRETKEY }}
       ITEMIMAGES__MODEL_PATH: ${{ vars.ITEMIMAGES__MODEL_PATH }}
       CLIP_MODEL_DIR: ${{ vars.CLIP_MODEL_DIR }}
+      LKVITAI_MSACCESS_DB_CONNECTION: ${{ secrets.LKVITAI_MSACCESS_DB_CONNECTION }}
 
     steps:
       - name: Fail fast if required env vars are missing or invalid
@@ -44,6 +45,10 @@ jobs:
           fi
           if [ "${CLIP_MODEL_DIR}" = "/tmp/models" ] || [[ "${CLIP_MODEL_DIR}" == /tmp/* ]]; then
             echo "::error::CLIP_MODEL_DIR points to /tmp, which is ephemeral after reboot/cleanup. Use a persistent path, e.g. /opt/lkvitai-mes/models."
+            exit 1
+          fi
+          if [ -z "${LKVITAI_MSACCESS_DB_CONNECTION}" ]; then
+            echo "::error::LKVITAI_MSACCESS_DB_CONNECTION is missing. Set it in GitHub Environment 'test' as the SQL Server connection string for the legacy LKvitaiDb (the migrated MS Access database). Sales.Api refuses to start without it after S-2."
             exit 1
           fi
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="MediatR" Version="12.2.0" />
     <PackageVersion Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Data.SqlClient" Version="5.2.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -96,9 +96,14 @@ services:
     depends_on:
       - portal-api
 
-  # --- Sales module (scaffold) --------------------------------------------------
+  # --- Sales module -------------------------------------------------------------
   # Uses the shared PortalAuth cookie (same auth-keys bind-mount, same cookie name)
   # so a user signed in via Portal is authenticated against the Sales API too.
+  # S-2: Sales.Api now talks directly to the legacy SQL Server (LKvitaiDb — the
+  # migrated MS Access database) via the weblb_* stored procedures. The
+  # connection string is required — the deploy workflow fails fast if
+  # LKVITAI_MSACCESS_DB_CONNECTION is empty, and Sales.Api itself refuses to
+  # start without ConnectionStrings__LKvitaiDb.
   sales-api:
     image: ghcr.io/lauresta/lkvitai-mes-sales-api:${IMAGE_TAG:-latest}
     container_name: lkvitai-mes-sales-api
@@ -108,6 +113,8 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Test
       PortalAuth__DataProtectionKeysPath: "/app/auth-keys"
+      ConnectionStrings__LKvitaiDb: "${LKVITAI_MSACCESS_DB_CONNECTION}"
+      Sales__OrdersDataSource: "Sql"
     volumes:
       - ${AUTH_KEYS_DIR:-/opt/lkvitai-mes/auth-keys}:/app/auth-keys
       - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
@@ -1,0 +1,98 @@
+@namespace LKvitai.MES.BuildingBlocks.WebUI.Components
+@inject NavigationManager Navigation
+
+<div class="app-shell">
+    <div class="test-strip">
+        <div class="test-strip__main">
+            <span class="icon-warning" aria-hidden="true"></span>
+            <strong>@EnvironmentLabel ENVIRONMENT</strong>
+            <span class="test-strip__note">@BannerNote</span>
+        </div>
+        <span class="mono test-strip__host">@DisplayHost</span>
+    </div>
+
+    <header class="topbar">
+        <div class="brand">
+            <div class="brand__mark">LK</div>
+            <div>
+                <div class="brand__name">LKvitai<span>.MES</span></div>
+                <div class="brand__tagline mono">Manufacturing &middot; Execution &middot; Standards</div>
+            </div>
+        </div>
+        <div class="topbar__separator" aria-hidden="true"></div>
+        <label class="portal-search">
+            <span class="portal-search__icon" aria-hidden="true"></span>
+            <span class="sr-only">@SearchLabel</span>
+            <input type="search" placeholder="@SearchPlaceholder" autocomplete="off" />
+        </label>
+        <div class="topbar__spacer"></div>
+        <div class="env-badge" aria-label="Environment and version">
+            <div><span class="mono">ENV</span><strong class="mono">@EnvironmentBadge</strong></div>
+            <div><span class="mono">VER</span><strong class="mono">@Version</strong></div>
+        </div>
+        <div class="user-block">
+            <div class="user-block__avatar">@Initials</div>
+            <div>
+                <div class="user-block__name">@DisplayName</div>
+                <form action="@LogoutAction" method="post" class="logout-form">
+                    <button class="link-button" type="submit">Logout</button>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    @Body
+</div>
+
+@code {
+    [Parameter] public RenderFragment? Body { get; set; }
+    [Parameter] public ClaimsPrincipal? User { get; set; }
+    [Parameter] public string EnvironmentName { get; set; } = "Development";
+    [Parameter] public string? HostLabel { get; set; }
+    [Parameter] public string Version { get; set; } = "0.1.0";
+    [Parameter] public string SearchPlaceholder { get; set; } = "Find a module...";
+    [Parameter] public string SearchLabel { get; set; } = "Find a module";
+    [Parameter] public string LogoutAction { get; set; } = "auth/logout";
+    [Parameter] public string BannerNote { get; set; } = "Data in this environment is not production data and may be reset without notice.";
+
+    private string EnvironmentLabel => (EnvironmentName ?? "Development").ToUpperInvariant();
+
+    private string DisplayHost => !string.IsNullOrWhiteSpace(HostLabel)
+        ? HostLabel
+        : ResolveNavigationHost();
+
+    private string EnvironmentBadge
+    {
+        get
+        {
+            var name = EnvironmentName ?? "Development";
+            return name.Length <= 4 ? name.ToUpperInvariant() : name[..4].ToUpperInvariant();
+        }
+    }
+
+    private string DisplayName => User?.FindFirstValue(ClaimTypes.Name)
+                                  ?? User?.Identity?.Name
+                                  ?? "Signed in";
+
+    private string Initials
+    {
+        get
+        {
+            var parts = DisplayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var raw = parts.Length >= 2
+                ? $"{parts[0][0]}{parts[1][0]}"
+                : parts.Length == 1 ? parts[0][0].ToString() : "U";
+            return raw.ToUpperInvariant();
+        }
+    }
+
+    private string ResolveNavigationHost()
+    {
+        if (Uri.TryCreate(Navigation.Uri, UriKind.Absolute, out var uri) && !string.IsNullOrWhiteSpace(uri.Host))
+        {
+            return uri.Host;
+        }
+
+        return "localhost";
+    }
+}

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/LKvitai.MES.BuildingBlocks.WebUI.csproj
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/LKvitai.MES.BuildingBlocks.WebUI.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Razor">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <RootNamespace>LKvitai.MES.BuildingBlocks.WebUI</RootNamespace>
+    <AssemblyName>LKvitai.MES.BuildingBlocks.WebUI</AssemblyName>
+    <AddRazorSupportForMvc>true</AddRazorSupportForMvc>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+</Project>

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
@@ -1,0 +1,3 @@
+@using System.Security.Claims
+@using Microsoft.AspNetCore.Components
+@using Microsoft.AspNetCore.Components.Authorization

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
@@ -1,0 +1,273 @@
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.app-shell {
+  max-width: 1440px;
+  min-height: 100vh;
+  margin: 0 auto;
+  background: var(--n-50);
+  box-shadow: 0 0 40px rgb(0 0 0 / 4%);
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.test-strip {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 28px;
+  background: repeating-linear-gradient(-45deg, #ead19b, #ead19b 12px, #dfc07a 12px, #dfc07a 24px);
+  color: var(--n-900);
+  font-size: 12px;
+}
+
+.test-strip__main {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  min-width: 0;
+}
+
+.test-strip__note {
+  opacity: .82;
+}
+
+.test-strip__host {
+  font-size: 11px;
+  white-space: nowrap;
+}
+
+.icon-warning {
+  width: 14px;
+  height: 14px;
+  background: currentColor;
+  clip-path: polygon(50% 5%, 96% 90%, 4% 90%);
+  display: inline-block;
+}
+
+.topbar {
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 14px 28px;
+  background: var(--dark);
+  color: var(--n-0);
+  border-bottom: 1px solid var(--dark-line);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+}
+
+.brand__mark {
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  flex: 0 0 auto;
+  border: 1px solid var(--dark-line);
+  border-radius: 6px;
+  background: var(--dark-2);
+  color: var(--accent-400);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+.brand__name {
+  color: var(--n-0);
+  font-size: 15px;
+  font-weight: 700;
+  line-height: 1.1;
+}
+
+.brand__name span {
+  color: #9ba4b0;
+  font-weight: 400;
+}
+
+.brand__tagline {
+  margin-top: 2px;
+  color: #a5adb8;
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.topbar__separator {
+  width: 1px;
+  height: 28px;
+  background: var(--dark-line);
+}
+
+.topbar__spacer {
+  flex: 1;
+}
+
+.portal-search {
+  position: relative;
+  flex: 1 1 360px;
+  max-width: 460px;
+}
+
+.portal-search input {
+  width: 100%;
+  padding: 8px 10px 8px 34px;
+  border: 1px solid var(--dark-line);
+  border-radius: 4px;
+  outline: none;
+  background: #1b2028;
+  color: var(--n-0);
+  font-size: 13px;
+}
+
+.portal-search input::placeholder {
+  color: #8f98a6;
+}
+
+.portal-search input:focus {
+  border-color: var(--accent-400);
+}
+
+.portal-search__icon {
+  position: absolute;
+  left: 12px;
+  top: 50%;
+  width: 13px;
+  height: 13px;
+  border: 1.8px solid #8f98a6;
+  border-radius: 50%;
+  transform: translateY(-58%);
+  pointer-events: none;
+}
+
+.portal-search__icon::after {
+  content: "";
+  position: absolute;
+  right: -5px;
+  bottom: -4px;
+  width: 6px;
+  height: 1.8px;
+  background: #8f98a6;
+  transform: rotate(45deg);
+  transform-origin: left center;
+}
+
+.env-badge {
+  display: flex;
+  border: 1px solid var(--dark-line);
+  border-radius: 4px;
+  overflow: hidden;
+  background: #1b2028;
+}
+
+.env-badge div {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 11px;
+}
+
+.env-badge div:first-child {
+  border-right: 1px solid var(--dark-line);
+  background: var(--dark-2);
+}
+
+.env-badge span {
+  color: #9ba4b0;
+  font-size: 10px;
+}
+
+.env-badge strong {
+  color: var(--n-0);
+  font-size: 11px;
+}
+
+.env-badge div:first-child strong {
+  color: #dfc07a;
+}
+
+.user-block {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding-left: 14px;
+  border-left: 1px solid var(--dark-line);
+}
+
+.user-block__avatar {
+  display: grid;
+  place-items: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 50%;
+  background: var(--dark-line);
+  color: var(--accent-400);
+  font-size: 11px;
+  font-weight: 700;
+  font-family: var(--font-mono);
+}
+
+.user-block__name {
+  color: var(--n-0);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.link-button {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #a5adb8;
+  cursor: pointer;
+  font-size: 12px;
+  text-align: left;
+}
+
+.link-button:hover,
+.link-button:focus {
+  color: var(--n-0);
+  text-decoration: underline;
+}
+
+@media (max-width: 980px) {
+  .topbar {
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .topbar__separator,
+  .env-badge {
+    display: none;
+  }
+
+  .portal-search {
+    order: 3;
+    flex-basis: 100%;
+    max-width: none;
+  }
+}
+
+@media (max-width: 760px) {
+  .test-strip {
+    display: none;
+  }
+
+  .brand__tagline {
+    display: none;
+  }
+}

--- a/src/LKvitai.MES.sln
+++ b/src/LKvitai.MES.sln
@@ -91,6 +91,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.Modules.Scannin
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.BuildingBlocks.ModuleStartup", "BuildingBlocks\LKvitai.MES.BuildingBlocks.ModuleStartup\LKvitai.MES.BuildingBlocks.ModuleStartup.csproj", "{62AF2A2A-F474-4644-8EAA-43740A0D8994}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.BuildingBlocks.WebUI", "BuildingBlocks\LKvitai.MES.BuildingBlocks.WebUI\LKvitai.MES.BuildingBlocks.WebUI.csproj", "{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -521,6 +523,18 @@ Global
 		{62AF2A2A-F474-4644-8EAA-43740A0D8994}.Release|x64.Build.0 = Release|Any CPU
 		{62AF2A2A-F474-4644-8EAA-43740A0D8994}.Release|x86.ActiveCfg = Release|Any CPU
 		{62AF2A2A-F474-4644-8EAA-43740A0D8994}.Release|x86.Build.0 = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|x64.Build.0 = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Debug|x86.Build.0 = Debug|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x64.ActiveCfg = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x64.Build.0 = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x86.ActiveCfg = Release|Any CPU
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -566,5 +580,6 @@ Global
 		{B7B7C22D-13E2-4504-9BEC-EF0F83AEC005} = {E517C80E-57DC-40DC-B774-86FB3BB2E677}
 		{C064108B-603E-44EC-9AF7-FE630A05AEEE} = {E517C80E-57DC-40DC-B774-86FB3BB2E677}
 		{62AF2A2A-F474-4644-8EAA-43740A0D8994} = {12C1EE8E-A2E0-45AF-BB0B-AE1B9FE15B43}
+		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3} = {12C1EE8E-A2E0-45AF-BB0B-AE1B9FE15B43}
 	EndGlobalSection
 EndGlobal

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
@@ -1,0 +1,121 @@
+using LKvitai.MES.Modules.Sales.Application.Ports;
+using LKvitai.MES.Modules.Sales.Infrastructure.Sql;
+using LKvitai.MES.Modules.Sales.Infrastructure.Stub;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace LKvitai.MES.Modules.Sales.Api.Composition;
+
+/// <summary>
+/// Composition root for the Sales orders read-side. Always picks the real
+/// <see cref="SqlOrdersQueryService"/> (S-2 SQL Server adapter over the legacy
+/// <c>weblb_*</c> stored procedures); the in-memory
+/// <see cref="StubOrdersQueryService"/> is only selectable through an
+/// explicit <c>Sales:OrdersDataSource = "Stub"</c> opt-in and is intended
+/// for tests / dev environments that genuinely cannot reach the legacy DB.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Selection rules (post-S-2).</b>
+/// </para>
+/// <list type="bullet">
+///   <item><c>"Sql"</c> (default when key is missing or set to <c>Auto</c>) —
+///   require <c>ConnectionStrings:LKvitaiDb</c>; throw at startup if it is
+///   missing, regardless of environment. There is no automatic stub fallback
+///   any more.</item>
+///   <item><c>"Stub"</c> — explicit opt-in only; logs a loud warning at startup
+///   to make it obvious the running process is serving sample data.</item>
+/// </list>
+/// <para>
+/// <b>Why no auto-fallback.</b> Pre-S-2 the WebUI silently surfaced seven
+/// hand-coded sample rows whenever the connection string was missing. That made
+/// missing config invisible in test/staging and risked shipping fake orders to
+/// real users. After S-2 the Sales surface either talks to the legacy SQL
+/// Server or refuses to start.
+/// </para>
+/// </remarks>
+public static class SalesOrdersDataSource
+{
+    private const string DataSourceConfigKey  = "Sales:OrdersDataSource";
+    private const string ConnectionStringName = "LKvitaiDb";
+    private const string CommandTimeoutKey    = "Sales:Sql:CommandTimeoutSeconds";
+
+    private const string ModeAuto = "Auto";
+    private const string ModeSql  = "Sql";
+    private const string ModeStub = "Stub";
+
+    public static IServiceCollection AddSalesOrdersDataSource(
+        this IServiceCollection services,
+        IConfiguration configuration,
+        IHostEnvironment environment)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+        ArgumentNullException.ThrowIfNull(configuration);
+        ArgumentNullException.ThrowIfNull(environment);
+
+        var requestedMode    = configuration[DataSourceConfigKey];
+        var connectionString = configuration.GetConnectionString(ConnectionStringName);
+        var hasConnection    = !string.IsNullOrWhiteSpace(connectionString);
+
+        var mode = ResolveMode(requestedMode);
+
+        if (mode == ModeStub)
+        {
+            // Explicit opt-in only — never the default code path. Used by unit
+            // / WebUI smoke tests that exercise the toolbar without spinning
+            // up a SQL Server. Logs a loud warning so a misconfigured env is
+            // visible in the startup banner.
+            services.AddSingleton<IOrdersQueryService>(sp =>
+            {
+                var logger = sp.GetService<ILoggerFactory>()?.CreateLogger("Sales.OrdersDataSource");
+                logger?.LogWarning(
+                    "Sales orders read-side is using the in-memory STUB (explicit Sales:OrdersDataSource=Stub). " +
+                    "Environment={Environment}. This must never be the case in Test or Production.",
+                    environment.EnvironmentName);
+                return new StubOrdersQueryService();
+            });
+            return services;
+        }
+
+        // Sql / Auto — both require the legacy connection string. Fail fast
+        // (at composition time, before the host opens any sockets) so the
+        // operator sees a clear startup error instead of a 500 on the first
+        // /api/sales/orders request.
+        if (!hasConnection)
+        {
+            throw new InvalidOperationException(
+                $"Sales orders SQL adapter requires ConnectionStrings:{ConnectionStringName} to be set " +
+                $"(environment '{environment.EnvironmentName}'). Provide the LKvitaiDb connection string via " +
+                "environment variable (ConnectionStrings__LKvitaiDb) or user-secrets, " +
+                "or set Sales:OrdersDataSource=Stub explicitly for a stub-only test/dev run.");
+        }
+
+        var commandTimeout = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
+        services.AddSingleton(new SalesSqlOptions
+        {
+            ConnectionString      = connectionString!,
+            CommandTimeoutSeconds = commandTimeout <= 0 ? 30 : commandTimeout,
+        });
+        services.AddSingleton<IOrdersQueryService, SqlOrdersQueryService>();
+        return services;
+    }
+
+    /// <summary>
+    /// Treats missing / empty / "Auto" as the default <c>Sql</c> path. The
+    /// only other accepted value is <c>"Stub"</c> (case-insensitive); anything
+    /// else is rejected so a typo in <c>appsettings</c> cannot silently fall
+    /// through to a stubbed runtime.
+    /// </summary>
+    private static string ResolveMode(string? requestedMode)
+    {
+        if (string.IsNullOrWhiteSpace(requestedMode)) return ModeSql;
+        if (string.Equals(requestedMode, ModeSql,  StringComparison.OrdinalIgnoreCase)) return ModeSql;
+        if (string.Equals(requestedMode, ModeAuto, StringComparison.OrdinalIgnoreCase)) return ModeSql;
+        if (string.Equals(requestedMode, ModeStub, StringComparison.OrdinalIgnoreCase)) return ModeStub;
+
+        throw new InvalidOperationException(
+            $"Unknown Sales:OrdersDataSource '{requestedMode}'. Expected one of: '{ModeSql}', '{ModeAuto}', '{ModeStub}'.");
+    }
+}

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Program.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Program.cs
@@ -1,9 +1,8 @@
 using LKvitai.MES.BuildingBlocks.ModuleStartup;
 using LKvitai.MES.BuildingBlocks.PortalAuth;
+using LKvitai.MES.Modules.Sales.Api.Composition;
 using LKvitai.MES.Modules.Sales.Api.Endpoints;
 using LKvitai.MES.Modules.Sales.Api.Security;
-using LKvitai.MES.Modules.Sales.Application.Ports;
-using LKvitai.MES.Modules.Sales.Infrastructure.Stub;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authorization;
@@ -13,9 +12,12 @@ var builder = WebApplication.CreateBuilder(args);
 builder.UseScaffoldSerilog("sales");
 builder.Services.AddScaffoldApiCore();
 
-// S-1: in-memory stub for the orders read model. Replaced in S-2 by the real
-// SQL Server adapter over the legacy weblb_* stored procedures.
-builder.Services.AddSingleton<IOrdersQueryService, StubOrdersQueryService>();
+// S-2: bind the orders read-side to the SQL Server adapter
+// (SqlOrdersQueryService over the legacy weblb_* stored procedures). Requires
+// ConnectionStrings:LKvitaiDb in every environment — Sales.Api now refuses to
+// start without it. The in-memory StubOrdersQueryService is only used when
+// Sales:OrdersDataSource is explicitly set to "Stub" (test / dev opt-in).
+builder.Services.AddSalesOrdersDataSource(builder.Configuration, builder.Environment);
 
 // Sales replicates Warehouse's "internal user mechanism" by leaning on the shared
 // Portal cookie (PortalAuth). Same DataProtection keys, same cookie name, so a user

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
@@ -5,7 +5,16 @@
       "Microsoft.AspNetCore": "Information"
     }
   },
+  "ConnectionStrings": {
+    "_Comment_LKvitaiDb": "Set via env var ConnectionStrings__LKvitaiDb or `dotnet user-secrets set ConnectionStrings:LKvitaiDb '...'`. Never commit a real value here.",
+    "LKvitaiDb": ""
+  },
   "Sales": {
-    "DevAuthEnabled": true
+    "DevAuthEnabled": true,
+    "_Comment_OrdersDataSource": "Default Sql adapter requires ConnectionStrings:LKvitaiDb. Set 'Stub' explicitly only when you knowingly want sample data.",
+    "OrdersDataSource": "Sql",
+    "Sql": {
+      "CommandTimeoutSeconds": 30
+    }
   }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderDetailsDto.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderDetailsDto.cs
@@ -6,7 +6,7 @@ namespace LKvitai.MES.Modules.Sales.Contracts.Orders;
 /// All raw values — the WebUI handles formatting and chip / debt-tier classes.
 /// </summary>
 public sealed record OrderDetailsDto(
-    int Id,
+    long Id,
     string Number,
     DateOnly Date,
     decimal Price,

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderSummaryDto.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderSummaryDto.cs
@@ -5,7 +5,7 @@ namespace LKvitai.MES.Modules.Sales.Contracts.Orders;
 /// (decimals, dates, flags, semantic codes) — never CSS class names. The WebUI
 /// derives chip / debt-tier classes and locale formatting from these fields.
 /// </summary>
-/// <param name="Id">Stable internal identifier (legacy <c>weblb_Order.Id</c>).</param>
+/// <param name="Id">Stable internal identifier (legacy <c>weblb_Order.Id</c> — BIGINT, mapped as <see cref="long"/>).</param>
 /// <param name="Number">Public order number, e.g. <c>KVT-240518-018</c>.</param>
 /// <param name="Date">Order date (no time component on the list).</param>
 /// <param name="Price">Total order price including VAT.</param>
@@ -28,7 +28,7 @@ namespace LKvitai.MES.Modules.Sales.Contracts.Orders;
 /// matches on <c>Number / Customer / Address</c>.
 /// </param>
 public sealed record OrderSummaryDto(
-    int Id,
+    long Id,
     string Number,
     DateOnly Date,
     decimal Price,

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/LKvitai.MES.Modules.Sales.Infrastructure.csproj
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/LKvitai.MES.Modules.Sales.Infrastructure.csproj
@@ -9,6 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.SharedKernel\LKvitai.MES.BuildingBlocks.SharedKernel.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Sales.Application\LKvitai.MES.Modules.Sales.Application.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Sales.Contracts\LKvitai.MES.Modules.Sales.Contracts.csproj" />

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesOrderStatusMap.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesOrderStatusMap.cs
@@ -1,0 +1,38 @@
+using LKvitai.MES.Modules.Sales.Contracts.Orders;
+
+namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
+
+/// <summary>
+/// Maps the localized (Lithuanian) status label returned by <c>dbo.weblb_Orders</c>
+/// / <c>dbo.weblb_Order</c> to the stable semantic <see cref="OrderStatusCodes"/>
+/// the WebUI uses to pick the chip modifier class. Comparison is case-insensitive
+/// and trimmed; unknown labels fall back to <see cref="OrderStatusCodes.Entered"/>
+/// (slate / neutral) so an unmapped status renders as a muted chip rather than
+/// breaking the row.
+/// </summary>
+internal static class SalesOrderStatusMap
+{
+    private static readonly Dictionary<string, string> Map = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["Įvestas"]      = OrderStatusCodes.Entered,
+        ["Patvirtintas"] = OrderStatusCodes.Approved,
+        ["Gaminamas"]    = OrderStatusCodes.InProgress,
+        ["Pagamintas"]   = OrderStatusCodes.Made,
+        ["Filialui"]     = OrderStatusCodes.Shipped,
+        ["Atiduotas"]    = OrderStatusCodes.Delivered,
+        ["Sustabdytas"]  = OrderStatusCodes.Paused,
+        ["Atšauktas"]    = OrderStatusCodes.Cancelled,
+    };
+
+    public static string ToStatusCode(string? label)
+    {
+        if (string.IsNullOrWhiteSpace(label))
+        {
+            return OrderStatusCodes.Entered;
+        }
+
+        return Map.TryGetValue(label.Trim(), out var code)
+            ? code
+            : OrderStatusCodes.Entered;
+    }
+}

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
@@ -1,0 +1,30 @@
+namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
+
+/// <summary>
+/// Connection settings the Sales SQL Server adapter (S-2) needs to talk to the
+/// legacy <c>LKvitaiDb</c> database. Resolved at composition time from
+/// <c>ConnectionStrings:LKvitaiDb</c> (and optional <c>Sales:Sql</c> section)
+/// and registered as a singleton — see
+/// <c>SalesOrdersDataSourceServiceCollectionExtensions</c> in <c>Sales.Api</c>.
+/// </summary>
+/// <remarks>
+/// Kept intentionally framework-light (no <c>IOptions&lt;T&gt;</c>) so the
+/// Infrastructure project does not have to take a hard dependency on
+/// <c>Microsoft.Extensions.Options</c> just to ferry two scalar values.
+/// </remarks>
+public sealed class SalesSqlOptions
+{
+    /// <summary>
+    /// SQL Server connection string for the legacy <c>LKvitaiDb</c> database.
+    /// Must be non-empty when the SQL adapter is in use; the dev/stub fallback
+    /// in <c>Sales.Api</c> is responsible for handling the missing / empty case.
+    /// </summary>
+    public string ConnectionString { get; init; } = string.Empty;
+
+    /// <summary>
+    /// Per-command timeout in seconds. The legacy <c>weblb_*</c> stored procedures
+    /// historically run sub-second, but the orders list materialises the entire
+    /// table in-memory so we leave headroom for bigger result sets.
+    /// </summary>
+    public int CommandTimeoutSeconds { get; init; } = 30;
+}

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -1,0 +1,518 @@
+using System.Data;
+using System.Globalization;
+using LKvitai.MES.Modules.Sales.Application.Ports;
+using LKvitai.MES.Modules.Sales.Contracts.Common;
+using LKvitai.MES.Modules.Sales.Contracts.Orders;
+using Microsoft.Data.SqlClient;
+using Microsoft.Extensions.Logging;
+
+namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
+
+/// <summary>
+/// SQL Server adapter for <see cref="IOrdersQueryService"/> that calls the
+/// legacy <c>dbo.weblb_*</c> stored procedures (S-2). Mirrors the behaviour of
+/// <c>LKvitai.Web.Controllers.OrdersController</c> in the legacy ASP.NET app:
+/// <list type="bullet">
+///   <item><c>dbo.weblb_Orders</c> — full table read, no parameters (used for
+///   both the orders list and as the seed for the details summary).</item>
+///   <item><c>dbo.weblb_Order</c> with <c>@OrderId</c> — order header + amounts.</item>
+///   <item><c>dbo.weblb_Accessories</c> with <c>@OrderId</c> — accessory rows.</item>
+///   <item><c>dbo.weblb_Items</c> with <c>@OrderId</c> — item rows (each becomes
+///   one <see cref="OrderItemGroupDto"/>; matching accessories are appended).</item>
+///   <item><c>dbo.weblb_Employees</c> with <c>@OrderId</c> — employee assignments.</item>
+/// </list>
+/// All column reads are <see cref="DBNull"/>-guarded; missing or unexpected
+/// types degrade to safe defaults (<c>0m</c>, empty string, <c>null</c>) instead
+/// of throwing, so a single bad row never blanks the entire list.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Paging / filtering note (TODO).</b> <c>dbo.weblb_Orders</c> takes no
+/// parameters and returns the full result set. This adapter therefore
+/// materialises every row into memory, then applies search / status / store /
+/// has-debt filters and pages in C#. That matches the legacy app's behaviour and
+/// is acceptable while the table size is in the low thousands, but a long-term
+/// fix is to introduce a paged proc wrapper (e.g. <c>dbo.weblb_Orders_Paged</c>
+/// taking <c>@Skip</c>, <c>@Take</c>, <c>@Search</c>, …) so the database does
+/// the work and we stop shipping the entire table per request.
+/// </para>
+/// <para>
+/// <b>Date filter.</b> <see cref="OrdersQueryParams.Date"/> is intentionally
+/// ignored here — the legacy proc has no date range parameters and the WebUI
+/// keeps that filter disabled until a paged proc wrapper exists. A future
+/// revision should plumb a real range through both the proc and this adapter.
+/// </para>
+/// <para>
+/// <b>Customer flags.</b> The legacy proc does not return <c>IsVip</c>,
+/// <c>HasNote</c> or <c>IsOverdue</c>. We derive <c>HasDebt = Debt &gt; 0</c>
+/// and leave the other three at <c>false</c>. Unknown column ordinals 8 and 9
+/// of <c>weblb_Orders</c> may carry these — to be confirmed with the DBA.
+/// </para>
+/// </remarks>
+public sealed class SqlOrdersQueryService : IOrdersQueryService
+{
+    private const string OrdersProcName      = "dbo.weblb_Orders";
+    private const string OrderProcName       = "dbo.weblb_Order";
+    private const string AccessoriesProcName = "dbo.weblb_Accessories";
+    private const string ItemsProcName       = "dbo.weblb_Items";
+    private const string EmployeesProcName   = "dbo.weblb_Employees";
+    private const string OrderIdParameter    = "@OrderId";
+
+    private readonly SalesSqlOptions _options;
+    private readonly ILogger<SqlOrdersQueryService> _logger;
+
+    public SqlOrdersQueryService(SalesSqlOptions options, ILogger<SqlOrdersQueryService> logger)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        if (string.IsNullOrWhiteSpace(options.ConnectionString))
+        {
+            throw new InvalidOperationException(
+                "SqlOrdersQueryService requires a non-empty SalesSqlOptions.ConnectionString. " +
+                "Configure ConnectionStrings:LKvitaiDb or switch Sales:OrdersDataSource to 'Stub'.");
+        }
+
+        _options = options;
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PagedResult<OrderSummaryDto>> GetOrdersAsync(
+        OrdersQueryParams query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
+        return ApplyFilterSortPage(all, query);
+    }
+
+    public async Task<OrderDetailsDto?> GetOrderDetailsAsync(
+        string number,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(number))
+        {
+            return null;
+        }
+
+        // Phase 1: locate the summary row in weblb_Orders so we can resolve the
+        // legacy Id (the @OrderId parameter all other procs require) and seed
+        // the price / debt / store / status fields the details proc does not
+        // return.
+        var summary = (await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false))
+            .FirstOrDefault(o => string.Equals(o.Number, number, StringComparison.OrdinalIgnoreCase));
+
+        if (summary is null)
+        {
+            return null;
+        }
+
+        await using var conn = new SqlConnection(_options.ConnectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        // Phase 2: header (operator + amounts + authoritative address override).
+        OrderOperatorDto? @operator = null;
+        var amounts = new List<OrderAmountDto>(6);
+        var headerCustomer = summary.Customer;
+        var headerStatus   = summary.Status;
+        var headerAddress  = summary.Address;
+
+        await using (var cmd = CreateProc(conn, OrderProcName, summary.Id))
+        await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                headerCustomer = ReadString(reader, "Customer", summary.Customer);
+                headerStatus   = ReadString(reader, "Status",   summary.Status);
+                headerAddress  = ReadString(reader, "Address",  summary.Address);
+
+                var operatorName = ReadString(reader, "sUserNameInsert", string.Empty);
+                var operatorAt   = ReadDateTime(reader, "Date");
+                if (!string.IsNullOrWhiteSpace(operatorName) && operatorAt is not null)
+                {
+                    @operator = new OrderOperatorDto(operatorName, operatorAt.Value);
+                }
+
+                amounts.Add(new OrderAmountDto(OrderAmountKind.Defined,       "Defined",        ReadDecimal(reader, "DefinedAmount"),    Percent: null));
+                amounts.Add(new OrderAmountDto(OrderAmountKind.Calculated,    "Calculated",     ReadDecimal(reader, "CalculatedAmount"), Percent: null));
+                amounts.Add(new OrderAmountDto(OrderAmountKind.Discount,      "Discount",       Amount: null,                            ReadDecimal(reader, "Discount")));
+                amounts.Add(new OrderAmountDto(OrderAmountKind.AfterDiscount, "After discount", ReadDecimal(reader, "FinalCost"),        Percent: null));
+                amounts.Add(new OrderAmountDto(OrderAmountKind.Paid,          "Paid",           ReadDecimal(reader, "Paid"),             Percent: null));
+                amounts.Add(new OrderAmountDto(OrderAmountKind.Debt,          "Debt",           ReadDecimal(reader, "Debt"),             Percent: null));
+            }
+        }
+
+        // Phase 3: accessories (collected first so we can attach them to their parent items).
+        var accessoriesByItemId = new Dictionary<long, List<OrderItemDto>>();
+        await using (var cmd = CreateProc(conn, AccessoriesProcName, summary.Id))
+        await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var itemId = ReadLongFromMaybeString(reader, "ItemId");
+                var qty    = ReadDecimal(reader, "Quantity");
+                var price  = ReadDecimal(reader, "Price");
+                var amount = ReadDecimal(reader, "Amount");
+                var title  = ReadString(reader, "Title", string.Empty);
+
+                var accessoryRow = new OrderItemDto(
+                    Num:         string.Empty,
+                    Name:        title,
+                    Side:        string.Empty,
+                    Color:       string.Empty,
+                    Width:       null,
+                    Height:      null,
+                    Notes:       string.Empty,
+                    Qty:         qty,
+                    Price:       price,
+                    Amount:      amount,
+                    IsAccessory: true);
+
+                if (!accessoriesByItemId.TryGetValue(itemId, out var bucket))
+                {
+                    bucket = new List<OrderItemDto>();
+                    accessoriesByItemId[itemId] = bucket;
+                }
+                bucket.Add(accessoryRow);
+            }
+        }
+
+        // Phase 4: items — each becomes one OrderItemGroupDto seeded with its parent line plus accessories.
+        var itemGroups = new List<OrderItemGroupDto>();
+        await using (var cmd = CreateProc(conn, ItemsProcName, summary.Id))
+        await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var displayOrder = 1;
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var itemId = ReadLongFromMaybeString(reader, "Id");
+                var name   = ReadString(reader, "Title",  string.Empty);
+                var side   = ReadString(reader, "Side",   string.Empty);
+                var color  = ReadString(reader, "Color",  string.Empty);
+                var notes  = ReadString(reader, "Notes",  string.Empty);
+                var width  = ReadDecimal(reader, "Width");
+                var height = ReadDecimal(reader, "Height");
+                var qty    = ReadDecimal(reader, "Quantity");
+                var price  = ReadDecimal(reader, "Price");
+                var amount = ReadDecimal(reader, "Amount");
+
+                var num = displayOrder.ToString(CultureInfo.InvariantCulture);
+
+                var parent = new OrderItemDto(
+                    Num:         num,
+                    Name:        name,
+                    Side:        side,
+                    Color:       color,
+                    Width:       width == 0m ? null : width,
+                    Height:      height == 0m ? null : height,
+                    Notes:       notes,
+                    Qty:         qty,
+                    Price:       price,
+                    Amount:      amount,
+                    IsAccessory: false);
+
+                var lines = new List<OrderItemDto>(capacity: 1) { parent };
+                if (accessoriesByItemId.TryGetValue(itemId, out var accessoryRows))
+                {
+                    lines.AddRange(accessoryRows);
+                }
+
+                itemGroups.Add(new OrderItemGroupDto(
+                    Label: $"{num}. {name}",
+                    Lines: lines));
+
+                displayOrder++;
+            }
+        }
+
+        // Phase 5: employees.
+        var employees = new List<OrderEmployeeDto>();
+        await using (var cmd = CreateProc(conn, EmployeesProcName, summary.Id))
+        await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
+        {
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                var fullName = ReadString(reader, "EmployeeFullName", string.Empty);
+                var dutyText = ReadString(reader, "Duty",             string.Empty);
+
+                employees.Add(new OrderEmployeeDto(
+                    Name:             fullName,
+                    Initials:         BuildInitials(fullName),
+                    DutyCode:         BuildDutyCode(dutyText),
+                    DutyLabel:        dutyText,
+                    ServiceDate:      ParseLegacyDate(ReadString(reader, "ServiceDate",    string.Empty)),
+                    AcquaintanceDate: ParseLegacyDate(ReadString(reader, "AquiranceDate",  string.Empty)),
+                    OrderQty:         ReadIntFromMaybeString(reader, "AquiredOrderQuanity"),
+                    ItemQty:          ReadIntFromMaybeString(reader, "AquiredBlindsQuanity"),
+                    Amount:           ReadDecimal(reader, "AquiredAmount")));
+            }
+        }
+
+        return new OrderDetailsDto(
+            Id:         summary.Id,
+            Number:     summary.Number,
+            Date:       summary.Date,
+            Price:      summary.Price,
+            Debt:       summary.Debt,
+            IsOverdue:  summary.IsOverdue,
+            Customer:   headerCustomer,
+            HasDebt:    summary.HasDebt,
+            IsVip:      summary.IsVip,
+            HasNote:    summary.HasNote,
+            Status:     headerStatus,
+            StatusCode: SalesOrderStatusMap.ToStatusCode(headerStatus),
+            Store:      summary.Store,
+            Address:    headerAddress,
+            Operator:   @operator,
+            ItemGroups: itemGroups,
+            Amounts:    amounts,
+            Employees:  employees);
+    }
+
+    /// <summary>
+    /// Reads <c>dbo.weblb_Orders</c> in full and projects each row to an
+    /// <see cref="OrderSummaryDto"/>. Column reads are by ordinal because the
+    /// legacy proc has no documented column-name contract — the indexes match
+    /// the legacy <c>OrdersController</c>'s <c>GetX(n)</c> calls one-for-one.
+    /// </summary>
+    private async Task<List<OrderSummaryDto>> ReadAllOrdersAsync(CancellationToken cancellationToken)
+    {
+        var rows = new List<OrderSummaryDto>(capacity: 256);
+
+        await using var conn = new SqlConnection(_options.ConnectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+        await using var cmd = new SqlCommand(OrdersProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        var fieldCount = reader.FieldCount;
+
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var id             = ReadInt64ByOrdinal(reader, ordinal: 0);
+            var number         = ReadStringByOrdinal(reader, ordinal: 1, fallback: string.Empty);
+            var date           = ReadDateOnlyByOrdinal(reader, ordinal: 2);
+            var price          = ReadDecimalByOrdinal(reader, ordinal: 3);
+            var debt           = ReadDecimalByOrdinal(reader, ordinal: 4);
+            var customer       = ReadStringByOrdinal(reader, ordinal: 5, fallback: string.Empty);
+            var status         = ReadStringByOrdinal(reader, ordinal: 6, fallback: string.Empty);
+            var store          = ReadStringByOrdinal(reader, ordinal: 7, fallback: string.Empty);
+            // ordinals 8 and 9 are unused by the legacy controller — possibly
+            // IsVip / HasNote / DueDate. To be confirmed with the DBA.
+            var address        = fieldCount > 10
+                ? ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty)
+                : string.Empty;
+            var productsSearch = fieldCount > 11
+                ? ReadStringOrNullByOrdinal(reader, ordinal: 11)
+                : null;
+
+            rows.Add(new OrderSummaryDto(
+                Id:             id,
+                Number:         number,
+                Date:           date,
+                Price:          price,
+                Debt:           debt,
+                IsOverdue:      false,
+                Customer:       customer,
+                HasDebt:        debt > 0m,
+                IsVip:          false,
+                HasNote:        false,
+                Status:         status,
+                StatusCode:     SalesOrderStatusMap.ToStatusCode(status),
+                Store:          store,
+                Address:        address,
+                ProductsSearch: productsSearch));
+        }
+
+        return rows;
+    }
+
+    /// <summary>
+    /// Applies the in-memory equivalent of the legacy WHERE / ORDER BY / TOP
+    /// clauses to the materialised order list. Mirrors the contract documented
+    /// on <see cref="OrdersQueryParams"/> and lets the WebUI render real paging
+    /// metadata (Total / Page / PageSize) without an extra count round-trip.
+    /// </summary>
+    private static PagedResult<OrderSummaryDto> ApplyFilterSortPage(
+        IReadOnlyList<OrderSummaryDto> all,
+        OrdersQueryParams query)
+    {
+        IEnumerable<OrderSummaryDto> filtered = all;
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            var needle = query.Search.Trim();
+            filtered = filtered.Where(o =>
+                o.Number.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
+                o.Customer.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
+                o.Address.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
+                (o.ProductsSearch is { Length: > 0 } &&
+                    o.ProductsSearch.Contains(needle, StringComparison.OrdinalIgnoreCase)));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.Status))
+        {
+            filtered = filtered.Where(o =>
+                string.Equals(o.Status, query.Status, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (!string.IsNullOrWhiteSpace(query.Store))
+        {
+            filtered = filtered.Where(o =>
+                string.Equals(o.Store, query.Store, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (query.HasDebt)
+        {
+            filtered = filtered.Where(o => o.HasDebt);
+        }
+
+        // S-2 ignores the Date preset on purpose — the legacy proc has no date
+        // range parameter and a real range arrives once a paged proc wrapper
+        // exists. Until then the WebUI keeps that selector disabled.
+
+        var sorted = filtered
+            .OrderByDescending(o => o.Date)
+            .ThenByDescending(o => o.Number, StringComparer.Ordinal)
+            .ToList();
+
+        var pageSize = query.PageSize <= 0 ? 100 : query.PageSize;
+        var page     = query.Page     <= 0 ? 1   : query.Page;
+
+        var paged = sorted
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToList();
+
+        return new PagedResult<OrderSummaryDto>(paged, sorted.Count, page, pageSize);
+    }
+
+    private SqlCommand CreateProc(SqlConnection conn, string procName, long orderId)
+    {
+        var cmd = new SqlCommand(procName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+        cmd.Parameters.Add(new SqlParameter(OrderIdParameter, SqlDbType.BigInt) { Value = orderId });
+        return cmd;
+    }
+
+    // ---------------------------------------------------------------------
+    // Defensive readers — every accessor below tolerates DBNull, missing
+    // columns and unexpected types so a single broken row never blanks the
+    // entire orders list.
+    // ---------------------------------------------------------------------
+
+    private static long ReadInt64ByOrdinal(SqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? 0L : Convert.ToInt64(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    private static string ReadStringByOrdinal(SqlDataReader reader, int ordinal, string fallback)
+        => reader.IsDBNull(ordinal) ? fallback : Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? fallback;
+
+    private static string? ReadStringOrNullByOrdinal(SqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? null : Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    private static decimal ReadDecimalByOrdinal(SqlDataReader reader, int ordinal)
+        => reader.IsDBNull(ordinal) ? 0m : Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+
+    private static DateOnly ReadDateOnlyByOrdinal(SqlDataReader reader, int ordinal)
+    {
+        if (reader.IsDBNull(ordinal)) return default;
+        var dt = Convert.ToDateTime(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+        return DateOnly.FromDateTime(dt);
+    }
+
+    private static string ReadString(SqlDataReader reader, string columnName, string fallback)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return fallback;
+        return Convert.ToString(reader.GetValue(ordinal), CultureInfo.InvariantCulture) ?? fallback;
+    }
+
+    private static decimal ReadDecimal(SqlDataReader reader, string columnName)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return 0m;
+        return Convert.ToDecimal(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+    }
+
+    private static DateTime? ReadDateTime(SqlDataReader reader, string columnName)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return null;
+        return Convert.ToDateTime(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+    }
+
+    private static long ReadLongFromMaybeString(SqlDataReader reader, string columnName)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return 0L;
+        var raw = reader.GetValue(ordinal);
+        if (raw is long l) return l;
+        if (raw is int i)  return i;
+        return long.TryParse(Convert.ToString(raw, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : 0L;
+    }
+
+    private static int ReadIntFromMaybeString(SqlDataReader reader, string columnName)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return 0;
+        var raw = reader.GetValue(ordinal);
+        if (raw is int i)   return i;
+        if (raw is long l)  return l > int.MaxValue ? int.MaxValue : l < int.MinValue ? int.MinValue : (int)l;
+        return int.TryParse(Convert.ToString(raw, CultureInfo.InvariantCulture), NumberStyles.Integer, CultureInfo.InvariantCulture, out var parsed)
+            ? parsed
+            : 0;
+    }
+
+    private static int TryGetOrdinal(SqlDataReader reader, string columnName)
+    {
+        try { return reader.GetOrdinal(columnName); }
+        catch (IndexOutOfRangeException) { return -1; }
+    }
+
+    private static string BuildInitials(string fullName)
+    {
+        if (string.IsNullOrWhiteSpace(fullName)) return string.Empty;
+        var parts = fullName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return string.Empty;
+        if (parts.Length == 1) return parts[0][..1].ToUpperInvariant();
+        return string.Concat(parts[0][..1], parts[^1][..1]).ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Reduces the Lithuanian duty title to a stable lowercase code the WebUI
+    /// uses to pick the <c>duty--*</c> dot color (<c>sales</c>, <c>prod</c>,
+    /// <c>inst</c>). Conservative: first non-empty word lowercased, then mapped
+    /// onto the three known buckets — anything else falls through as-is and
+    /// renders as a neutral dot.
+    /// </summary>
+    private static string BuildDutyCode(string dutyLabel)
+    {
+        if (string.IsNullOrWhiteSpace(dutyLabel)) return string.Empty;
+        var lower = dutyLabel.Trim().ToLowerInvariant();
+
+        if (lower.Contains("pardav") || lower.Contains("sales"))                 return "sales";
+        if (lower.Contains("gamyb")  || lower.Contains("prod"))                  return "prod";
+        if (lower.Contains("monta")  || lower.Contains("install") || lower.Contains("inst")) return "inst";
+
+        var firstWord = lower.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        return firstWord ?? string.Empty;
+    }
+
+    private static DateOnly? ParseLegacyDate(string? text)
+    {
+        if (string.IsNullOrWhiteSpace(text)) return null;
+
+        if (DateOnly.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var d)) return d;
+        if (DateTime.TryParse(text, CultureInfo.InvariantCulture, DateTimeStyles.None, out var dt)) return DateOnly.FromDateTime(dt);
+        return null;
+    }
+}

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/App.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/App.razor
@@ -2,7 +2,6 @@
     <Router AppAssembly="@typeof(App).Assembly">
         <Found Context="routeData">
             <RouteView RouteData="@routeData" DefaultLayout="@typeof(MainLayout)" />
-            <FocusOnNavigate RouteData="@routeData" Selector="h1" />
         </Found>
         <NotFound>
             <PageTitle>Not found</PageTitle>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Dockerfile
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Dockerfile
@@ -9,6 +9,7 @@ COPY global.json .
 
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/LKvitai.MES.BuildingBlocks.ModuleStartup.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/LKvitai.MES.BuildingBlocks.PortalAuth.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/LKvitai.MES.BuildingBlocks.WebUI.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/
 COPY src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/LKvitai.MES.Modules.Sales.Contracts.csproj Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/
 COPY src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/LKvitai.MES.Modules.Sales.WebUI.csproj Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/
 
@@ -16,6 +17,7 @@ RUN dotnet restore Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/LKvitai.MES.Mod
 
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/ BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/ BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/ BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/
 COPY src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/ Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/
 COPY src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/ Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/
 

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/LKvitai.MES.Modules.Sales.WebUI.csproj
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/LKvitai.MES.Modules.Sales.WebUI.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.ModuleStartup\LKvitai.MES.BuildingBlocks.ModuleStartup.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.PortalAuth\LKvitai.MES.BuildingBlocks.PortalAuth.csproj" />
+    <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.WebUI\LKvitai.MES.BuildingBlocks.WebUI.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Sales.Contracts\LKvitai.MES.Modules.Sales.Contracts.csproj" />
   </ItemGroup>
 </Project>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -221,7 +221,7 @@
     private string                _storeFilter  = "";
     private string                _dateFilter   = "30d";
     private bool                  _hasDebtFilter;
-    private int?                  _selectedId;
+    private long?                 _selectedId;
     private bool                  _loadFailed;
     private CancellationTokenSource? _searchCts;
 

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
@@ -13,6 +13,7 @@
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/tokens.css" rel="stylesheet" />
+    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" />
     <link href="css/orders.css" rel="stylesheet" />
     <link rel="icon" href="data:," />
     <title>LKvitai.MES · Sales</title>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
@@ -1,7 +1,5 @@
 @inherits LayoutComponentBase
-@inject AuthenticationStateProvider AuthStateProvider
 @inject IWebHostEnvironment Env
-@using System.Security.Claims
 
 <MudThemeProvider />
 <MudDialogProvider />
@@ -9,52 +7,13 @@
 
 @* Force a real Portal login on Test/Production. RedirectToLogin builds the
    correct return URL from the Sales PathBase so the user comes back here
-   after Portal sets the shared __pa_auth cookie. Local dev with
-   ASPNETCORE_ENVIRONMENT=Development still goes through Portal too — to
-   skip Portal entirely on a workstation, run Portal locally next to Sales. *@
+   after Portal sets the shared auth cookie. *@
 <AuthorizeView>
     <Authorized Context="auth">
-        <div class="app-shell">
-            <div class="test-strip">
-                <div class="test-strip__main">
-                    <span class="icon-warning" aria-hidden="true"></span>
-                    <strong>@(_envLabel) ENVIRONMENT</strong>
-                    <span class="test-strip__note">&middot; S-1 &middot; stub API</span>
-                </div>
-                <span class="mono test-strip__host">sales-webui &middot; @_envSlug</span>
-            </div>
-
-            <header class="topbar">
-                <div class="brand">
-                    <div class="brand__mark">LK</div>
-                    <div>
-                        <div class="brand__name">LKvitai<span>.MES</span></div>
-                        <div class="brand__tagline mono">Manufacturing &middot; Execution &middot; Standards</div>
-                    </div>
-                </div>
-                <div class="topbar__separator"></div>
-                <label class="portal-search">
-                    <span class="portal-search__icon" aria-hidden="true"></span>
-                    <input type="search" placeholder="Find orders, modules, customers..." />
-                </label>
-                <div class="topbar__spacer"></div>
-                <div class="env-badge" aria-label="Environment and version">
-                    <div><span class="mono">ENV</span><strong class="mono">@_envBadge</strong></div>
-                    <div><span class="mono">VER</span><strong class="mono">0.1.0</strong></div>
-                </div>
-                <div class="user-block">
-                    <div class="user-block__avatar">@GetInitials(auth.User)</div>
-                    <div>
-                        <div class="user-block__name">@GetDisplayName(auth.User)</div>
-                        <form action="auth/logout" method="post" class="logout-form">
-                            <button class="link-button" type="submit">Logout</button>
-                        </form>
-                    </div>
-                </div>
-            </header>
-
+        <PortalModuleShell EnvironmentName="@_environmentName"
+                           User="@auth.User">
             @Body
-        </div>
+        </PortalModuleShell>
     </Authorized>
     <NotAuthorized>
         <RedirectToLogin />
@@ -62,30 +21,11 @@
 </AuthorizeView>
 
 @code {
-    private string _envLabel = "DEVELOPMENT";
-    private string _envBadge = "DEV";
-    private string _envSlug  = "dev";
+    private string _environmentName = "Development";
 
     protected override void OnInitialized()
     {
         var name = Env.EnvironmentName ?? "Development";
-        _envLabel = name.ToUpperInvariant();
-        _envBadge = name.Length <= 4 ? name.ToUpperInvariant() : name[..4].ToUpperInvariant();
-        _envSlug  = name.ToLowerInvariant();
-    }
-
-    private static string GetDisplayName(ClaimsPrincipal user)
-        => user.FindFirstValue(ClaimTypes.Name)
-           ?? user.Identity?.Name
-           ?? "User";
-
-    private static string GetInitials(ClaimsPrincipal user)
-    {
-        var name = GetDisplayName(user);
-        var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        var raw = parts.Length >= 2
-            ? $"{parts[0][0]}{parts[1][0]}"
-            : parts.Length == 1 ? parts[0][0].ToString() : "U";
-        return raw.ToUpperInvariant();
+        _environmentName = name;
     }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/_Imports.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/_Imports.razor
@@ -8,6 +8,7 @@
 @using Microsoft.AspNetCore.Components.Authorization
 @using Microsoft.JSInterop
 @using MudBlazor
+@using LKvitai.MES.BuildingBlocks.WebUI.Components
 @using LKvitai.MES.Modules.Sales.Contracts.Common
 @using LKvitai.MES.Modules.Sales.Contracts.Orders
 @using LKvitai.MES.Modules.Sales.WebUI

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
@@ -10,43 +10,6 @@ a { color: inherit; }
 button, input, select { font: inherit; }
 .mono { font-family: var(--font-mono); font-feature-settings: "zero"; }
 
-/* ── App shell ─────────────────────────────────────────────── */
-.app-shell { max-width: 1440px; min-height: 100vh; margin: 0 auto; background: var(--n-50); box-shadow: 0 0 40px rgb(0 0 0 / 4%); overflow-x: hidden; display: flex; flex-direction: column; }
-
-/* ── Test strip ────────────────────────────────────────────── */
-.test-strip { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 28px; background: repeating-linear-gradient(-45deg, #ead19b, #ead19b 12px, #dfc07a 12px, #dfc07a 24px); color: var(--n-900); font-size: 12px; }
-.test-strip__main { display: flex; align-items: center; gap: 9px; min-width: 0; }
-.test-strip__note { opacity: .82; }
-.test-strip__host { font-size: 11px; white-space: nowrap; }
-.icon-warning { width: 14px; height: 14px; background: currentColor; clip-path: polygon(50% 5%, 96% 90%, 4% 90%); display: inline-block; }
-
-/* ── Topbar ────────────────────────────────────────────────── */
-.topbar { display: flex; align-items: center; gap: 24px; padding: 14px 28px; background: var(--dark); color: var(--n-0); border-bottom: 1px solid var(--dark-line); }
-.brand { display: flex; align-items: center; gap: 12px; min-width: 0; }
-.brand__mark { display: grid; place-items: center; width: 36px; height: 36px; flex: 0 0 auto; border: 1px solid var(--dark-line); border-radius: 6px; background: var(--dark-2); color: var(--accent-400); font-size: 13px; font-weight: 700; }
-.brand__name { color: var(--n-0); font-size: 15px; font-weight: 700; line-height: 1.1; }
-.brand__name span { color: #9ba4b0; font-weight: 400; }
-.brand__tagline { margin-top: 2px; color: #a5adb8; font-size: 10px; letter-spacing: 1.4px; text-transform: uppercase; white-space: nowrap; }
-.topbar__separator { width: 1px; height: 28px; background: var(--dark-line); }
-.topbar__spacer { flex: 1; }
-.portal-search { position: relative; flex: 1 1 360px; max-width: 460px; }
-.portal-search input { width: 100%; padding: 8px 10px 8px 34px; border: 1px solid var(--dark-line); border-radius: 4px; outline: none; background: #1b2028; color: var(--n-0); font-size: 13px; }
-.portal-search input::placeholder { color: #8f98a6; }
-.portal-search input:focus { border-color: var(--accent-400); }
-.portal-search__icon { position: absolute; left: 12px; top: 50%; width: 13px; height: 13px; border: 1.8px solid #8f98a6; border-radius: 50%; transform: translateY(-58%); pointer-events: none; }
-.portal-search__icon::after { content: ""; position: absolute; right: -5px; bottom: -4px; width: 6px; height: 1.8px; background: #8f98a6; transform: rotate(45deg); transform-origin: left center; }
-.env-badge { display: flex; border: 1px solid var(--dark-line); border-radius: 4px; overflow: hidden; background: #1b2028; }
-.env-badge div { display: flex; align-items: center; gap: 7px; padding: 6px 11px; }
-.env-badge div:first-child { border-right: 1px solid var(--dark-line); background: var(--dark-2); }
-.env-badge span { color: #9ba4b0; font-size: 10px; }
-.env-badge strong { color: var(--n-0); font-size: 11px; }
-.env-badge div:first-child strong { color: #dfc07a; }
-.user-block { display: flex; align-items: center; gap: 9px; padding-left: 14px; border-left: 1px solid var(--dark-line); }
-.user-block__avatar { display: grid; place-items: center; width: 30px; height: 30px; border-radius: 50%; background: var(--dark-line); color: var(--accent-400); font-size: 11px; font-weight: 700; font-family: var(--font-mono); }
-.user-block__name { color: var(--n-0); font-size: 12px; font-weight: 700; }
-.link-button { padding: 0; border: 0; background: transparent; color: #a5adb8; cursor: pointer; font-size: 12px; text-align: left; }
-.link-button:hover { color: var(--n-0); }
-
 /* ── Main ──────────────────────────────────────────────────── */
 .main { padding: 22px 28px 48px; flex: 1; display: flex; flex-direction: column; }
 
@@ -54,6 +17,7 @@ button, input, select { font: inherit; }
 .page-head { display: flex; align-items: flex-end; justify-content: space-between; gap: 18px; margin-bottom: 14px; }
 .eyebrow { margin: 0 0 6px; color: var(--accent-700); font-size: 10px; font-weight: 700; letter-spacing: 1.4px; text-transform: uppercase; }
 h1 { margin: 0; color: var(--n-900); font-size: 26px; line-height: 1.12; }
+h1:focus { outline: none; }
 .page-head p { max-width: 740px; margin: 7px 0 0; color: var(--n-500); font-size: 13px; }
 .page-actions { display: flex; gap: 8px; align-items: center; }
 
@@ -217,9 +181,6 @@ h1 { margin: 0; color: var(--n-900); font-size: 26px; line-height: 1.12; }
 
 /* ── Responsive ──────────────────────────────────────────────── */
 @media (max-width: 980px) {
-  .topbar { flex-wrap: wrap; gap: 12px; }
-  .topbar__separator, .env-badge { display: none; }
-  .portal-search { order: 3; flex-basis: 100%; max-width: none; }
   .page-head { display: block; }
   .page-actions { margin-top: 12px; }
   .toolbar { flex-wrap: wrap; }
@@ -230,9 +191,7 @@ h1 { margin: 0; color: var(--n-900); font-size: 26px; line-height: 1.12; }
 }
 
 @media (max-width: 760px) {
-  .test-strip { display: none; }
   .main { padding: 16px 12px 32px; }
-  .brand__tagline { display: none; }
   .table-wrap.is-mobile-hidden { display: none; }
   .mobile-cards { display: grid; }
   .table-foot { align-items: flex-start; flex-direction: column; }


### PR DESCRIPTION
## Summary

Two-commit feature branch covering the Sales WebUI shell extraction (already merged-style, was on this branch before) and S-2: the real SQL Server gateway for the legacy `weblb_*` procs.

- **`bce73a8` — Extract shared portal shell for Sales.** Lifts the dark Portal topbar / brand block / env badge / user block into `LKvitai.MES.BuildingBlocks.WebUI` (`PortalModuleShell.razor` + `portal-shell.css`) so Sales (and future modules) reuse the same chrome instead of forking it. No visual redesign — same approved tokens from `docs/ux/lkvitai-mes-ux-handoff.html`.
- **`87de919` — S-2 Sales: real SQL adapter over legacy `weblb_*` procs, no stub fallback.** Replaces `StubOrdersQueryService` with `SqlOrdersQueryService` over the legacy `LKvitaiDb` SQL Server. Defensive `DBNull` / type / missing-column guards. Lithuanian status labels mapped to `OrderStatusCodes` via `SalesOrderStatusMap`. Fail-fast composition (`SalesOrdersDataSource`) — Sales.Api refuses to start without `ConnectionStrings:LKvitaiDb` in any environment; in-memory stub remains in tree but only as an explicit `Sales:OrdersDataSource=Stub` opt-in with a loud startup warning. Test deploy now requires the new `LKVITAI_MSACCESS_DB_CONNECTION` GitHub secret and pipes it into `docker-compose.test.yml`'s `sales-api`. Drive-by: widened `OrderSummaryDto.Id` / `OrderDetailsDto.Id` from `int` to `long` (legacy column is BIGINT — the Int32 saturation was collapsing every row to `Int32.MaxValue` and breaking row selection in the WebUI).

API / UI contract is unchanged: `GET /api/sales/orders` and `GET /api/sales/orders/{number}` keep the same shape, `/sales/` stays list-only, order numbers still open `/sales/orders/{number}` in a new tab.

## Test plan

- [x] `dotnet build src/LKvitai.MES.sln -c Release --no-restore` — 0 errors.
- [x] `dotnet test tests/ArchitectureTests/LKvitai.MES.ArchitectureTests/...` — 22/22 pass.
- [x] `dotnet run --project tools/DependencyValidator/...` — 36 projects scanned, 0 violations.
- [x] Local SQL smoke test against the legacy DB:
  - [x] `GET /api/sales/orders?pageSize=3` returns real legacy orders (`VL-2682-26 / VL-2681-26 / VL-2678-26`, real BIGINT IDs, real customers / amounts), **not** the seven hardcoded `KVT-*` sample rows.
  - [x] `GET /api/sales/orders/VJ-4109-26` returns full payload: real operator (`TERMINAL\l.badokaite`), 6-card amounts grid, 1 employee (`Trusevic Joana`), 1 item group with parent line.
  - [x] `GET /api/sales/orders?search=VJ-4109` → `total: 1` (server-side search across number / customer / address / `ProductsSearch`).
  - [x] Fail-fast verified: with env vars cleared, Sales.Api dies at composition with `InvalidOperationException` ("Sales orders SQL adapter requires ConnectionStrings:LKvitaiDb to be set ...").
- [ ] Test deploy run on `mes-test.lauresta.com` to confirm the new `LKVITAI_MSACCESS_DB_CONNECTION` secret is set in the `test` GitHub Environment and `lkvitai-mes-sales-api` comes up healthy talking to the legacy DB.
- [ ] Manual UI walk: open `/sales/`, search by order number, click an order to open `/sales/orders/{number}` in a new tab, confirm Items / Amounts / Employees populate from real data.

## Notes for reviewer

- `appsettings.Development.json` keeps `ConnectionStrings:LKvitaiDb` as an empty placeholder with a `_Comment_LKvitaiDb` reminder. Real local value must come from env var (`ConnectionStrings__LKvitaiDb`) or `dotnet user-secrets`. **No real secret is in the diff.**
- Production compose / workflow do not yet have a Sales container — prod wiring is intentionally out of scope here and should be added when Sales is promoted to prod.
- New TODOs surfaced by real data (non-blocking, logged inline in `SqlOrdersQueryService` and the S-2 commit message): paged proc wrapper for `weblb_Orders`, `SKIRTINGAI` status mapping, `Vadybininkas` duty code, `address: "---"` placeholder rendering, and a future `Tests.Sales.Integration` project against a Testcontainers SQL Server.
