### PR TITLE
polish(sales-orders): wire persist-component-state, cache-bust CSS, fix duty colors

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderStatusCodes.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Contracts/Orders/OrderStatusCodes.cs
@@ -17,4 +17,11 @@ public static class OrderStatusCodes
     public const string Delivered  = "delivered";
     public const string Paused     = "paused";
     public const string Cancelled  = "cancelled";
+
+    /// <summary>
+    /// Multi-status — the order has lines in more than one status family
+    /// at the same time (legacy label "SKIRTINGAI"). Renders as info-blue
+    /// chip so it's clearly distinct from the single-state families above.
+    /// </summary>
+    public const string MultiStatus = "multistatus";
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesOrderStatusMap.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesOrderStatusMap.cs
@@ -22,6 +22,11 @@ internal static class SalesOrderStatusMap
         ["Atiduotas"]    = OrderStatusCodes.Delivered,
         ["Sustabdytas"]  = OrderStatusCodes.Paused,
         ["Atšauktas"]    = OrderStatusCodes.Cancelled,
+        // SKIRTINGAI = "different" / "various" — legacy uppercase label that
+        // weblb_Orders emits for an order whose lines straddle multiple status
+        // families. Mapped to a dedicated MultiStatus code so the chip can
+        // render in info-blue instead of falling back to slate "Entered".
+        ["SKIRTINGAI"]   = OrderStatusCodes.MultiStatus,
     };
 
     public static string ToStatusCode(string? label)

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -520,23 +520,26 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
     }
 
     /// <summary>
-    /// Reduces the Lithuanian duty title to a stable lowercase code the WebUI
-    /// uses to pick the <c>duty--*</c> dot color (<c>sales</c>, <c>prod</c>,
-    /// <c>inst</c>). Conservative: first non-empty word lowercased, then mapped
-    /// onto the three known buckets — anything else falls through as-is and
-    /// renders as a neutral dot.
+    /// Reduces the Lithuanian duty title to a stable short code the WebUI uses
+    /// to pick the <c>duty--*</c> dot color. Recognised buckets (per business
+    /// confirmation 2026-05-02): <c>kons</c> Konsultantas, <c>vady</c>
+    /// Vadybininkas, <c>matu</c> Matuotojas, <c>mont</c> Montuotojas,
+    /// <c>trans</c> Transportas. Anything else returns empty so the WebUI
+    /// renders a neutral light-grey dot — the data is small and any new role
+    /// only needs an extra branch here plus a one-line CSS rule.
     /// </summary>
     private static string BuildDutyCode(string dutyLabel)
     {
         if (string.IsNullOrWhiteSpace(dutyLabel)) return string.Empty;
         var lower = dutyLabel.Trim().ToLowerInvariant();
 
-        if (lower.Contains("pardav") || lower.Contains("sales"))                 return "sales";
-        if (lower.Contains("gamyb")  || lower.Contains("prod"))                  return "prod";
-        if (lower.Contains("monta")  || lower.Contains("install") || lower.Contains("inst")) return "inst";
+        if (lower.Contains("konsult"))                                  return "kons";
+        if (lower.Contains("vadyb"))                                    return "vady";
+        if (lower.Contains("matuot"))                                   return "matu";
+        if (lower.Contains("montuot") || lower.Contains("install"))     return "mont";
+        if (lower.Contains("transport"))                                return "trans";
 
-        var firstWord = lower.Split(' ', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
-        return firstWord ?? string.Empty;
+        return string.Empty; // neutral dot — keeps the row legible without guessing
     }
 
     private static DateOnly? ParseLegacyDate(string? text)

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Stub/StubOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Stub/StubOrdersQueryService.cs
@@ -340,11 +340,14 @@ public sealed class StubOrdersQueryService : IOrdersQueryService
     {
         return new List<OrderEmployeeDto>
         {
+            // Stub employees use the same 5-bucket short codes the SQL adapter
+            // emits (kons / vady / matu / mont / trans) so the duty dot colors
+            // render consistently between Stub and SQL data sources.
             new(
                 Name:             "Rūta Markevičienė",
                 Initials:         "RM",
-                DutyCode:         "sales",
-                DutyLabel:        "Sales consultant",
+                DutyCode:         "kons",
+                DutyLabel:        "Konsultantas",
                 ServiceDate:      new DateOnly(2026, 4, 29),
                 AcquaintanceDate: new DateOnly(2026, 4, 29),
                 OrderQty:         1,
@@ -353,8 +356,8 @@ public sealed class StubOrdersQueryService : IOrdersQueryService
             new(
                 Name:             "Mantas Jankauskas",
                 Initials:         "MJ",
-                DutyCode:         "prod",
-                DutyLabel:        "Production",
+                DutyCode:         "matu",
+                DutyLabel:        "Matuotojas",
                 ServiceDate:      new DateOnly(2026, 4, 30),
                 AcquaintanceDate: new DateOnly(2026, 4, 30),
                 OrderQty:         1,
@@ -363,8 +366,8 @@ public sealed class StubOrdersQueryService : IOrdersQueryService
             new(
                 Name:             "Tomas Varnas",
                 Initials:         "TV",
-                DutyCode:         "inst",
-                DutyLabel:        "Installation",
+                DutyCode:         "mont",
+                DutyLabel:        "Montuotojas",
                 ServiceDate:      new DateOnly(2026, 5, 3),
                 AcquaintanceDate: new DateOnly(2026, 5, 3),
                 OrderQty:         1,

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Formatting/OrderFormat.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Formatting/OrderFormat.cs
@@ -57,9 +57,15 @@ public static class OrderFormat
     public static string StatusChip(string statusCode)
         => string.IsNullOrWhiteSpace(statusCode) ? "chip--entered" : $"chip--{statusCode}";
 
-    /// <summary>Returns the duty dot class for an employee row (<c>duty--sales</c> etc).</summary>
+    /// <summary>
+    /// Returns the duty dot class for an employee row. Known short codes:
+    /// <c>kons</c>, <c>vady</c>, <c>matu</c>, <c>mont</c>, <c>trans</c>
+    /// (see <c>SqlOrdersQueryService.BuildDutyCode</c>). Empty / unknown
+    /// codes fall through with no modifier so the base <c>.duty</c> dot
+    /// renders in neutral light-grey.
+    /// </summary>
     public static string DutyClass(string dutyCode)
-        => string.IsNullOrWhiteSpace(dutyCode) ? "duty--sales" : $"duty--{dutyCode}";
+        => string.IsNullOrWhiteSpace(dutyCode) ? string.Empty : $"duty--{dutyCode}";
 
     /// <summary>
     /// Maps an <see cref="OrderAmountKind"/> to the matching <c>amount-card--*</c>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -192,10 +192,11 @@
 </main>
 
 @code {
-    private const int    PageSize          = 100;
-    private const int    SearchDebounceMs  = 250;
-    private const string PersistKeyOrders  = "sales.orders.list";
-    private const string PersistKeyFilters = "sales.orders.filterOptions";
+    private const int    PageSize             = 100;
+    private const int    SearchDebounceMs     = 250;
+    private const int    LoadingMinVisibleMs  = 200; // floor for the loading bar
+    private const string PersistKeyOrders     = "sales.orders.list";
+    private const string PersistKeyFilters    = "sales.orders.filterOptions";
 
     /// <summary>Snapshot of the orders page persisted across the prerender →
     /// interactive boundary so OnInitializedAsync skips a second HTTP call and
@@ -497,7 +498,14 @@
         PagedResult<OrderSummaryDto>? result;
         try
         {
-            result = await Api.GetOrdersAsync(query, token);
+            // Run the API call in parallel with a minimum-visibility delay so
+            // very fast responses still leave the loading bar on screen long
+            // enough for the user to register that the click was registered.
+            // The delay is cancelled along with the API call when superseded.
+            var apiTask   = Api.GetOrdersAsync(query, token);
+            var floorTask = Task.Delay(LoadingMinVisibleMs, token);
+            await Task.WhenAll(apiTask, floorTask);
+            result = await apiTask;
         }
         catch (OperationCanceledException)
         {

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
@@ -12,9 +12,13 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="css/tokens.css" rel="stylesheet" />
-    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" />
-    <link href="css/orders.css" rel="stylesheet" />
+    @* asp-append-version=true emits a content-hash query string (?v=...) so
+       Cloudflare and the browser cache the CSS by hash instead of by name —
+       a redeploy of the same URL with new content reaches the user instantly,
+       not in 4 hours when max-age expires. *@
+    <link href="css/tokens.css" rel="stylesheet" asp-append-version="true" />
+    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" asp-append-version="true" />
+    <link href="css/orders.css" rel="stylesheet" asp-append-version="true" />
     <link rel="icon" href="data:," />
     <title>LKvitai.MES · Sales</title>
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
@@ -27,6 +31,14 @@
         <a href="" class="reload">Reload</a>
         <a class="dismiss">🗙</a>
     </div>
+
+    @* Required for PersistentComponentState to actually transfer state from the
+       prerender pass to the interactive (post-SignalR) pass. Without this tag
+       the RegisterOnPersisting callbacks fire on the server but the serialized
+       payload is never written into the page, so TryTakeFromJson on the client
+       always returns false and OnInitializedAsync re-fetches data — visible
+       as a flash between the prerendered grid and the re-rendered grid. *@
+    <persist-component-state />
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
@@ -9,11 +9,12 @@
    correct return URL from the Sales PathBase so the user comes back here
    after Portal sets the shared auth cookie.
 
-   The <Authorizing> template intentionally renders the same shell with empty
-   content while AuthenticationStateProvider re-resolves on the client after
-   prerender → interactive hydration. Without it AuthorizeView shows nothing,
-   which causes a visible white flash between the prerendered page and the
-   interactive re-render. *@
+   No <Authorizing> template here on purpose: in Blazor Server with
+   ServerPrerendered the AuthenticationStateProvider resolves synchronously
+   from the cookie/circuit context, so the Authorizing branch never renders
+   and would just be dead code. The hydration-time flash is fixed structurally
+   by <persist-component-state /> in _Layout.cshtml + PersistentComponentState
+   in Index.razor / OrderDetail.razor. *@
 <AuthorizeView>
     <Authorized Context="auth">
         <PortalModuleShell EnvironmentName="@_environmentName"
@@ -21,9 +22,6 @@
             @Body
         </PortalModuleShell>
     </Authorized>
-    <Authorizing>
-        <PortalModuleShell EnvironmentName="@_environmentName" />
-    </Authorizing>
     <NotAuthorized>
         <RedirectToLogin />
     </NotAuthorized>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/css/orders.css
@@ -106,6 +106,9 @@ h1:focus { outline: none; }
 .chip--delivered  { background: var(--done-bg);   color: var(--done-fg);   border-color: var(--done-bd); }
 .chip--paused     { background: var(--danger-bg); color: var(--danger-fg); border-color: var(--danger-bd); }
 .chip--cancelled  { background: var(--n-50);      color: var(--n-400);     border-color: var(--n-200); text-decoration: line-through; }
+/* "SKIRTINGAI" — order has lines in multiple status families simultaneously.
+   Info-blue family so it reads as informational rather than warn/danger. */
+.chip--multistatus { background: var(--info-bg);  color: var(--info-fg);   border-color: var(--info-bd); }
 
 /* ── Table foot ──────────────────────────────────────────────── */
 .table-foot { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 9px 12px; border-top: 1px solid var(--n-150); color: var(--n-500); font-size: 12px; }
@@ -179,10 +182,17 @@ h1:focus { outline: none; }
 /* ── Employees table ─────────────────────────────────────────── */
 .emp-name { display: flex; align-items: center; gap: 7px; }
 .emp-avatar { display: inline-grid; place-items: center; width: 22px; height: 22px; border-radius: 50%; background: var(--n-100); color: var(--n-700); font-family: var(--font-mono); font-size: 10px; font-weight: 900; flex-shrink: 0; }
+/* Employee duty dots — 5 fixed roles per business confirmation 2026-05-02:
+   Konsultantas / Vadybininkas / Matuotojas / Montuotojas / Transportas.
+   Default base dot stays neutral light-grey so an unmapped role doesn't
+   silently steal one of the 5 functional colors. */
 .duty { display: inline-flex; align-items: center; gap: 6px; font-size: 12.5px; }
-.duty::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--accent-500); flex-shrink: 0; }
-.duty--prod::before { background: var(--sand-600); }
-.duty--inst::before { background: var(--ok-dot); }
+.duty::before { content: ""; width: 6px; height: 6px; border-radius: 50%; background: var(--n-300); flex-shrink: 0; }
+.duty--kons::before  { background: var(--accent-500); } /* Konsultantas — sales floor (teal) */
+.duty--vady::before  { background: var(--accent-700); } /* Vadybininkas — manager (darker teal) */
+.duty--matu::before  { background: var(--info-fg); }    /* Matuotojas — measurer (info-blue) */
+.duty--mont::before  { background: var(--ok-fg); }      /* Montuotojas — installer (ok-green) */
+.duty--trans::before { background: var(--slate-fg); }   /* Transportas — transport (slate-grey) */
 
 /* ── LkSelect custom dropdown ─────────────────────────────── */
 .lk-select { position: relative; cursor: pointer; user-select: none; flex-wrap: nowrap; }


### PR DESCRIPTION
## Summary

Followup to PR #77. The previous polish PR shipped but two infra-level issues prevented users from seeing the result on `mes-test`. This PR fixes both at the root, plus closes the WHF-1 / WHF-2 backlog the user signed off.

### Why the previous polish PR didn't help users (verified, not assumed)

**Bug A — flicker remained.** `PersistentComponentState` requires the `<persist-component-state />` Tag Helper inside the host page (`_Layout.cshtml`). It was missing. So `RegisterOnPersisting` ran on the prerender side, but the serialized payload was never written into the page → client-side `TryTakeFromJson` always returned false → second `OnInitializedAsync` re-fetched data → flash visible.

**Bug B — loading bar invisible.** `_Layout.cshtml` linked `css/orders.css` without `asp-append-version="true"`. Cloudflare caches `/sales/css/*` for 4 hours (`Cache-Control: max-age=14400`) and the URL never changed across deploys. Users got an `orders.css` from a pre-PR build for up to 4 h after merge.

Verification:

```
$ curl -I /sales/css/orders.css                 # CDN HIT
HTTP/1.1 200 OK
Last-Modified: 04:47:51 GMT   ← before PR #77 merge
Content-Length: 17218
( no .list-loading-bar in body )

$ curl -I /sales/css/orders.css?v=<random>      # cf MISS, origin
HTTP/1.1 200 OK
Last-Modified: 05:53:24 GMT   ← post merge
Content-Length: 18660
( .list-loading-bar present at line 164 )
```

### Changes

#### A. Critical infra (3 files, root cause for both bugs)

1. **`_Layout.cshtml`** — add `<persist-component-state />` before the Blazor script tag. Activates the prerender → interactive state transfer.
2. **`_Layout.cshtml`** — add `asp-append-version="true"` to the three local `<link>` tags (`tokens.css`, `portal-shell.css`, `orders.css`). Hashed `?v=` URLs invalidate Cloudflare and browser caches instantly on every redeploy.
3. **`MainLayout.razor`** — remove the dead `<Authorizing>` template I added in PR #77. In Blazor Server with `ServerPrerendered` the `AuthenticationStateProvider` resolves synchronously from the cookie/circuit context, so the `Authorizing` branch never renders. The hydration flash is fixed by #1, not by this template.
4. **`Index.razor` `ReloadAsync`** — parallel `Task.Delay(LoadingMinVisibleMs = 200ms)` alongside the API call so even very fast responses leave the loading bar on screen long enough to register visually. Cancelled together with the API call when superseded.

#### B. WHF-1 — `SKIRTINGAI` status

5. `OrderStatusCodes.MultiStatus = "multistatus"`.
6. `SalesOrderStatusMap`: `"SKIRTINGAI" → MultiStatus`.
7. `orders.css` adds `.chip--multistatus` using the **info-blue** functional family.

#### C. WHF-2 — 5-color duty dots

Per business confirmation 2026-05-02:

| Role          | Code    | Color                     |
|---------------|---------|---------------------------|
| Konsultantas  | `kons`  | teal `--accent-500`       |
| Vadybininkas  | `vady`  | darker teal `--accent-700`|
| Matuotojas    | `matu`  | info-blue `--info-fg`     |
| Montuotojas   | `mont`  | ok-green `--ok-fg`        |
| Transportas   | `trans` | slate-grey `--slate-fg`   |
| _unknown_     | _empty_ | light-grey `--n-300`      |

8. `SqlOrdersQueryService.BuildDutyCode` rewritten to recognise the five actual roles. Anything else returns empty so the WebUI shows a neutral light-grey dot instead of stealing one of the 5 functional colors.
9. `OrderFormat.DutyClass`: fallback changed from `"duty--sales"` to empty so unmapped roles inherit the base `.duty` light-grey dot.
10. `orders.css` duty section rewritten with the 5 new rules. Removes the broken `.duty--prod` (no Production role exists) and the typo `.duty--inst { background: var(--ok-dot) }` (`--ok-dot` was never defined — pre-existing bug).
11. `StubOrdersQueryService.BuildSampleEmployees` switched to the same five short codes so Stub and SQL data sources render duty colors identically.

### Out of scope (acknowledged)

- **WHF-3** (address `"---"` and customer `"Vilnius - mazmena"`): cosmetic no-op per user — render as-is.
- **WHF-4** (server-side paged proc wrapper) and **WHF-5** (Sales integration tests): remain Phase-2 backlog.
- Portal / Frontline / Fabric / Scanning host files have the same cache-busting and `persist-component-state` gaps but stay out per AGENTS.md *"Do not touch Frontline/Fabric yet"* — separate sweep PR will follow.

## Test plan

- [ ] CI green
- [ ] `view-source:https://mes-test.lauresta.com/sales/` after deploy contains `<persist-component-state>` ... `</persist-component-state>` block with serialized JSON
- [ ] CSS link href shows `?v=<hash>` query string on every `<link href="css/...">`
- [ ] Reload `/sales/` — no white flash between prerender and interactive
- [ ] Click `Next` page — visible 2px teal progress bar at top of orders panel for ≥200 ms, rows dim, pagination disabled briefly
- [ ] Find a SKIRTINGAI order — chip renders info-blue, not slate
- [ ] Order details Employees table — each duty (Konsultantas / Vadybininkas / Matuotojas / Montuotojas / Transportas) shows distinct colored dot; unknown duties show neutral light-grey dot
