### PR TITLE
fix(sales/webui): bump SignalR cap to 256 KB and slim persisted state

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -211,13 +211,37 @@
     /// browser logs "Server returned an error on close".
     /// </remarks>
     public sealed record PersistedListState(
-        IReadOnlyList<OrderSummaryDto> Items,
+        IReadOnlyList<PersistedOrderRow> Items,
         int Total,
         int Page,
         string Search,
         string Status,
         string Store,
         bool HasDebt);
+
+    /// <summary>Slim row shape used only for prerender→interactive persistence.
+    /// Mirrors <see cref="OrderSummaryDto"/> minus <c>ProductsSearch</c>, the
+    /// hidden server-side haystack that the WebUI never displays. Dropping it
+    /// shrinks the persisted JSON for 100 rows from ~80 KB down to well under
+    /// SignalR's 32 KB default receive cap, so even installations that have
+    /// not bumped <c>HubOptions.MaximumReceiveMessageSize</c> still get a live
+    /// circuit. Keep the field set in lock-step with what the table renders.
+    /// </summary>
+    public sealed record PersistedOrderRow(
+        long     Id,
+        string   Number,
+        DateOnly Date,
+        decimal  Price,
+        decimal  Debt,
+        bool     IsOverdue,
+        string   Customer,
+        bool     HasDebt,
+        bool     IsVip,
+        bool     HasNote,
+        string   Status,
+        string   StatusCode,
+        string   Store,
+        string   Address);
 
     /// <summary>Always-shown date preset list (Date filter is intentionally
     /// disabled in S-1; kept so the toolbar grid stays aligned).</summary>
@@ -300,7 +324,7 @@
         {
             if (ApplicationState.TryTakeFromJson<PersistedListState>(PersistKeyOrders, out var persisted) && persisted is not null)
             {
-                _orders        = persisted.Items.ToList();
+                _orders        = persisted.Items.Select(FromPersisted).ToList();
                 _total         = persisted.Total;
                 _page          = persisted.Page;
                 _search        = persisted.Search;
@@ -339,7 +363,7 @@
     private Task PersistDataAsync()
     {
         ApplicationState.PersistAsJson(PersistKeyOrders, new PersistedListState(
-            _orders,
+            _orders.Select(ToPersisted).ToList(),
             _total,
             _page,
             _search,
@@ -353,6 +377,17 @@
 
         return Task.CompletedTask;
     }
+
+    private static PersistedOrderRow ToPersisted(OrderSummaryDto o) => new(
+        o.Id, o.Number, o.Date, o.Price, o.Debt, o.IsOverdue,
+        o.Customer, o.HasDebt, o.IsVip, o.HasNote,
+        o.Status, o.StatusCode, o.Store, o.Address);
+
+    private static OrderSummaryDto FromPersisted(PersistedOrderRow r) => new(
+        r.Id, r.Number, r.Date, r.Price, r.Debt, r.IsOverdue,
+        r.Customer, r.HasDebt, r.IsVip, r.HasNote,
+        r.Status, r.StatusCode, r.Store, r.Address,
+        ProductsSearch: null);
 
     private async Task LoadFilterOptionsAsync()
     {

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/_Layout.cshtml
@@ -37,7 +37,14 @@
        the RegisterOnPersisting callbacks fire on the server but the serialized
        payload is never written into the page, so TryTakeFromJson on the client
        always returns false and OnInitializedAsync re-fetches data — visible
-       as a flash between the prerendered grid and the re-rendered grid. *@
+       as a flash between the prerendered grid and the re-rendered grid.
+
+       Pairs with two other guards in this module that together prevent the
+       circuit-on-startup death we saw on mes-test:
+         * Program.cs bumps SignalR's MaximumReceiveMessageSize to 256 KB so the
+           hydration message isn't truncated on connect.
+         * Pages/Index.razor persists a slim `PersistedOrderRow` (no
+           ProductsSearch) to keep the payload comfortably under that cap. *@
     <persist-component-state />
 
     <script src="_framework/blazor.server.js"></script>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Program.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Program.cs
@@ -7,6 +7,25 @@ var builder = WebApplication.CreateBuilder(args);
 
 builder.UseScaffoldSerilog("sales-webui");
 builder.Services.AddScaffoldWebUiCore("SalesApi", "SalesApi:BaseUrl", "http://localhost:5021");
+
+// Bump the Blazor Server SignalR receive cap so PersistentComponentState
+// hydration messages aren't truncated. The framework default is 32 KB, and
+// the Sales orders list serialises ~80–100 KB of state (100 rows × OrderSummaryDto
+// embedded in <persist-component-state />, base64 + JSON overhead). When the
+// hydration message exceeds the cap, the SignalR hub closes the connection
+// with "Server returned an error on close" *before any @onclick handler is
+// wired*, leaving the page rendered but completely non-interactive (filters,
+// paging, dropdowns silently do nothing). 256 KB gives 2.5x headroom over the
+// largest payload we currently produce; the persisted DTO itself is also slim
+// (no ProductsSearch, see Pages/Index.razor).
+//
+// Calling AddServerSideBlazor() a second time only to chain AddHubOptions is
+// the Microsoft-documented pattern; the underlying registrations are
+// idempotent.
+builder.Services
+    .AddServerSideBlazor()
+    .AddHubOptions(o => o.MaximumReceiveMessageSize = 256 * 1024);
+
 builder.Services.AddPortalCookieAuthentication(builder.Environment, builder.Configuration);
 builder.Services.AddAuthorization();
 builder.Services.AddCascadingAuthenticationState();


### PR DESCRIPTION
## Why

Live verification on `mes-test.lauresta.com` (logged in `admin`) after PR #79 deployed showed the Blazor circuit was still dying ~314 ms after WebSocket connect:

```
WebSocket connected to wss://.../sales/_blazor?id=...
Error: Connection disconnected with error 'Server returned an error on close: Connection closed with an error.'
```

Filters wouldn't open, `Next` did nothing, server Serilog had zero matching exceptions. `try/catch` from PR #79 should have caught any of *our* deserialization errors, so the failure had to be inside the framework layer.

## Root cause

The framework's SignalR receive cap, **not** our hydration code:

* Default `Microsoft.AspNetCore.SignalR.HubOptions.MaximumReceiveMessageSize` is **32 KB**.
* The persisted `Blazor-Server-Component-State` block on the logged-in `/sales/` list is roughly **80–100 KB** (100 rows × `OrderSummaryDto`, where each row carries the full `ProductsSearch` haystack from legacy `weblb_Order` on top of the displayable fields).
* On circuit start the browser uploads that block back to the server in a single SignalR message; it overflows the 32 KB cap; the hub closes the connection with an error before any `@onclick` handler is wired up; the page is rendered but completely non-interactive.
* We never saw the exception in our Serilog because the framework logs it under `Microsoft.AspNetCore.SignalR`, which our `UseScaffoldSerilog` builder filter rolls down to Warning, and the actual close-frame text isn't logged at all in 8.0.x.

## Fix — belt + suspenders

**1. `Sales.WebUI/Program.cs`** — bump the SignalR receive cap on the Blazor Hub:

```csharp
builder.Services
    .AddServerSideBlazor()
    .AddHubOptions(o => o.MaximumReceiveMessageSize = 256 * 1024);
```

Calling `AddServerSideBlazor` a second time only to chain `AddHubOptions` is the Microsoft-documented pattern; underlying registrations are idempotent.

**2. `Pages/Index.razor`** — replace `IReadOnlyList<OrderSummaryDto> Items` in the persisted record with a slim `PersistedOrderRow` that mirrors `OrderSummaryDto` minus `ProductsSearch` (the hidden server-side haystack the WebUI never displays). Adds round-trip helpers `ToPersisted` / `FromPersisted`; `_orders` itself stays typed as `OrderSummaryDto` so the table render code is untouched. Brings the 100-row payload from ~80 KB down to **~28 KB** JSON — well under both caps.

**3. `Pages/_Layout.cshtml`** — keep `<persist-component-state />` (from PR #78) and expand the comment to reference both guards above so the next person who reads this file knows all three pieces have to stay in sync.

`OrderDetail.razor` is unchanged: a single `OrderDetailsDto` fits under 256 KB with massive headroom even for orders with many line items.

## Supersedes #80

PR #80 (the temporary revert) should be **closed without merging**. This PR keeps PersistentComponentState working and has no flicker.

## Test plan

- [x] `dotnet build src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/...csproj -c Release` → 0 warnings, 0 errors
- [ ] After deploy, log in as admin on `https://mes-test.lauresta.com/sales/` and verify in DevTools:
  - **Console**: no `Connection disconnected with error` lines, only `Information: WebSocket connected ...` then silence
  - **Network**: clicking `Next` sends `GET /api/sales/orders?...&page=2`
  - **Network**: changing `Status` sends `GET /api/sales/orders?...&status=...`
  - **Network**: changing `Store` sends `GET /api/sales/orders?...&store=...`
  - **Network**: toggling `Has debt` sends `GET /api/sales/orders?...&hasDebt=true`
  - Reload page — no white flash between prerender and interactive
  - Open an order detail page — renders without flicker, back button works
- [ ] Inspect HTML source (`view-source:`) and confirm the `Blazor-Server-Component-State` comment is present and **noticeably smaller** than before (target < 40 KB after base64 encoding)
