### PR TITLE
fix(sales-api): allow legacy SQL Server TLS handshake from container

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Dockerfile
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Dockerfile
@@ -40,6 +40,18 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Legacy LKvitaiDb (SQL Server 2008/2012) compatibility:
+# the .NET 8 base image (Debian 12) ships OpenSSL 3 with SECLEVEL=2 and
+# MinProtocol=TLSv1.2. The legacy SQL Server only offers TLS 1.0 with
+# SHA1-signed self-signed certs during the TDS pre-login handshake (which
+# is mandatory regardless of Encrypt=False), so the connection dies with
+# "SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed" before
+# any SQL is sent. Lower SECLEVEL and MinProtocol so the handshake can
+# complete; the actual data exchange is still unencrypted because the
+# connection string sets Encrypt=False;TrustServerCertificate=True.
+RUN sed -i 's|^\[openssl_init\]|[openssl_init]\nssl_conf = ssl_sect|' /etc/ssl/openssl.cnf \
+    && printf '\n[ssl_sect]\nsystem_default = system_default_sect\n\n[system_default_sect]\nMinProtocol = TLSv1\nCipherString = DEFAULT:@SECLEVEL=0\n' >> /etc/ssl/openssl.cnf
+
 # Standard .NET 8 non-root app user (uid 1654). Same pattern as Warehouse + Portal.
 COPY --from=build /app/publish .
 USER app


### PR DESCRIPTION
## What

In the Sales.Api Dockerfile (runtime stage), relax OpenSSL 3 defaults so that the TDS pre-login TLS handshake to legacy SQL Server can complete:

* MinProtocol = TLSv1 (Debian 12 default is TLSv1.2)
* CipherString = DEFAULT:@SECLEVEL=0 (default is SECLEVEL=2)

Implemented by sed-injecting ssl_conf = ssl_sect into [openssl_init] of /etc/ssl/openssl.cnf and appending the two new sections.

## Why

After PR #75 fixed the Blazor ChildContent issue, `https://mes-test.lauresta.com/sales/` rendered but every order list call returned 500 with:

``
Microsoft.Data.SqlClient.SqlException: A connection was successfully established
with the server, but then an error occurred during the pre-login handshake.
(provider: SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed)
 ---> System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
   at System.Net.Security.SslStream.ReceiveHandshakeFrameAsync...
   at Microsoft.Data.SqlClient.SNI.SNITCPHandle.EnableSsl
``

The legacy LKvitaiDb is SQL Server 2008/2012-era and only offers TLS 1.0 with SHA1-signed self-signed certs. Microsoft.Data.SqlClient does a TLS handshake during pre-login regardless of Encrypt=False, which Debian 12's OpenSSL 3 refuses to negotiate by default. The connection dies before any SQL is sent, so the WebUI just sees /api/sales/orders time out and shows `Sales API unreachable. Try again or reload the page.`

The connection string still has Encrypt=False;TrustServerCertificate=True, so post-handshake the bulk traffic is unencrypted. This change only allows the pre-login handshake to complete.

## Scope

* Only `Sales.Api` Dockerfile is touched. Warehouse/Portal/Frontline/Scanning don't talk to the legacy SQL Server.
* No application code changed.
* dotnet build src/LKvitai.MES.sln -c Release is unaffected (this is a runtime image change).

## Verification plan

1. Sales CI green (Docker build must still succeed; sed/printf snippet validated against mcr.microsoft.com/dotnet/aspnet:8.0 recipe pattern).
2. After deploy:  open `https://mes-test.lauresta.com/sales/`, expect orders to populate and /api/sales/orders to return 200.
3. Optional: re-run `Debug Test Logs` workflow with `service=sales` to confirm no more SqlException entries.

Made with [Cursor](https://cursor.com)