### PR TITLE
fix(sales/webui): revert PersistentComponentState — circuit was dying

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -1,6 +1,5 @@
 @page "/"
 @inject SalesApiClient Api
-@inject PersistentComponentState ApplicationState
 @implements IAsyncDisposable
 
 <PageTitle>Sales · Orders</PageTitle>
@@ -195,29 +194,6 @@
     private const int    PageSize             = 100;
     private const int    SearchDebounceMs     = 250;
     private const int    LoadingMinVisibleMs  = 200; // floor for the loading bar
-    private const string PersistKeyOrders     = "sales.orders.list";
-    private const string PersistKeyFilters    = "sales.orders.filterOptions";
-
-    /// <summary>Snapshot of the orders page persisted across the prerender →
-    /// interactive boundary so OnInitializedAsync skips a second HTTP call and
-    /// the page does not flash empty during hydration.</summary>
-    /// <remarks>
-    /// MUST be <c>public</c>: <see cref="System.Text.Json.JsonSerializer"/> uses
-    /// the parameterized public constructor of records for deserialization.
-    /// A <c>private</c>/<c>internal</c> primary constructor causes
-    /// <see cref="PersistentComponentState.TryTakeFromJson{T}"/> to throw during
-    /// hydration, which kills the Blazor Server circuit before any event
-    /// handlers are wired up — filters/buttons silently stop responding and the
-    /// browser logs "Server returned an error on close".
-    /// </remarks>
-    public sealed record PersistedListState(
-        IReadOnlyList<OrderSummaryDto> Items,
-        int Total,
-        int Page,
-        string Search,
-        string Status,
-        string Store,
-        bool HasDebt);
 
     /// <summary>Always-shown date preset list (Date filter is intentionally
     /// disabled in S-1; kept so the toolbar grid stays aligned).</summary>
@@ -270,9 +246,6 @@
     // returned. Together with _reloadCts this gives us strict last-write-wins.
     private int _latestReloadId;
 
-    // PersistentComponentState subscription — disposed in DisposeAsync.
-    private PersistingComponentStateSubscription _persistingSub;
-
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_total / (double)_pageSize));
     private int _from       => _total == 0 ? 0 : ((_page - 1) * _pageSize) + 1;
     private int _to         => Math.Min(_page * _pageSize, _total);
@@ -280,78 +253,19 @@
     private IReadOnlyList<SelectOption> StatusOptions => _statusOptions;
     private IReadOnlyList<SelectOption> StoreOptions  => _storeOptions;
 
-    protected override void OnInitialized()
-    {
-        // Subscribe BEFORE we touch state so the prerender side has a callback
-        // registered when the framework asks for state to persist into the page.
-        _persistingSub = ApplicationState.RegisterOnPersisting(PersistDataAsync);
-    }
-
     protected override async Task OnInitializedAsync()
     {
-        // 1) Try to rehydrate the orders snapshot persisted by the prerender
-        //    side. When present, we skip the HTTP call entirely so the user
-        //    sees the same data the prerendered HTML showed — no flicker.
-        //
-        //    Wrapped in try/catch so a malformed/incompatible persist payload
-        //    can never kill the Blazor circuit — we just fall back to fetching
-        //    fresh data, exactly like a cold load would do.
-        try
-        {
-            if (ApplicationState.TryTakeFromJson<PersistedListState>(PersistKeyOrders, out var persisted) && persisted is not null)
-            {
-                _orders        = persisted.Items.ToList();
-                _total         = persisted.Total;
-                _page          = persisted.Page;
-                _search        = persisted.Search;
-                _statusFilter  = persisted.Status;
-                _storeFilter   = persisted.Store;
-                _hasDebtFilter = persisted.HasDebt;
-                _hasEverLoaded = true;
-            }
-        }
-        catch
-        {
-            _hasEverLoaded = false; // force a fresh fetch below
-        }
-
-        // 2) Same for the filter options: persisted dropdowns avoid a second
-        //    request and an empty-then-populated visual flicker on the toolbar.
-        try
-        {
-            if (ApplicationState.TryTakeFromJson<OrdersFilterOptionsDto>(PersistKeyFilters, out var persistedFilters) && persistedFilters is not null)
-            {
-                ApplyFilterOptions(persistedFilters);
-            }
-        }
-        catch
-        {
-            // toolbar will repopulate from LoadFilterOptionsAsync below
-        }
-
-        // Both fetches happen during prerender so their results are persisted
-        // for the interactive phase. Run in parallel — no dependency between them.
+        // Both fetches happen on every component init. We deliberately do NOT
+        // use PersistentComponentState here: a prior attempt (PR #78/#79) shipped
+        // hydration + `<persist-component-state />` to skip the second fetch and
+        // kill the post-prerender flicker, but that combination broke the entire
+        // Blazor Server circuit on this stack — filters, paging and any @onclick
+        // silently stopped working with "Server returned an error on close" in
+        // the browser console and zero exceptions on the server side. Until that
+        // root cause is properly diagnosed, a brief flash beats a dead page.
         await Task.WhenAll(
-            _hasEverLoaded   ? Task.CompletedTask : ReloadAsync(),
-            _statusOptions.Count > 1 ? Task.CompletedTask : LoadFilterOptionsAsync());
-    }
-
-    private Task PersistDataAsync()
-    {
-        ApplicationState.PersistAsJson(PersistKeyOrders, new PersistedListState(
-            _orders,
-            _total,
-            _page,
-            _search,
-            _statusFilter,
-            _storeFilter,
-            _hasDebtFilter));
-
-        ApplicationState.PersistAsJson(PersistKeyFilters, new OrdersFilterOptionsDto(
-            _statusOptions.Where(o => !string.IsNullOrEmpty(o.Value)).Select(o => o.Value).ToList(),
-            _storeOptions .Where(o => !string.IsNullOrEmpty(o.Value)).Select(o => o.Value).ToList()));
-
-        return Task.CompletedTask;
+            ReloadAsync(),
+            LoadFilterOptionsAsync());
     }
 
     private async Task LoadFilterOptionsAsync()
@@ -402,8 +316,6 @@
 
     public async ValueTask DisposeAsync()
     {
-        _persistingSub.Dispose();
-
         if (_searchDebounceCts is not null)
         {
             await _searchDebounceCts.CancelAsync();

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/OrderDetail.razor
@@ -1,7 +1,5 @@
 @page "/orders/{Number}"
 @inject SalesApiClient Api
-@inject PersistentComponentState ApplicationState
-@implements IDisposable
 
 <PageTitle>@Number &middot; Sales</PageTitle>
 
@@ -198,51 +196,16 @@
     private OrderDetailsDto? _order;
     private bool             _loadFailed;
     private bool             _loadCompleted;
-    private string?          _hydratedFromNumber;
-    private PersistingComponentStateSubscription _persistingSub;
-
-    private string PersistKey => $"sales.order.details.{Number}";
-
-    protected override void OnInitialized()
-    {
-        // Persist the just-fetched details so the interactive (post-hydration)
-        // pass can rehydrate without a second HTTP roundtrip — kills the
-        // brief "blank → re-render" flash users see when entering the page.
-        _persistingSub = ApplicationState.RegisterOnPersisting(() =>
-        {
-            if (_order is not null)
-            {
-                ApplicationState.PersistAsJson(PersistKey, _order);
-            }
-            return Task.CompletedTask;
-        });
-    }
+    private string?          _loadedNumber;
 
     protected override async Task OnParametersSetAsync()
     {
-        // Skip the second fetch if the prerender side persisted us a payload
-        // for this exact order number. Tracked by _hydratedFromNumber so we
-        // still refetch when the user navigates to a different /orders/{Number}.
-        //
-        // try/catch ensures a malformed/incompatible persist payload never
-        // kills the circuit (filters and buttons would silently stop working).
-        try
-        {
-            if (_hydratedFromNumber != Number &&
-                ApplicationState.TryTakeFromJson<OrderDetailsDto>(PersistKey, out var persisted) &&
-                persisted is not null)
-            {
-                _order = persisted;
-                _loadFailed = false;
-                _loadCompleted = true;
-                _hydratedFromNumber = Number;
-                return;
-            }
-        }
-        catch
-        {
-            // fall through to a fresh fetch
-        }
+        // Refetch only when the route number actually changes (covers Blazor's
+        // habit of calling OnParametersSetAsync more than once for the same
+        // URL during prerender → interactive). Persistence across the
+        // prerender boundary was attempted in PR #78/#79 but broke the circuit
+        // on this stack and was reverted; see Index.razor for the rationale.
+        if (_loadedNumber == Number) return;
 
         _order = null;
         _loadFailed = false;
@@ -279,10 +242,8 @@
         finally
         {
             _loadCompleted = true;
-            _hydratedFromNumber = Number;
+            _loadedNumber = Number;
             StateHasChanged();
         }
     }
-
-    public void Dispose() => _persistingSub.Dispose();
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
@@ -32,13 +32,14 @@
         <a class="dismiss">🗙</a>
     </div>
 
-    @* Required for PersistentComponentState to actually transfer state from the
-       prerender pass to the interactive (post-SignalR) pass. Without this tag
-       the RegisterOnPersisting callbacks fire on the server but the serialized
-       payload is never written into the page, so TryTakeFromJson on the client
-       always returns false and OnInitializedAsync re-fetches data — visible
-       as a flash between the prerendered grid and the re-rendered grid. *@
-    <persist-component-state />
+    @* PersistentComponentState was wired in PR #78 (added <persist-component-state />)
+       and patched in PR #79 to fix a private-record deserialization issue. Both
+       were reverted in this PR because the resulting circuit died ~300 ms after
+       SignalR connect with "Server returned an error on close" in the browser
+       and zero exception traces server-side, leaving the page completely
+       non-interactive (no filters, no paging). The brief post-prerender
+       re-render flash is the lesser of two evils until the persist failure
+       can be reproduced locally and the actual root cause identified. *@
 
     <script src="_framework/blazor.server.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>


### PR DESCRIPTION
## Why

Backout PR — PR #78 / #79 broke the entire Sales WebUI page on `mes-test.lauresta.com`.

I verified live in the browser (logged in as admin, opened `/sales/`):

- `Status` and `Store` dropdowns wouldn't open on click
- `Next` / `Prev` pagination did nothing
- DevTools Console:
  ```
  WebSocket connected to wss://mes-test.lauresta.com/sales/_blazor?id=...
  Error: Connection disconnected with error 'Server returned an error on close: Connection closed with an error.'
  Uncaught (in promise) Error: Server returned an error on close: Connection closed with an error.
  ```
- Sales WebUI Serilog: `GET /_blazor responded 101 in 314 ms` then **no** reconnect — the signature of a circuit that died during component init before any `@onclick` handler was wired
- Zero `[ERR]` / `[WRN]` entries on the server side, so it's something the framework swallows or logs at a level my Serilog filter drops

PR #79's `try/catch` around `TryTakeFromJson` should have caught any of *our* deserialization exceptions. The fact that the circuit still dies means the failure happens either inside the framework's outer hydration layer or during `PersistAsJson` on the prerender side — neither is reachable from page-level code.

I'm not going to spend more time diagnosing this with the user blocked on a non-functional Sales page. Reverting now.

## What

Backs out PersistentComponentState entirely on Sales WebUI:

- **`Pages/Index.razor`** — drop `@inject PersistentComponentState`, drop the `PersistedListState` record, drop `PersistDataAsync`, drop the `TryTakeFromJson` hydration paths. `OnInitializedAsync` is back to its pre-PR-#78 shape: `ReloadAsync` + `LoadFilterOptionsAsync` in parallel on every init. **Loading bar, debounced search, stale-response guard, dynamic filter options, all the other UX work from PR #77/#78 stays.**
- **`Pages/OrderDetail.razor`** — drop the persist subscription and the `TryTakeFromJson` hydration. Replaces `_hydratedFromNumber` with a simpler `_loadedNumber` so the page still avoids redundant fetches when `OnParametersSetAsync` fires twice for the same URL.
- **`Pages/_Layout.cshtml`** — remove `<persist-component-state />`. Nothing in this module uses it now and leaving it triggers framework-level component-state marshalling we don't need. `asp-append-version` cache-busting on `tokens.css` / `portal-shell.css` / `orders.css` stays — that's the working part of PR #78.

## Trade-off

The brief post-prerender re-render flash from before PR #78 returns. That's strictly less bad than the current "nothing on the page is clickable" state. A proper fix for the flicker requires reproducing the persist failure locally first; that goes on the backlog as a separate, calmer task.

## Test plan

- [x] `dotnet build src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/...csproj -c Release` → 0 warnings, 0 errors
- [ ] After deploy:
  - Browser DevTools Console on `https://mes-test.lauresta.com/sales/` is clean
  - `Status` dropdown opens on click and applies a filter (Network shows `/api/sales/orders?...&status=...`)
  - `Store` dropdown opens on click and applies a filter
  - `Next` / `Prev` pagination changes the page (Network shows `/api/sales/orders?...&page=N`)
  - Search box filters on debounce
  - Order link opens `/orders/<num>` in a new tab and that page renders details
- [ ] HTML response no longer contains `<!--Blazor-Server-Component-State:-->` markers
