### PR TITLE
fix(sales/webui): make PersistedListState public so circuit survives hydration

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -201,7 +201,16 @@
     /// <summary>Snapshot of the orders page persisted across the prerender →
     /// interactive boundary so OnInitializedAsync skips a second HTTP call and
     /// the page does not flash empty during hydration.</summary>
-    private sealed record PersistedListState(
+    /// <remarks>
+    /// MUST be <c>public</c>: <see cref="System.Text.Json.JsonSerializer"/> uses
+    /// the parameterized public constructor of records for deserialization.
+    /// A <c>private</c>/<c>internal</c> primary constructor causes
+    /// <see cref="PersistentComponentState.TryTakeFromJson{T}"/> to throw during
+    /// hydration, which kills the Blazor Server circuit before any event
+    /// handlers are wired up — filters/buttons silently stop responding and the
+    /// browser logs "Server returned an error on close".
+    /// </remarks>
+    public sealed record PersistedListState(
         IReadOnlyList<OrderSummaryDto> Items,
         int Total,
         int Page,
@@ -283,23 +292,41 @@
         // 1) Try to rehydrate the orders snapshot persisted by the prerender
         //    side. When present, we skip the HTTP call entirely so the user
         //    sees the same data the prerendered HTML showed — no flicker.
-        if (ApplicationState.TryTakeFromJson<PersistedListState>(PersistKeyOrders, out var persisted) && persisted is not null)
+        //
+        //    Wrapped in try/catch so a malformed/incompatible persist payload
+        //    can never kill the Blazor circuit — we just fall back to fetching
+        //    fresh data, exactly like a cold load would do.
+        try
         {
-            _orders        = persisted.Items.ToList();
-            _total         = persisted.Total;
-            _page          = persisted.Page;
-            _search        = persisted.Search;
-            _statusFilter  = persisted.Status;
-            _storeFilter   = persisted.Store;
-            _hasDebtFilter = persisted.HasDebt;
-            _hasEverLoaded = true;
+            if (ApplicationState.TryTakeFromJson<PersistedListState>(PersistKeyOrders, out var persisted) && persisted is not null)
+            {
+                _orders        = persisted.Items.ToList();
+                _total         = persisted.Total;
+                _page          = persisted.Page;
+                _search        = persisted.Search;
+                _statusFilter  = persisted.Status;
+                _storeFilter   = persisted.Store;
+                _hasDebtFilter = persisted.HasDebt;
+                _hasEverLoaded = true;
+            }
+        }
+        catch
+        {
+            _hasEverLoaded = false; // force a fresh fetch below
         }
 
         // 2) Same for the filter options: persisted dropdowns avoid a second
         //    request and an empty-then-populated visual flicker on the toolbar.
-        if (ApplicationState.TryTakeFromJson<OrdersFilterOptionsDto>(PersistKeyFilters, out var persistedFilters) && persistedFilters is not null)
+        try
         {
-            ApplyFilterOptions(persistedFilters);
+            if (ApplicationState.TryTakeFromJson<OrdersFilterOptionsDto>(PersistKeyFilters, out var persistedFilters) && persistedFilters is not null)
+            {
+                ApplyFilterOptions(persistedFilters);
+            }
+        }
+        catch
+        {
+            // toolbar will repopulate from LoadFilterOptionsAsync below
         }
 
         // Both fetches happen during prerender so their results are persisted

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
@@ -223,15 +223,25 @@
         // Skip the second fetch if the prerender side persisted us a payload
         // for this exact order number. Tracked by _hydratedFromNumber so we
         // still refetch when the user navigates to a different /orders/{Number}.
-        if (_hydratedFromNumber != Number &&
-            ApplicationState.TryTakeFromJson<OrderDetailsDto>(PersistKey, out var persisted) &&
-            persisted is not null)
+        //
+        // try/catch ensures a malformed/incompatible persist payload never
+        // kills the circuit (filters and buttons would silently stop working).
+        try
         {
-            _order = persisted;
-            _loadFailed = false;
-            _loadCompleted = true;
-            _hydratedFromNumber = Number;
-            return;
+            if (_hydratedFromNumber != Number &&
+                ApplicationState.TryTakeFromJson<OrderDetailsDto>(PersistKey, out var persisted) &&
+                persisted is not null)
+            {
+                _order = persisted;
+                _loadFailed = false;
+                _loadCompleted = true;
+                _hydratedFromNumber = Number;
+                return;
+            }
+        }
+        catch
+        {
+            // fall through to a fresh fetch
         }
 
         _order = null;


### PR DESCRIPTION
## Summary

PR #78 (which I merged ~10 minutes ago) added `<persist-component-state />` to `_Layout.cshtml`. That tag is what actually wires Blazor's prerender → interactive state transfer. Until then, `PersistDataAsync` was being called on the prerender side but the produced JSON was never written into the page, so `TryTakeFromJson` always returned `false` on the interactive boot and a latent bug stayed hidden.

The latent bug:

```csharp
// Pages/Index.razor
private sealed record PersistedListState(...)   // ← private constructor
```

`System.Text.Json` deserializes records via their parameterised primary constructor and requires it to be **publicly accessible**. A `private` (or `internal`) nested record exposes only a private constructor, so the moment `_Layout.cshtml` started shipping persisted state down to the client, `TryTakeFromJson<PersistedListState>` threw at the very first line of `OnInitializedAsync` on the interactive pass — taking the Blazor Server circuit down with it ~335 ms after connect, before any `@onclick` handlers got wired.

User-visible symptoms (matched the report exactly):
- Filters (Status / Store) silently doing nothing when clicked
- Browser console: `Connection disconnected with error 'Error: Server returned an error on close: Connection closed with an error.'`
- `Unhandled Promise Rejection` in `blazor.server.js`
- Sales WebUI Serilog showed the matching dead-circuit pattern: `GET /_blazor responded 101 in 335ms` with no follow-up reconnect

## Fix

- **`Pages/Index.razor`**: promote `PersistedListState` from `private sealed record` to `public sealed record`, with an XML `<remarks/>` block documenting *why* it must stay public so future me / future contributors don't accidentally make it private again.
- **`Pages/Index.razor`** & **`Pages/OrderDetail.razor`**: wrap both `TryTakeFromJson` calls in `try/catch`. A malformed or version-skewed persist payload will now degrade to a fresh fetch instead of killing the entire Blazor circuit (defense in depth — one bad DTO change should never make every button on the page silently stop working).

## Why `OrderDetail.razor` doesn't have the same root-cause bug

`OrderDetail` persists `OrderDetailsDto` directly, which is already `public record` in `Sales.Contracts`. Only the nested helper record in `Index.razor` was private.

## Test plan

- [x] `dotnet build src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/...csproj -c Release` — 0 warnings, 0 errors
- [ ] After deploy: open `https://mes-test.lauresta.com/sales/`, wait for hydration, then
  - Status dropdown opens and applying a filter calls the API (verify in Network tab)
  - Store dropdown opens and applying a filter calls the API
  - Pagination Next/Prev work
  - Browser DevTools console is clean (no `Connection closed with an error`)
- [ ] Reload `/sales/` — no white flash between prerender and interactive (PR #78 fix should still hold)
- [ ] Click into an order detail page, then back — circuit stays alive, no console errors
