### PR TITLE
fix(portal-shell): rename Body to ChildContent so /sales/ stops 500ing on Test

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
@@ -41,11 +41,11 @@
         </div>
     </header>
 
-    @Body
+    @ChildContent
 </div>
 
 @code {
-    [Parameter] public RenderFragment? Body { get; set; }
+    [Parameter] public RenderFragment? ChildContent { get; set; }
     [Parameter] public ClaimsPrincipal? User { get; set; }
     [Parameter] public string EnvironmentName { get; set; } = "Development";
     [Parameter] public string? HostLabel { get; set; }


### PR DESCRIPTION
## What

Rename [Parameter] RenderFragment? Body → [Parameter] RenderFragment? ChildContent on LKvitai.MES.BuildingBlocks.WebUI.Components.PortalModuleShell, and render @ChildContent instead of @Body.

## Why

After PR #73 was deployed to Test, `https://mes-test.lauresta.com/sales/` returned HTTP 500 on every request. Live container logs (lkvitai-mes-sales-webui) showed:

``
System.InvalidOperationException: Object of type
'LKvitai.MES.BuildingBlocks.WebUI.Components.PortalModuleShell'
does not have a property matching the name 'ChildContent'.
   ...
   at LKvitai.MES.Modules.Sales.WebUI.Pages.Pages__Host.ExecuteAsync()
   in /src/Modules/Sales/.../Pages/_Host.cshtml:line 6
``

Sales.WebUI/Shared/MainLayout.razor uses the shell as
``azor
<PortalModuleShell EnvironmentName=... User=...>
    @Body
</PortalModuleShell>
``
Razor binds tag-body content to a parameter literally named ChildContent. The shell exposed Body instead, so prerender threw at runtime. Razor doesn't validate this at compile time, which is why both Sales CI and the test deploy went green while every real page request failed.

## Scope

* No call site passes Body= explicitly anywhere in the repo (verified via grep).
* No other module uses PortalModuleShell yet.
* /health keeps returning 200 (which is why deploy stayed healthy through the outage).

## Verification

* dotnet build src/LKvitai.MES.sln -c Release — succeeds, 0 errors.
* After merge + deploy: GET /sales/ should render, follow-up health/asset requests already work.

Made with [Cursor](https://cursor.com)