### PR TITLE
polish(sales-orders): kill flicker, add loading bar, fix Status/Store filters

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Endpoints/OrdersEndpoints.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Endpoints/OrdersEndpoints.cs
@@ -28,6 +28,13 @@ public static class OrdersEndpoints
             .Produces<OrderDetailsDto>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
 
+        // Filter options for the toolbar Status / Store dropdowns. The WebUI
+        // uses these instead of hardcoded city/status names so every option
+        // shown actually filters at least one row in the current data.
+        group.MapGet("/orders/filters", GetOrdersFilterOptionsAsync)
+            .WithName("GetSalesOrdersFilterOptions")
+            .Produces<OrdersFilterOptionsDto>(StatusCodes.Status200OK);
+
         return group;
     }
 
@@ -48,6 +55,14 @@ public static class OrdersEndpoints
     {
         var details = await orders.GetOrderDetailsAsync(number, cancellationToken).ConfigureAwait(false);
         return details is null ? Results.NotFound() : Results.Ok(details);
+    }
+
+    private static async Task<IResult> GetOrdersFilterOptionsAsync(
+        IOrdersQueryService orders,
+        CancellationToken cancellationToken)
+    {
+        var options = await orders.GetFilterOptionsAsync(cancellationToken).ConfigureAwait(false);
+        return Results.Ok(options);
     }
 
     /// <summary>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Application/Ports/IOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Application/Ports/IOrdersQueryService.cs
@@ -27,4 +27,13 @@ public interface IOrdersQueryService
     Task<OrderDetailsDto?> GetOrderDetailsAsync(
         string number,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Returns distinct values currently present in the data for the toolbar
+    /// Status and Store dropdowns. The WebUI uses these to populate the
+    /// dropdowns dynamically instead of hardcoding labels — guarantees that
+    /// every option, when picked, actually filters at least one row.
+    /// </summary>
+    Task<OrdersFilterOptionsDto> GetFilterOptionsAsync(
+        CancellationToken cancellationToken);
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrdersFilterOptionsDto.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrdersFilterOptionsDto.cs
@@ -1,0 +1,17 @@
+namespace LKvitai.MES.Modules.Sales.Contracts.Orders;
+
+/// <summary>
+/// Distinct values for the Status and Store toolbar filters, populated from the
+/// current orders data. Returned by <c>GET /api/sales/orders/filters</c> so the
+/// WebUI doesn't hardcode lists that drift away from the real data — fixes the
+/// S-2 bug where hardcoded city names like <c>"Vilnius"</c> never matched real
+/// store labels like <c>"Vilnius - mazmena"</c>, and any new status added in
+/// the legacy DB silently became unfilterable.
+/// </summary>
+/// <param name="Statuses">Distinct, non-empty, case-sensitive status labels as
+/// they appear in the underlying data, sorted alphabetically.</param>
+/// <param name="Stores">Distinct, non-empty store labels as they appear in the
+/// underlying data, sorted alphabetically.</param>
+public sealed record OrdersFilterOptionsDto(
+    IReadOnlyList<string> Statuses,
+    IReadOnlyList<string> Stores);

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -85,6 +85,33 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         return ApplyFilterSortPage(all, query);
     }
 
+    public async Task<OrdersFilterOptionsDto> GetFilterOptionsAsync(CancellationToken cancellationToken)
+    {
+        // Same full-table read as GetOrdersAsync (weblb_Orders has no parameters).
+        // We project the two label sets the WebUI toolbar needs; the data is
+        // small enough that an ad-hoc DISTINCT in C# is cheaper than another
+        // round trip. When the paged proc wrapper lands (TODO above), expose
+        // dedicated dbo.weblb_StatusList / dbo.weblb_StoreList and wire them
+        // here instead.
+        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
+
+        var statuses = all
+            .Select(o => o.Status)
+            .Where(static s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static s => s, StringComparer.CurrentCulture)
+            .ToList();
+
+        var stores = all
+            .Select(o => o.Store)
+            .Where(static s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static s => s, StringComparer.CurrentCulture)
+            .ToList();
+
+        return new OrdersFilterOptionsDto(statuses, stores);
+    }
+
     public async Task<OrderDetailsDto?> GetOrderDetailsAsync(
         string number,
         CancellationToken cancellationToken)
@@ -354,16 +381,21 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                     o.ProductsSearch.Contains(needle, StringComparison.OrdinalIgnoreCase)));
         }
 
+        // Trim both sides — legacy nchar/char columns are right-padded with
+        // spaces, which would otherwise make an exact-equality dropdown filter
+        // silently return zero rows.
         if (!string.IsNullOrWhiteSpace(query.Status))
         {
+            var status = query.Status.Trim();
             filtered = filtered.Where(o =>
-                string.Equals(o.Status, query.Status, StringComparison.OrdinalIgnoreCase));
+                string.Equals(o.Status?.Trim(), status, StringComparison.OrdinalIgnoreCase));
         }
 
         if (!string.IsNullOrWhiteSpace(query.Store))
         {
+            var store = query.Store.Trim();
             filtered = filtered.Where(o =>
-                string.Equals(o.Store, query.Store, StringComparison.OrdinalIgnoreCase));
+                string.Equals(o.Store?.Trim(), store, StringComparison.OrdinalIgnoreCase));
         }
 
         if (query.HasDebt)

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Stub/StubOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Stub/StubOrdersQueryService.cs
@@ -42,14 +42,16 @@ public sealed class StubOrdersQueryService : IOrdersQueryService
 
         if (!string.IsNullOrWhiteSpace(query.Status))
         {
+            var status = query.Status.Trim();
             filtered = filtered.Where(o =>
-                string.Equals(o.Status, query.Status, StringComparison.Ordinal));
+                string.Equals(o.Status?.Trim(), status, StringComparison.OrdinalIgnoreCase));
         }
 
         if (!string.IsNullOrWhiteSpace(query.Store))
         {
+            var store = query.Store.Trim();
             filtered = filtered.Where(o =>
-                string.Equals(o.Store, query.Store, StringComparison.Ordinal));
+                string.Equals(o.Store?.Trim(), store, StringComparison.OrdinalIgnoreCase));
         }
 
         if (query.HasDebt)
@@ -111,6 +113,25 @@ public sealed class StubOrdersQueryService : IOrdersQueryService
             Employees:  SampleEmployees);
 
         return Task.FromResult<OrderDetailsDto?>(details);
+    }
+
+    public Task<OrdersFilterOptionsDto> GetFilterOptionsAsync(CancellationToken cancellationToken)
+    {
+        var statuses = Orders
+            .Select(o => o.Status)
+            .Where(static s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static s => s, StringComparer.CurrentCulture)
+            .ToList();
+
+        var stores = Orders
+            .Select(o => o.Store)
+            .Where(static s => !string.IsNullOrWhiteSpace(s))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(static s => s, StringComparer.CurrentCulture)
+            .ToList();
+
+        return Task.FromResult(new OrdersFilterOptionsDto(statuses, stores));
     }
 
     private static IReadOnlyList<OrderSummaryDto> BuildOrders()

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -1,5 +1,6 @@
 @page "/"
 @inject SalesApiClient Api
+@inject PersistentComponentState ApplicationState
 @implements IAsyncDisposable
 
 <PageTitle>Sales · Orders</PageTitle>
@@ -20,7 +21,9 @@
     </div>
 
     @* ── Orders list panel ─────────────────────────────────────── *@
-    <section class="panel orders-list" aria-labelledby="orders-list-title">
+    <section class="panel orders-list @(_isRefreshing ? "is-refreshing" : "")"
+             aria-labelledby="orders-list-title"
+             aria-busy="@(_isRefreshing ? "true" : "false")">
         <div class="panel__head">
             <div>
                 <h2 id="orders-list-title">Recent, unpaid and unfinished orders</h2>
@@ -62,6 +65,12 @@
             @RenderPagination("Pagination top")
         </div>
 
+        @* Top-of-grid loading affordance — non-blocking 2px teal bar visible
+           only while a refresh is in flight. The toolbar above it stays fully
+           interactive (search, filters, debt toggle); only pagination buttons
+           are disabled to prevent click-spam. *@
+        <div class="list-loading-bar @(_isRefreshing ? "is-active" : "")" aria-hidden="true"></div>
+
         @if (_loadFailed)
         {
             <div class="panel__head" role="alert" style="border-top:1px solid var(--n-150);background:var(--danger-bg);color:var(--danger-fg)">
@@ -90,8 +99,11 @@
                         <th>Address</th>
                     </tr>
                 </thead>
-                <tbody>
-                    @if (_orders.Count == 0 && !_loadFailed)
+                <tbody class="orders-list__body">
+                    @* Empty-state copy only after at least one fetch has come back —
+                       prevents the "No orders match" message flashing before any
+                       data has loaded (e.g. during the very first prerender). *@
+                    @if (_orders.Count == 0 && _hasEverLoaded && !_loadFailed)
                     {
                         <tr>
                             <td colspan="10" style="text-align:center;color:var(--n-500);padding:24px 12px">
@@ -133,8 +145,8 @@
         </div>
 
         @* Mobile cards *@
-        <div class="mobile-cards" aria-label="Mobile orders">
-            @if (_orders.Count == 0 && !_loadFailed)
+        <div class="mobile-cards orders-list__cards" aria-label="Mobile orders">
+            @if (_orders.Count == 0 && _hasEverLoaded && !_loadFailed)
             {
                 <article class="mobile-card">
                     <div class="mobile-card__cust" style="color:var(--n-500)">No orders match these filters.</div>
@@ -180,31 +192,25 @@
 </main>
 
 @code {
-    private const int PageSize = 100;
+    private const int    PageSize          = 100;
+    private const int    SearchDebounceMs  = 250;
+    private const string PersistKeyOrders  = "sales.orders.list";
+    private const string PersistKeyFilters = "sales.orders.filterOptions";
 
-    private static readonly IReadOnlyList<SelectOption> StatusOptions =
-    [
-        new("",             "All statuses"),
-        new("Įvestas",      "Įvestas"),
-        new("Patvirtintas", "Patvirtintas"),
-        new("Gaminamas",    "Gaminamas"),
-        new("Pagamintas",   "Pagamintas"),
-        new("Filialui",     "Filialui"),
-        new("Atiduotas",    "Atiduotas"),
-        new("Sustabdytas",  "Sustabdytas"),
-    ];
+    /// <summary>Snapshot of the orders page persisted across the prerender →
+    /// interactive boundary so OnInitializedAsync skips a second HTTP call and
+    /// the page does not flash empty during hydration.</summary>
+    private sealed record PersistedListState(
+        IReadOnlyList<OrderSummaryDto> Items,
+        int Total,
+        int Page,
+        string Search,
+        string Status,
+        string Store,
+        bool HasDebt);
 
-    private static readonly IReadOnlyList<SelectOption> StoreOptions =
-    [
-        new("",          "All stores"),
-        new("Vilnius",   "Vilnius"),
-        new("Kaunas",    "Kaunas"),
-        new("Klaipėda",  "Klaipėda"),
-        new("Šiauliai",  "Šiauliai"),
-        new("Panevėžys", "Panevėžys"),
-    ];
-
-    // Disabled in S-1 — kept so the visual control stays aligned with the toolbar grid.
+    /// <summary>Always-shown date preset list (Date filter is intentionally
+    /// disabled in S-1; kept so the toolbar grid stays aligned).</summary>
     private static readonly IReadOnlyList<SelectOption> DateOptions =
     [
         new("30d",   "Last 30 days"),
@@ -212,44 +218,155 @@
         new("ytd",   "YTD"),
     ];
 
-    private List<OrderSummaryDto> _orders       = new();
+    /// <summary>Fallback while the live filter options request is in flight or
+    /// failed — at minimum the user still sees an "All" option so the dropdown
+    /// is never empty.</summary>
+    private static readonly IReadOnlyList<SelectOption> EmptyStatusOptions =
+    [
+        new("", "All statuses"),
+    ];
+
+    private static readonly IReadOnlyList<SelectOption> EmptyStoreOptions =
+    [
+        new("", "All stores"),
+    ];
+
+    private List<OrderSummaryDto> _orders        = new();
     private int                   _total;
-    private int                   _page         = 1;
-    private readonly int          _pageSize     = PageSize;
-    private string                _search       = "";
-    private string                _statusFilter = "";
-    private string                _storeFilter  = "";
-    private string                _dateFilter   = "30d";
+    private int                   _page          = 1;
+    private readonly int          _pageSize      = PageSize;
+    private string                _search        = "";
+    private string                _statusFilter  = "";
+    private string                _storeFilter   = "";
+    private string                _dateFilter    = "30d";
     private bool                  _hasDebtFilter;
     private long?                 _selectedId;
     private bool                  _loadFailed;
-    private CancellationTokenSource? _searchCts;
+    private bool                  _isRefreshing;
+    private bool                  _hasEverLoaded;
+
+    private IReadOnlyList<SelectOption> _statusOptions = EmptyStatusOptions;
+    private IReadOnlyList<SelectOption> _storeOptions  = EmptyStoreOptions;
+
+    // Cancels the previous in-flight ReloadAsync so a fast click on Next/Next/Next
+    // doesn't end up showing a stale page after the latest one has already arrived.
+    private CancellationTokenSource? _reloadCts;
+
+    // Debounces keystrokes in the search box so we don't fire a request per character.
+    private CancellationTokenSource? _searchDebounceCts;
+
+    // Monotonic id used as a second guard: the response of an old request is
+    // ignored even if its CancellationToken hadn't yet fired by the time it
+    // returned. Together with _reloadCts this gives us strict last-write-wins.
+    private int _latestReloadId;
+
+    // PersistentComponentState subscription — disposed in DisposeAsync.
+    private PersistingComponentStateSubscription _persistingSub;
 
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_total / (double)_pageSize));
     private int _from       => _total == 0 ? 0 : ((_page - 1) * _pageSize) + 1;
     private int _to         => Math.Min(_page * _pageSize, _total);
 
+    private IReadOnlyList<SelectOption> StatusOptions => _statusOptions;
+    private IReadOnlyList<SelectOption> StoreOptions  => _storeOptions;
+
+    protected override void OnInitialized()
+    {
+        // Subscribe BEFORE we touch state so the prerender side has a callback
+        // registered when the framework asks for state to persist into the page.
+        _persistingSub = ApplicationState.RegisterOnPersisting(PersistDataAsync);
+    }
+
     protected override async Task OnInitializedAsync()
     {
-        await ReloadAsync();
+        // 1) Try to rehydrate the orders snapshot persisted by the prerender
+        //    side. When present, we skip the HTTP call entirely so the user
+        //    sees the same data the prerendered HTML showed — no flicker.
+        if (ApplicationState.TryTakeFromJson<PersistedListState>(PersistKeyOrders, out var persisted) && persisted is not null)
+        {
+            _orders        = persisted.Items.ToList();
+            _total         = persisted.Total;
+            _page          = persisted.Page;
+            _search        = persisted.Search;
+            _statusFilter  = persisted.Status;
+            _storeFilter   = persisted.Store;
+            _hasDebtFilter = persisted.HasDebt;
+            _hasEverLoaded = true;
+        }
+
+        // 2) Same for the filter options: persisted dropdowns avoid a second
+        //    request and an empty-then-populated visual flicker on the toolbar.
+        if (ApplicationState.TryTakeFromJson<OrdersFilterOptionsDto>(PersistKeyFilters, out var persistedFilters) && persistedFilters is not null)
+        {
+            ApplyFilterOptions(persistedFilters);
+        }
+
+        // Both fetches happen during prerender so their results are persisted
+        // for the interactive phase. Run in parallel — no dependency between them.
+        await Task.WhenAll(
+            _hasEverLoaded   ? Task.CompletedTask : ReloadAsync(),
+            _statusOptions.Count > 1 ? Task.CompletedTask : LoadFilterOptionsAsync());
+    }
+
+    private Task PersistDataAsync()
+    {
+        ApplicationState.PersistAsJson(PersistKeyOrders, new PersistedListState(
+            _orders,
+            _total,
+            _page,
+            _search,
+            _statusFilter,
+            _storeFilter,
+            _hasDebtFilter));
+
+        ApplicationState.PersistAsJson(PersistKeyFilters, new OrdersFilterOptionsDto(
+            _statusOptions.Where(o => !string.IsNullOrEmpty(o.Value)).Select(o => o.Value).ToList(),
+            _storeOptions .Where(o => !string.IsNullOrEmpty(o.Value)).Select(o => o.Value).ToList()));
+
+        return Task.CompletedTask;
+    }
+
+    private async Task LoadFilterOptionsAsync()
+    {
+        var options = await Api.GetFilterOptionsAsync(CancellationToken.None);
+        if (options is null) return; // toolbar keeps the "All …" placeholder lists
+        ApplyFilterOptions(options);
+        StateHasChanged();
+    }
+
+    private void ApplyFilterOptions(OrdersFilterOptionsDto options)
+    {
+        var statuses = new List<SelectOption>(options.Statuses.Count + 1)
+        {
+            new("", "All statuses"),
+        };
+        foreach (var s in options.Statuses) statuses.Add(new SelectOption(s, s));
+        _statusOptions = statuses;
+
+        var stores = new List<SelectOption>(options.Stores.Count + 1)
+        {
+            new("", "All stores"),
+        };
+        foreach (var s in options.Stores) stores.Add(new SelectOption(s, s));
+        _storeOptions = stores;
     }
 
     private async Task OnSearch(ChangeEventArgs e)
     {
         _search = e.Value?.ToString() ?? "";
 
-        if (_searchCts is not null)
+        if (_searchDebounceCts is not null)
         {
-            await _searchCts.CancelAsync();
-            _searchCts.Dispose();
+            await _searchDebounceCts.CancelAsync();
+            _searchDebounceCts.Dispose();
         }
-        _searchCts = new CancellationTokenSource();
-        var token = _searchCts.Token;
+        _searchDebounceCts = new CancellationTokenSource();
+        var token = _searchDebounceCts.Token;
 
         try
         {
-            await Task.Delay(200, token);
-            _page = 1; // any filter change resets to page 1 to avoid landing on an empty page
+            await Task.Delay(SearchDebounceMs, token);
+            _page = 1; // any filter change resets to page 1
             await ReloadAsync();
         }
         catch (TaskCanceledException) { /* superseded by a newer keystroke */ }
@@ -257,11 +374,20 @@
 
     public async ValueTask DisposeAsync()
     {
-        if (_searchCts is not null)
+        _persistingSub.Dispose();
+
+        if (_searchDebounceCts is not null)
         {
-            await _searchCts.CancelAsync();
-            _searchCts.Dispose();
-            _searchCts = null;
+            await _searchDebounceCts.CancelAsync();
+            _searchDebounceCts.Dispose();
+            _searchDebounceCts = null;
+        }
+
+        if (_reloadCts is not null)
+        {
+            await _reloadCts.CancelAsync();
+            _reloadCts.Dispose();
+            _reloadCts = null;
         }
     }
 
@@ -322,7 +448,7 @@
 
     private RenderFragment RenderPagination(string ariaLabel) => @<text>
         <nav class="pagination" aria-label="@ariaLabel">
-            <button type="button" disabled="@(_page <= 1)" @onclick="GoPrev">&#8249; Prev</button>
+            <button type="button" disabled="@(_isRefreshing || _page <= 1)" @onclick="GoPrev">&#8249; Prev</button>
             @foreach (var p in PageButtons())
             {
                 if (p < 0)
@@ -334,28 +460,54 @@
                     var pageValue = p;
                     <button type="button"
                             class="@(pageValue == _page ? "is-active" : "")"
-                            disabled="@(pageValue == _page)"
+                            disabled="@(_isRefreshing || pageValue == _page)"
                             @onclick="@(() => GoToPage(pageValue))">@pageValue</button>
                 }
             }
-            <button type="button" disabled="@(_page >= _totalPages)" @onclick="GoNext">Next &#8250;</button>
+            <button type="button" disabled="@(_isRefreshing || _page >= _totalPages)" @onclick="GoNext">Next &#8250;</button>
         </nav>
     </text>;
 
     private async Task ReloadAsync()
     {
+        // Cancel any previous in-flight reload — superseded by this newer one.
+        if (_reloadCts is not null)
+        {
+            await _reloadCts.CancelAsync();
+            _reloadCts.Dispose();
+        }
+        _reloadCts = new CancellationTokenSource();
+        var token = _reloadCts.Token;
+
+        var thisReloadId = ++_latestReloadId;
+        _isRefreshing = true;
+        StateHasChanged(); // immediately show progress bar / dim rows
+
         var query = new OrdersQueryParams
         {
             Search   = string.IsNullOrWhiteSpace(_search) ? null : _search,
             Status   = string.IsNullOrEmpty(_statusFilter) ? null : _statusFilter,
             Store    = string.IsNullOrEmpty(_storeFilter)  ? null : _storeFilter,
-            Date     = null, // S-1: date preset is disabled in the UI; never sent to API
+            Date     = null,
             HasDebt  = _hasDebtFilter,
             Page     = _page,
             PageSize = _pageSize,
         };
 
-        var result = await Api.GetOrdersAsync(query, CancellationToken.None);
+        PagedResult<OrderSummaryDto>? result;
+        try
+        {
+            result = await Api.GetOrdersAsync(query, token);
+        }
+        catch (OperationCanceledException)
+        {
+            return; // superseded
+        }
+
+        // Stale-response guard: if a newer request started while we were waiting,
+        // discard this result quietly without touching shared state.
+        if (thisReloadId != _latestReloadId) return;
+
         if (result is null)
         {
             _loadFailed = true;
@@ -373,11 +525,14 @@
             if (_orders.Count == 0 && _total > 0 && _page > _totalPages)
             {
                 _page = _totalPages;
+                _isRefreshing = false;
                 await ReloadAsync();
                 return;
             }
         }
 
+        _isRefreshing = false;
+        _hasEverLoaded = true;
         StateHasChanged();
     }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
@@ -1,5 +1,7 @@
 @page "/orders/{Number}"
 @inject SalesApiClient Api
+@inject PersistentComponentState ApplicationState
+@implements IDisposable
 
 <PageTitle>@Number &middot; Sales</PageTitle>
 
@@ -196,9 +198,42 @@
     private OrderDetailsDto? _order;
     private bool             _loadFailed;
     private bool             _loadCompleted;
+    private string?          _hydratedFromNumber;
+    private PersistingComponentStateSubscription _persistingSub;
+
+    private string PersistKey => $"sales.order.details.{Number}";
+
+    protected override void OnInitialized()
+    {
+        // Persist the just-fetched details so the interactive (post-hydration)
+        // pass can rehydrate without a second HTTP roundtrip — kills the
+        // brief "blank → re-render" flash users see when entering the page.
+        _persistingSub = ApplicationState.RegisterOnPersisting(() =>
+        {
+            if (_order is not null)
+            {
+                ApplicationState.PersistAsJson(PersistKey, _order);
+            }
+            return Task.CompletedTask;
+        });
+    }
 
     protected override async Task OnParametersSetAsync()
     {
+        // Skip the second fetch if the prerender side persisted us a payload
+        // for this exact order number. Tracked by _hydratedFromNumber so we
+        // still refetch when the user navigates to a different /orders/{Number}.
+        if (_hydratedFromNumber != Number &&
+            ApplicationState.TryTakeFromJson<OrderDetailsDto>(PersistKey, out var persisted) &&
+            persisted is not null)
+        {
+            _order = persisted;
+            _loadFailed = false;
+            _loadCompleted = true;
+            _hydratedFromNumber = Number;
+            return;
+        }
+
         _order = null;
         _loadFailed = false;
         _loadCompleted = false;
@@ -234,7 +269,10 @@
         finally
         {
             _loadCompleted = true;
+            _hydratedFromNumber = Number;
             StateHasChanged();
         }
     }
+
+    public void Dispose() => _persistingSub.Dispose();
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
@@ -134,6 +134,40 @@ public sealed class SalesApiClient
         }
     }
 
+    /// <summary>
+    /// Fetches the toolbar filter options (distinct Statuses + Stores currently
+    /// present in the data) from <c>GET /api/sales/orders/filters</c>.
+    /// Returns <c>null</c> when the API is unreachable so the toolbar can fall
+    /// back to a single "All" option without crashing the page.
+    /// </summary>
+    public async Task<OrdersFilterOptionsDto?> GetFilterOptionsAsync(CancellationToken cancellationToken)
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientName);
+        const string url = "/api/sales/orders/filters";
+
+        try
+        {
+            using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "Sales API returned {StatusCode} for {Url}",
+                    response.StatusCode,
+                    url);
+                return null;
+            }
+
+            return await response.Content
+                .ReadFromJsonAsync<OrdersFilterOptionsDto>(cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            _logger.LogError(ex, "Sales API call to {Url} failed", url);
+            return null;
+        }
+    }
+
     private static string BuildOrdersListUrl(OrdersQueryParams query)
     {
         var parts = new List<string>(8);

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
@@ -7,7 +7,13 @@
 
 @* Force a real Portal login on Test/Production. RedirectToLogin builds the
    correct return URL from the Sales PathBase so the user comes back here
-   after Portal sets the shared auth cookie. *@
+   after Portal sets the shared auth cookie.
+
+   The <Authorizing> template intentionally renders the same shell with empty
+   content while AuthenticationStateProvider re-resolves on the client after
+   prerender → interactive hydration. Without it AuthorizeView shows nothing,
+   which causes a visible white flash between the prerendered page and the
+   interactive re-render. *@
 <AuthorizeView>
     <Authorized Context="auth">
         <PortalModuleShell EnvironmentName="@_environmentName"
@@ -15,6 +21,9 @@
             @Body
         </PortalModuleShell>
     </Authorized>
+    <Authorizing>
+        <PortalModuleShell EnvironmentName="@_environmentName" />
+    </Authorizing>
     <NotAuthorized>
         <RedirectToLogin />
     </NotAuthorized>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
@@ -153,6 +153,29 @@ h1:focus { outline: none; }
 .amount-card--debt { border-color: var(--danger-bd); background: #fff4f1; }
 .amount-card--debt .amount-card__value { color: var(--danger-fg); }
 
+/* ── List loading affordance ─────────────────────────────────
+   2px teal sliver at the top of the orders panel that's only visible while
+   a refresh is in flight (page change, filter, search). Pure CSS animation,
+   no JS — uses an indeterminate left↔right slide so the user immediately
+   sees that the click was registered without any click being blocked.
+   The dim modifier on .orders-list__body / .orders-list__cards softens
+   the previous rows while the new ones load (fades to 0.6 opacity, but
+   never disappears, so there's no skeleton flash on every page click). */
+.list-loading-bar { position: relative; height: 2px; overflow: hidden; background: transparent; transition: background .12s ease-in-out; }
+.list-loading-bar.is-active { background: var(--accent-50); }
+.list-loading-bar.is-active::before {
+  content: "";
+  position: absolute; left: 0; top: 0; bottom: 0; width: 35%;
+  background: linear-gradient(90deg, transparent 0%, var(--accent-500) 30%, var(--accent-500) 70%, transparent 100%);
+  animation: orders-loading-slide 1.05s ease-in-out infinite;
+}
+@keyframes orders-loading-slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(286%); }
+}
+.orders-list.is-refreshing .orders-list__body,
+.orders-list.is-refreshing .orders-list__cards { opacity: .6; pointer-events: none; transition: opacity .12s ease-in-out; }
+
 /* ── Employees table ─────────────────────────────────────────── */
 .emp-name { display: flex; align-items: center; gap: 7px; }
 .emp-avatar { display: inline-grid; place-items: center; width: 22px; height: 22px; border-radius: 50%; background: var(--n-100); color: var(--n-700); font-family: var(--font-mono); font-size: 10px; font-weight: 900; flex-shrink: 0; }


### PR DESCRIPTION
## Summary

Three-in-one UX polish PR for the Sales Orders pages following the S-2 SQL gateway merge. No domain/contract changes other than the new `OrdersFilterOptionsDto` and the new `GET /api/sales/orders/filters` endpoint.

### 0.1 - Page no longer flashes white during prerender -> interactive hydration
- `MainLayout.razor` now renders an `<Authorizing>` template that keeps the Portal shell mounted while `AuthenticationStateProvider` re-resolves on the client. Without this, `AuthorizeView` rendered nothing for ~50-150ms after SignalR connected, producing the visible white flash.
- `Index.razor` and `OrderDetail.razor` use `PersistentComponentState` to carry the just-fetched payload across the prerender -> interactive boundary, so the second `OnInitializedAsync` skips the HTTP roundtrip and reuses the data the prerendered HTML already showed - no empty-then-populated flash, no double request.

### 0.2 - Real loading affordance during page changes / filters / search
- New 2px teal indeterminate progress bar at the top of the orders panel (`.list-loading-bar`) - pure CSS animation, no JS.
- `.orders-list.is-refreshing` dims `<tbody>` and the mobile cards container to 0.6 opacity and disables pointer events. Previous rows stay visible (no skeleton flicker on every page click).
- Pagination `Prev / 1 2 3 ... / Next` buttons disable themselves while a refresh is in flight - kills the click-spam race.
- Search input remains fully interactive; the request is debounced (250ms via `SearchDebounceMs`) so we don't fire one request per keystroke.
- Each `ReloadAsync` cancels the previous `CancellationTokenSource` AND guards on a monotonic `_latestReloadId` counter - strict last-write-wins on stale responses (Next/Next/Next won't end up showing page 2 after page 4 has already arrived).
- "No orders match these filters" empty-state copy is gated on `_hasEverLoaded` so it can't flash before the very first fetch completes.

### 0.3 - Status and Store filters now actually filter
Root cause: hardcoded city/status dropdowns were authored against the design preview, not the real legacy data. `"Vilnius"` never matched real labels like `"Vilnius - mazmena"`, `"Vilnius rinka"`, etc., so picking any option silently filtered to zero rows.

- Drop the hardcoded `StatusOptions` / `StoreOptions` lists in `Index.razor`.
- Add `OrdersFilterOptionsDto` (Contracts) + `IOrdersQueryService.GetFilterOptionsAsync` (Application port) + `SqlOrdersQueryService` and `StubOrdersQueryService` impls returning distinct `Status` / `Store` values straight from the data, deduped case-insensitively, sorted with `CurrentCulture` (proper Lithuanian collation).
- New `GET /api/sales/orders/filters` endpoint and `SalesApiClient.GetFilterOptionsAsync`. The WebUI fetches options on init in parallel with the orders list (`Task.WhenAll`).
- Trim both sides + `OrdinalIgnoreCase` in the in-memory Status / Store filter so legacy `nchar`/`char` right-padding can't drop matches.

The dropdowns now show exactly the values present in the data (so picking any option always filters at least one row), and a new status/store added in the legacy DB will appear automatically without any code change.

### Out of scope (Phase-2 backlog, not in this PR)
- WHF-1: map `SKIRTINGAI` status to a `MultiStatus` family + `info-blue` chip color
- WHF-2: 5-color duty dots (Konsultantas teal, Vadybininkas darker teal, Matuotojas info-blue, Montuotojas ok-green, Transportas slate)
- WHF-4: server-side paged proc wrapper (`dbo.weblb_Orders_Paged`) so we stop materialising the whole table per request
- WHF-5: `LKvitai.MES.Tests.Sales.Integration` with Testcontainers SQL Server + seed of `weblb_*` rows

## Test plan

- [ ] CI green on `polish/sales-orders-ux`
- [ ] `mes-test.lauresta.com/sales/` loads without a visible white flash between prerender and interactive
- [ ] Click `Next` rapidly: progress bar appears, rows dim but stay visible, only the latest page result wins
- [ ] Type in the search box: requests are debounced and stale responses are discarded
- [ ] Status dropdown is populated from real data (e.g. includes `SKIRTINGAI`); picking any option filters down to a non-empty result set
- [ ] Store dropdown shows real labels like `Vilnius - mazmena`; picking any option filters correctly
- [ ] `mes-test.lauresta.com/sales/orders/{number}` loads without flashing the spinner / empty panel after the data has already prerendered
