### PR TITLE
perf(sales/orders): instrument list path and add paged-SP mode

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
@@ -38,9 +38,11 @@ namespace LKvitai.MES.Modules.Sales.Api.Composition;
 /// </remarks>
 public static class SalesOrdersDataSource
 {
-    private const string DataSourceConfigKey  = "Sales:OrdersDataSource";
-    private const string ConnectionStringName = "LKvitaiDb";
-    private const string CommandTimeoutKey    = "Sales:Sql:CommandTimeoutSeconds";
+    private const string DataSourceConfigKey   = "Sales:OrdersDataSource";
+    private const string ConnectionStringName  = "LKvitaiDb";
+    private const string CommandTimeoutKey     = "Sales:Sql:CommandTimeoutSeconds";
+    private const string OrdersCacheTtlKey     = "Sales:Sql:OrdersListCacheTtlSeconds";
+    private const string OrdersQueryModeKey    = "Sales:Sql:OrdersQueryMode";
 
     private const string ModeAuto = "Auto";
     private const string ModeSql  = "Sql";
@@ -92,14 +94,84 @@ public static class SalesOrdersDataSource
                 "or set Sales:OrdersDataSource=Stub explicitly for a stub-only test/dev run.");
         }
 
-        var commandTimeout = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
+        var commandTimeout  = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
+        var ordersCacheTtl  = configuration.GetValue(OrdersCacheTtlKey, defaultValue: 30);
+        var ordersQueryMode = ResolveOrdersQueryMode(configuration[OrdersQueryModeKey]);
+
         services.AddSingleton(new SalesSqlOptions
         {
-            ConnectionString      = connectionString!,
-            CommandTimeoutSeconds = commandTimeout <= 0 ? 30 : commandTimeout,
+            ConnectionString          = connectionString!,
+            CommandTimeoutSeconds     = commandTimeout <= 0 ? 30 : commandTimeout,
+            OrdersListCacheTtlSeconds = ordersCacheTtl < 0 ? 30 : ordersCacheTtl,
+            QueryMode                 = ordersQueryMode,
         });
         services.AddSingleton<IOrdersQueryService, SqlOrdersQueryService>();
+
+        // The orders snapshot cache is a deliberate stop-gap; once Paged mode
+        // is the default everywhere we can drop both the cache and this banner.
+        // Until then, surface a loud reminder in non-Development environments
+        // whenever the cache is still hot — so operators don't lose track of it.
+        var snapshotStillUsedForList = ordersQueryMode == OrdersQueryMode.Snapshot;
+        if (!environment.IsDevelopment() && ordersCacheTtl > 0 && snapshotStillUsedForList)
+        {
+            services.AddHostedService(sp => new SalesOrdersCacheBannerHostedService(
+                sp.GetRequiredService<ILoggerFactory>().CreateLogger("Sales.OrdersDataSource"),
+                ordersCacheTtl,
+                environment.EnvironmentName));
+        }
+
         return services;
+    }
+
+    /// <summary>
+    /// Maps the optional <c>Sales:Sql:OrdersQueryMode</c> config value to the
+    /// <see cref="OrdersQueryMode"/> enum. Missing / blank → Snapshot
+    /// (backwards-compatible default). Unknown values fail fast at startup so
+    /// a typo in <c>appsettings</c> cannot silently degrade list latency.
+    /// </summary>
+    private static OrdersQueryMode ResolveOrdersQueryMode(string? requested)
+    {
+        if (string.IsNullOrWhiteSpace(requested)) return OrdersQueryMode.Snapshot;
+        if (Enum.TryParse<OrdersQueryMode>(requested, ignoreCase: true, out var parsed))
+        {
+            return parsed;
+        }
+
+        throw new InvalidOperationException(
+            $"Unknown {OrdersQueryModeKey} '{requested}'. Expected one of: " +
+            $"'{nameof(OrdersQueryMode.Snapshot)}', '{nameof(OrdersQueryMode.Paged)}'.");
+    }
+
+    /// <summary>
+    /// Logs a one-shot Warning during host startup whenever the in-process
+    /// orders snapshot cache is enabled outside Development. Operators see it
+    /// in the same banner as <c>"Application started"</c>, so the stop-gap
+    /// nature of the cache stays visible until the paged-proc wrapper lands.
+    /// </summary>
+    private sealed class SalesOrdersCacheBannerHostedService : IHostedService
+    {
+        private readonly ILogger _logger;
+        private readonly int _ttlSeconds;
+        private readonly string _environmentName;
+
+        public SalesOrdersCacheBannerHostedService(ILogger logger, int ttlSeconds, string environmentName)
+        {
+            _logger = logger;
+            _ttlSeconds = ttlSeconds;
+            _environmentName = environmentName;
+        }
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            _logger.LogWarning(
+                "Sales orders read-side is using an in-process snapshot cache (TTL={TtlSeconds}s, " +
+                "environment={Environment}). This is a stop-gap; replace with a paged dbo.weblb_Orders_Paged " +
+                "wrapper as soon as practical so the database does the work and the snapshot is no longer needed.",
+                _ttlSeconds, _environmentName);
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Composition/SalesOrdersDataSource.cs
@@ -41,8 +41,6 @@ public static class SalesOrdersDataSource
     private const string DataSourceConfigKey   = "Sales:OrdersDataSource";
     private const string ConnectionStringName  = "LKvitaiDb";
     private const string CommandTimeoutKey     = "Sales:Sql:CommandTimeoutSeconds";
-    private const string OrdersCacheTtlKey     = "Sales:Sql:OrdersListCacheTtlSeconds";
-    private const string OrdersQueryModeKey    = "Sales:Sql:OrdersQueryMode";
 
     private const string ModeAuto = "Auto";
     private const string ModeSql  = "Sql";
@@ -94,84 +92,15 @@ public static class SalesOrdersDataSource
                 "or set Sales:OrdersDataSource=Stub explicitly for a stub-only test/dev run.");
         }
 
-        var commandTimeout  = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
-        var ordersCacheTtl  = configuration.GetValue(OrdersCacheTtlKey, defaultValue: 30);
-        var ordersQueryMode = ResolveOrdersQueryMode(configuration[OrdersQueryModeKey]);
-
+        var commandTimeout = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
         services.AddSingleton(new SalesSqlOptions
         {
-            ConnectionString          = connectionString!,
-            CommandTimeoutSeconds     = commandTimeout <= 0 ? 30 : commandTimeout,
-            OrdersListCacheTtlSeconds = ordersCacheTtl < 0 ? 30 : ordersCacheTtl,
-            QueryMode                 = ordersQueryMode,
+            ConnectionString      = connectionString!,
+            CommandTimeoutSeconds = commandTimeout <= 0 ? 30 : commandTimeout,
         });
         services.AddSingleton<IOrdersQueryService, SqlOrdersQueryService>();
 
-        // The orders snapshot cache is a deliberate stop-gap; once Paged mode
-        // is the default everywhere we can drop both the cache and this banner.
-        // Until then, surface a loud reminder in non-Development environments
-        // whenever the cache is still hot — so operators don't lose track of it.
-        var snapshotStillUsedForList = ordersQueryMode == OrdersQueryMode.Snapshot;
-        if (!environment.IsDevelopment() && ordersCacheTtl > 0 && snapshotStillUsedForList)
-        {
-            services.AddHostedService(sp => new SalesOrdersCacheBannerHostedService(
-                sp.GetRequiredService<ILoggerFactory>().CreateLogger("Sales.OrdersDataSource"),
-                ordersCacheTtl,
-                environment.EnvironmentName));
-        }
-
         return services;
-    }
-
-    /// <summary>
-    /// Maps the optional <c>Sales:Sql:OrdersQueryMode</c> config value to the
-    /// <see cref="OrdersQueryMode"/> enum. Missing / blank → Snapshot
-    /// (backwards-compatible default). Unknown values fail fast at startup so
-    /// a typo in <c>appsettings</c> cannot silently degrade list latency.
-    /// </summary>
-    private static OrdersQueryMode ResolveOrdersQueryMode(string? requested)
-    {
-        if (string.IsNullOrWhiteSpace(requested)) return OrdersQueryMode.Snapshot;
-        if (Enum.TryParse<OrdersQueryMode>(requested, ignoreCase: true, out var parsed))
-        {
-            return parsed;
-        }
-
-        throw new InvalidOperationException(
-            $"Unknown {OrdersQueryModeKey} '{requested}'. Expected one of: " +
-            $"'{nameof(OrdersQueryMode.Snapshot)}', '{nameof(OrdersQueryMode.Paged)}'.");
-    }
-
-    /// <summary>
-    /// Logs a one-shot Warning during host startup whenever the in-process
-    /// orders snapshot cache is enabled outside Development. Operators see it
-    /// in the same banner as <c>"Application started"</c>, so the stop-gap
-    /// nature of the cache stays visible until the paged-proc wrapper lands.
-    /// </summary>
-    private sealed class SalesOrdersCacheBannerHostedService : IHostedService
-    {
-        private readonly ILogger _logger;
-        private readonly int _ttlSeconds;
-        private readonly string _environmentName;
-
-        public SalesOrdersCacheBannerHostedService(ILogger logger, int ttlSeconds, string environmentName)
-        {
-            _logger = logger;
-            _ttlSeconds = ttlSeconds;
-            _environmentName = environmentName;
-        }
-
-        public Task StartAsync(CancellationToken cancellationToken)
-        {
-            _logger.LogWarning(
-                "Sales orders read-side is using an in-process snapshot cache (TTL={TtlSeconds}s, " +
-                "environment={Environment}). This is a stop-gap; replace with a paged dbo.weblb_Orders_Paged " +
-                "wrapper as soon as practical so the database does the work and the snapshot is no longer needed.",
-                _ttlSeconds, _environmentName);
-            return Task.CompletedTask;
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
     }
 
     /// <summary>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Endpoints/OrdersEndpoints.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Endpoints/OrdersEndpoints.cs
@@ -1,7 +1,9 @@
+using System.Diagnostics;
 using LKvitai.MES.Modules.Sales.Application.Ports;
 using LKvitai.MES.Modules.Sales.Contracts.Common;
 using LKvitai.MES.Modules.Sales.Contracts.Orders;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 
 namespace LKvitai.MES.Modules.Sales.Api.Endpoints;
 
@@ -41,27 +43,54 @@ public static class OrdersEndpoints
     private static async Task<IResult> GetOrdersAsync(
         [AsParameters] OrdersListRequest request,
         IOrdersQueryService orders,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
+        var sw = Stopwatch.StartNew();
         var query = request.ToQueryParams();
         var result = await orders.GetOrdersAsync(query, cancellationToken).ConfigureAwait(false);
+        sw.Stop();
+
+        loggerFactory.CreateLogger("LKvitai.MES.Modules.Sales.Api.Endpoints.Orders").LogInformation(
+            "[SalesPerf] api GET /api/sales/orders page={Page} pageSize={PageSize} returned={Returned} total={Total} " +
+            "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} elapsedMs={ElapsedMs}",
+            result.Page, result.PageSize, result.Items.Count, result.Total,
+            !string.IsNullOrWhiteSpace(query.Search), !string.IsNullOrWhiteSpace(query.Status),
+            !string.IsNullOrWhiteSpace(query.Store), query.HasDebt, sw.ElapsedMilliseconds);
+
         return Results.Ok(result);
     }
 
     private static async Task<IResult> GetOrderDetailsAsync(
         string number,
         IOrdersQueryService orders,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
+        var sw = Stopwatch.StartNew();
         var details = await orders.GetOrderDetailsAsync(number, cancellationToken).ConfigureAwait(false);
+        sw.Stop();
+
+        loggerFactory.CreateLogger("LKvitai.MES.Modules.Sales.Api.Endpoints.Orders").LogInformation(
+            "[SalesPerf] api GET /api/sales/orders/{{number}} number={Number} found={Found} elapsedMs={ElapsedMs}",
+            number, details is not null, sw.ElapsedMilliseconds);
+
         return details is null ? Results.NotFound() : Results.Ok(details);
     }
 
     private static async Task<IResult> GetOrdersFilterOptionsAsync(
         IOrdersQueryService orders,
+        ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
+        var sw = Stopwatch.StartNew();
         var options = await orders.GetFilterOptionsAsync(cancellationToken).ConfigureAwait(false);
+        sw.Stop();
+
+        loggerFactory.CreateLogger("LKvitai.MES.Modules.Sales.Api.Endpoints.Orders").LogInformation(
+            "[SalesPerf] api GET /api/sales/orders/filters statuses={StatusCount} stores={StoreCount} elapsedMs={ElapsedMs}",
+            options.Statuses.Count, options.Stores.Count, sw.ElapsedMilliseconds);
+
         return Results.Ok(options);
     }
 

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
@@ -14,7 +14,9 @@
     "_Comment_OrdersDataSource": "Default Sql adapter requires ConnectionStrings:LKvitaiDb. Set 'Stub' explicitly only when you knowingly want sample data.",
     "OrdersDataSource": "Sql",
     "Sql": {
-      "CommandTimeoutSeconds": 30
+      "CommandTimeoutSeconds": 30,
+      "_Comment_OrdersQueryMode": "'Snapshot' (default) caches dbo.weblb_Orders in-process and pages in C#. 'Paged' calls dbo.weblb_Orders_Paged for every list request — only safe once that SP is deployed (see .scratch/sp-paged.sql).",
+      "OrdersQueryMode": "Paged"
     }
   }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/appsettings.Development.json
@@ -14,9 +14,7 @@
     "_Comment_OrdersDataSource": "Default Sql adapter requires ConnectionStrings:LKvitaiDb. Set 'Stub' explicitly only when you knowingly want sample data.",
     "OrdersDataSource": "Sql",
     "Sql": {
-      "CommandTimeoutSeconds": 30,
-      "_Comment_OrdersQueryMode": "'Snapshot' (default) caches dbo.weblb_Orders in-process and pages in C#. 'Paged' calls dbo.weblb_Orders_Paged for every list request — only safe once that SP is deployed (see .scratch/sp-paged.sql).",
-      "OrdersQueryMode": "Paged"
+      "CommandTimeoutSeconds": 30
     }
   }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
@@ -1,30 +1,6 @@
 namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
 
 /// <summary>
-/// How the Sales SQL adapter satisfies <c>GetOrdersAsync</c>.
-/// </summary>
-public enum OrdersQueryMode
-{
-    /// <summary>
-    /// Original behaviour: read <c>dbo.weblb_Orders</c> in full once per TTL,
-    /// keep the result set in-process, then filter / sort / page in C# on every
-    /// list call. Cheap to roll back to and easy to reason about, but the cache
-    /// has bounded staleness (see <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>).
-    /// </summary>
-    Snapshot,
-
-    /// <summary>
-    /// Paged behaviour: each list call invokes <c>dbo.weblb_Orders_Paged</c>
-    /// with the page / filter parameters. The DB returns only the requested
-    /// page plus a windowed <c>TotalRows</c>, so there is no in-process cache
-    /// for the orders list itself. Filter dropdowns and details lookup-by-number
-    /// still use the snapshot (small distinct projections / per-id lookup —
-    /// not on the page-change hot path).
-    /// </summary>
-    Paged,
-}
-
-/// <summary>
 /// Connection settings the Sales SQL Server adapter (S-2) needs to talk to the
 /// legacy <c>LKvitaiDb</c> database. Resolved at composition time from
 /// <c>ConnectionStrings:LKvitaiDb</c> (and optional <c>Sales:Sql</c> section)
@@ -46,38 +22,9 @@ public sealed class SalesSqlOptions
     public string ConnectionString { get; init; } = string.Empty;
 
     /// <summary>
-    /// Per-command timeout in seconds. The legacy <c>weblb_*</c> stored procedures
-    /// historically run sub-second, but the orders list materialises the entire
-    /// table in-memory so we leave headroom for bigger result sets.
+    /// Per-command timeout in seconds. The Sales <c>weblb_*</c> stored
+    /// procedures historically run sub-second; the paged orders SP scales
+    /// with page size rather than table size, so 30 s is comfortable headroom.
     /// </summary>
     public int CommandTimeoutSeconds { get; init; } = 30;
-
-    /// <summary>
-    /// In-process snapshot TTL for <c>dbo.weblb_Orders</c>, in seconds. While the
-    /// snapshot is fresh, every <c>GetOrders</c> / <c>GetFilterOptions</c>
-    /// page-change reuses the same in-memory list and pays only the
-    /// filter / sort / page cost (~10 ms), instead of re-running the 600 ms
-    /// stored procedure. Set to <c>0</c> to disable the cache and force a
-    /// fresh SQL read on every call (useful for diagnostics or once a paged
-    /// proc wrapper makes the cache obsolete).
-    /// </summary>
-    /// <remarks>
-    /// Trade-off: a value of 30 s means a freshly inserted order can stay
-    /// invisible for up to 30 s. The existing list is already eventually
-    /// consistent with the legacy SP (no real-time invalidation), so this
-    /// only adds a bounded, configurable delay on top. When
-    /// <see cref="QueryMode"/> is <see cref="OrdersQueryMode.Paged"/>,
-    /// <c>GetOrdersAsync</c> bypasses the snapshot entirely; the cache is
-    /// then only used by filter dropdowns and the details lookup-by-number.
-    /// </remarks>
-    public int OrdersListCacheTtlSeconds { get; init; } = 30;
-
-    /// <summary>
-    /// How <c>GetOrdersAsync</c> resolves a page of orders. Defaults to
-    /// <see cref="OrdersQueryMode.Snapshot"/> for backwards compatibility —
-    /// flip to <see cref="OrdersQueryMode.Paged"/> via
-    /// <c>Sales:Sql:OrdersQueryMode = "Paged"</c> in <c>appsettings</c> once
-    /// <c>dbo.weblb_Orders_Paged</c> has been deployed to the target database.
-    /// </summary>
-    public OrdersQueryMode QueryMode { get; init; } = OrdersQueryMode.Snapshot;
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SalesSqlOptions.cs
@@ -1,6 +1,30 @@
 namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
 
 /// <summary>
+/// How the Sales SQL adapter satisfies <c>GetOrdersAsync</c>.
+/// </summary>
+public enum OrdersQueryMode
+{
+    /// <summary>
+    /// Original behaviour: read <c>dbo.weblb_Orders</c> in full once per TTL,
+    /// keep the result set in-process, then filter / sort / page in C# on every
+    /// list call. Cheap to roll back to and easy to reason about, but the cache
+    /// has bounded staleness (see <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>).
+    /// </summary>
+    Snapshot,
+
+    /// <summary>
+    /// Paged behaviour: each list call invokes <c>dbo.weblb_Orders_Paged</c>
+    /// with the page / filter parameters. The DB returns only the requested
+    /// page plus a windowed <c>TotalRows</c>, so there is no in-process cache
+    /// for the orders list itself. Filter dropdowns and details lookup-by-number
+    /// still use the snapshot (small distinct projections / per-id lookup —
+    /// not on the page-change hot path).
+    /// </summary>
+    Paged,
+}
+
+/// <summary>
 /// Connection settings the Sales SQL Server adapter (S-2) needs to talk to the
 /// legacy <c>LKvitaiDb</c> database. Resolved at composition time from
 /// <c>ConnectionStrings:LKvitaiDb</c> (and optional <c>Sales:Sql</c> section)
@@ -27,4 +51,33 @@ public sealed class SalesSqlOptions
     /// table in-memory so we leave headroom for bigger result sets.
     /// </summary>
     public int CommandTimeoutSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// In-process snapshot TTL for <c>dbo.weblb_Orders</c>, in seconds. While the
+    /// snapshot is fresh, every <c>GetOrders</c> / <c>GetFilterOptions</c>
+    /// page-change reuses the same in-memory list and pays only the
+    /// filter / sort / page cost (~10 ms), instead of re-running the 600 ms
+    /// stored procedure. Set to <c>0</c> to disable the cache and force a
+    /// fresh SQL read on every call (useful for diagnostics or once a paged
+    /// proc wrapper makes the cache obsolete).
+    /// </summary>
+    /// <remarks>
+    /// Trade-off: a value of 30 s means a freshly inserted order can stay
+    /// invisible for up to 30 s. The existing list is already eventually
+    /// consistent with the legacy SP (no real-time invalidation), so this
+    /// only adds a bounded, configurable delay on top. When
+    /// <see cref="QueryMode"/> is <see cref="OrdersQueryMode.Paged"/>,
+    /// <c>GetOrdersAsync</c> bypasses the snapshot entirely; the cache is
+    /// then only used by filter dropdowns and the details lookup-by-number.
+    /// </remarks>
+    public int OrdersListCacheTtlSeconds { get; init; } = 30;
+
+    /// <summary>
+    /// How <c>GetOrdersAsync</c> resolves a page of orders. Defaults to
+    /// <see cref="OrdersQueryMode.Snapshot"/> for backwards compatibility —
+    /// flip to <see cref="OrdersQueryMode.Paged"/> via
+    /// <c>Sales:Sql:OrdersQueryMode = "Paged"</c> in <c>appsettings</c> once
+    /// <c>dbo.weblb_Orders_Paged</c> has been deployed to the target database.
+    /// </summary>
+    public OrdersQueryMode QueryMode { get; init; } = OrdersQueryMode.Snapshot;
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -1,4 +1,5 @@
 using System.Data;
+using System.Diagnostics;
 using System.Globalization;
 using LKvitai.MES.Modules.Sales.Application.Ports;
 using LKvitai.MES.Modules.Sales.Contracts.Common;
@@ -51,15 +52,30 @@ namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
 /// </remarks>
 public sealed class SqlOrdersQueryService : IOrdersQueryService
 {
-    private const string OrdersProcName      = "dbo.weblb_Orders";
-    private const string OrderProcName       = "dbo.weblb_Order";
-    private const string AccessoriesProcName = "dbo.weblb_Accessories";
-    private const string ItemsProcName       = "dbo.weblb_Items";
-    private const string EmployeesProcName   = "dbo.weblb_Employees";
-    private const string OrderIdParameter    = "@OrderId";
+    private const string OrdersProcName       = "dbo.weblb_Orders";
+    private const string OrdersPagedProcName  = "dbo.weblb_Orders_Paged";
+    private const string OrderProcName        = "dbo.weblb_Order";
+    private const string AccessoriesProcName  = "dbo.weblb_Accessories";
+    private const string ItemsProcName        = "dbo.weblb_Items";
+    private const string EmployeesProcName    = "dbo.weblb_Employees";
+    private const string OrderIdParameter     = "@OrderId";
 
     private readonly SalesSqlOptions _options;
     private readonly ILogger<SqlOrdersQueryService> _logger;
+
+    // Single-flight in-process snapshot cache for dbo.weblb_Orders. Guarded by
+    // a SemaphoreSlim so that N concurrent page-change requests behind a stale
+    // snapshot only trigger ONE SQL re-fetch — the rest wait, then return the
+    // freshly populated list. The cached list is treated as immutable (every
+    // reader uses LINQ enumeration; no mutation in ApplyFilterSortPage), so
+    // it is safe to share across concurrent callers without copying.
+    //
+    // Stop-gap until a paged dbo.weblb_Orders_Paged wrapper exists; see the
+    // class header TODO. TTL is configurable via SalesSqlOptions; 0 disables
+    // caching entirely.
+    private readonly SemaphoreSlim _snapshotGate = new(initialCount: 1, maxCount: 1);
+    private List<OrderSummaryDto> _snapshotRows = new(capacity: 0);
+    private DateTime _snapshotExpiresUtc = DateTime.MinValue;
 
     public SqlOrdersQueryService(SalesSqlOptions options, ILogger<SqlOrdersQueryService> logger)
     {
@@ -81,9 +97,160 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
-        return ApplyFilterSortPage(all, query);
+        // Two implementations live behind this method (selected by config —
+        // SalesSqlOptions.QueryMode). The behaviour seen by the caller is the
+        // same; only the latency profile and where the work happens differ.
+        return _options.QueryMode == OrdersQueryMode.Paged
+            ? await GetOrdersFromPagedSpAsync(query, cancellationToken).ConfigureAwait(false)
+            : await GetOrdersFromSnapshotAsync(query, cancellationToken).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Snapshot path. Materialises <c>dbo.weblb_Orders</c> in full (cached for
+    /// <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>) and runs
+    /// filter / sort / page in C#. Trades freshness for simplicity — was the
+    /// only path before <c>dbo.weblb_Orders_Paged</c> existed.
+    /// </summary>
+    private async Task<PagedResult<OrderSummaryDto>> GetOrdersFromSnapshotAsync(
+        OrdersQueryParams query,
+        CancellationToken cancellationToken)
+    {
+        // Phase 0 instrumentation: split the SQL read from the in-memory
+        // filter/sort/page pass so we can attribute latency to whichever side
+        // is the actual cost. Connection string and credentials never logged.
+        var totalSw = Stopwatch.StartNew();
+        var sqlSw = Stopwatch.StartNew();
+        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
+        sqlSw.Stop();
+
+        var postSw = Stopwatch.StartNew();
+        var result = ApplyFilterSortPage(all, query);
+        postSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogInformation(
+            "[SalesPerf] sql.GetOrders mode=snapshot rows={SourceRows} returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
+            "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} " +
+            "sqlMs={SqlMs} postProcMs={PostProcMs} totalMs={TotalMs}",
+            all.Count, result.Items.Count, result.Total, result.Page, result.PageSize,
+            !string.IsNullOrWhiteSpace(query.Search), !string.IsNullOrWhiteSpace(query.Status),
+            !string.IsNullOrWhiteSpace(query.Store), query.HasDebt,
+            sqlSw.ElapsedMilliseconds, postSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Paged path. Calls <c>dbo.weblb_Orders_Paged</c> with the filter / page
+    /// parameters; the SP returns just the requested page plus a windowed
+    /// <c>TotalRows</c> value (replicated on every row). No in-process cache
+    /// for the orders list itself — every call is a fresh SP execution, so
+    /// the cost scales with <c>PageSize</c>, not with the table size.
+    /// </summary>
+    private async Task<PagedResult<OrderSummaryDto>> GetOrdersFromPagedSpAsync(
+        OrdersQueryParams query,
+        CancellationToken cancellationToken)
+    {
+        var pageSize = query.PageSize <= 0 ? 100 : query.PageSize;
+        var page     = query.Page     <= 0 ? 1   : query.Page;
+
+        var totalSw = Stopwatch.StartNew();
+
+        var openSw = Stopwatch.StartNew();
+        await using var conn = new SqlConnection(_options.ConnectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        openSw.Stop();
+
+        await using var cmd = new SqlCommand(OrdersPagedProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+
+        // The SP normalises NULL / empty parameters internally (LTRIM/RTRIM
+        // and IS NULL guards), so we can pass DBNull straight through for the
+        // "no filter" case without pre-trimming on the client.
+        cmd.Parameters.Add(new SqlParameter("@Page",     SqlDbType.Int)            { Value = page });
+        cmd.Parameters.Add(new SqlParameter("@PageSize", SqlDbType.Int)            { Value = pageSize });
+        cmd.Parameters.Add(new SqlParameter("@Search",   SqlDbType.NVarChar, 200)  { Value = NullableNVarChar(query.Search) });
+        cmd.Parameters.Add(new SqlParameter("@Status",   SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(query.Status) });
+        cmd.Parameters.Add(new SqlParameter("@Store",    SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(query.Store) });
+        cmd.Parameters.Add(new SqlParameter("@HasDebt",  SqlDbType.Bit)            { Value = query.HasDebt ? (object)true : DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateFrom", SqlDbType.Date)           { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateTo",   SqlDbType.Date)           { Value = DBNull.Value });
+
+        var execSw = Stopwatch.StartNew();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        execSw.Stop();
+
+        // Column ordinals for dbo.weblb_Orders_Paged (kept in sync with
+        // .scratch/sp-paged.sql). Any drift would silently mis-project rows,
+        // so when the SP changes shape both sides must be updated together.
+        // Order: Id, Number, Date, Price, Debt, Customer, Status, Store,
+        //        IsCancelled, sImageKey, Address, ProductsSearch, TotalRows
+        var rows = new List<OrderSummaryDto>(capacity: pageSize);
+        var totalRows = 0;
+
+        var matSw = Stopwatch.StartNew();
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            var id             = ReadInt64ByOrdinal(reader, ordinal: 0);
+            var number         = ReadStringByOrdinal(reader, ordinal: 1, fallback: string.Empty);
+            var date           = ReadDateOnlyByOrdinal(reader, ordinal: 2);
+            var price          = ReadDecimalByOrdinal(reader, ordinal: 3);
+            var debt           = ReadDecimalByOrdinal(reader, ordinal: 4);
+            var customer       = ReadStringByOrdinal(reader, ordinal: 5, fallback: string.Empty);
+            var status         = ReadStringByOrdinal(reader, ordinal: 6, fallback: string.Empty);
+            var store          = ReadStringByOrdinal(reader, ordinal: 7, fallback: string.Empty);
+            // ordinals 8 (IsCancelled) and 9 (sImageKey) are returned by the
+            // SP but currently unused by the C# DTO — left in the result set
+            // for parity with the legacy weblb_Orders shape.
+            var address        = ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty);
+            var productsSearch = ReadStringOrNullByOrdinal(reader, ordinal: 11);
+            // TotalRows is windowed COUNT(*) OVER () — same value on every row;
+            // we just keep the last one read (or zero if the page is empty).
+            totalRows = (int)ReadInt64ByOrdinal(reader, ordinal: 12);
+
+            rows.Add(new OrderSummaryDto(
+                Id:             id,
+                Number:         number,
+                Date:           date,
+                Price:          price,
+                Debt:           debt,
+                IsOverdue:      false,
+                Customer:       customer,
+                HasDebt:        debt > 0m,
+                IsVip:          false,
+                HasNote:        false,
+                Status:         status,
+                StatusCode:     SalesOrderStatusMap.ToStatusCode(status),
+                Store:          store,
+                Address:        address,
+                ProductsSearch: productsSearch));
+        }
+        matSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogInformation(
+            "[SalesPerf] sql.GetOrders mode=paged returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
+            "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} " +
+            "openMs={OpenMs} execMs={ExecMs} materialiseMs={MaterialiseMs} totalMs={TotalMs}",
+            rows.Count, totalRows, page, pageSize,
+            !string.IsNullOrWhiteSpace(query.Search), !string.IsNullOrWhiteSpace(query.Status),
+            !string.IsNullOrWhiteSpace(query.Store), query.HasDebt,
+            openSw.ElapsedMilliseconds, execSw.ElapsedMilliseconds,
+            matSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+
+        return new PagedResult<OrderSummaryDto>(rows, totalRows, page, pageSize);
+    }
+
+    /// <summary>
+    /// SQL parameter helper: emit <see cref="DBNull.Value"/> for null / blank
+    /// strings so the SP's <c>IS NULL</c> branches fire instead of looking
+    /// for the literal <c>N''</c>.
+    /// </summary>
+    private static object NullableNVarChar(string? value)
+        => string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
 
     public async Task<OrdersFilterOptionsDto> GetFilterOptionsAsync(CancellationToken cancellationToken)
     {
@@ -93,8 +260,12 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         // round trip. When the paged proc wrapper lands (TODO above), expose
         // dedicated dbo.weblb_StatusList / dbo.weblb_StoreList and wire them
         // here instead.
+        var totalSw = Stopwatch.StartNew();
+        var sqlSw = Stopwatch.StartNew();
         var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
+        sqlSw.Stop();
 
+        var projSw = Stopwatch.StartNew();
         var statuses = all
             .Select(o => o.Status)
             .Where(static s => !string.IsNullOrWhiteSpace(s))
@@ -108,6 +279,14 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .OrderBy(static s => s, StringComparer.CurrentCulture)
             .ToList();
+        projSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogInformation(
+            "[SalesPerf] sql.GetFilterOptions rows={SourceRows} statuses={StatusCount} stores={StoreCount} " +
+            "sqlMs={SqlMs} projectMs={ProjectMs} totalMs={TotalMs}",
+            all.Count, statuses.Count, stores.Count,
+            sqlSw.ElapsedMilliseconds, projSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
 
         return new OrdersFilterOptionsDto(statuses, stores);
     }
@@ -121,20 +300,29 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
             return null;
         }
 
+        var totalSw = Stopwatch.StartNew();
+
         // Phase 1: locate the summary row in weblb_Orders so we can resolve the
         // legacy Id (the @OrderId parameter all other procs require) and seed
         // the price / debt / store / status fields the details proc does not
         // return.
+        var lookupSw = Stopwatch.StartNew();
         var summary = (await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false))
             .FirstOrDefault(o => string.Equals(o.Number, number, StringComparison.OrdinalIgnoreCase));
+        lookupSw.Stop();
 
         if (summary is null)
         {
+            _logger.LogInformation(
+                "[SalesPerf] sql.GetOrderDetails number={Number} found=False lookupMs={LookupMs} totalMs={TotalMs}",
+                number, lookupSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
             return null;
         }
 
+        var openSw = Stopwatch.StartNew();
         await using var conn = new SqlConnection(_options.ConnectionString);
         await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        openSw.Stop();
 
         // Phase 2: header (operator + amounts + authoritative address override).
         OrderOperatorDto? @operator = null;
@@ -143,6 +331,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         var headerStatus   = summary.Status;
         var headerAddress  = summary.Address;
 
+        var headerSw = Stopwatch.StartNew();
         await using (var cmd = CreateProc(conn, OrderProcName, summary.Id))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -167,8 +356,10 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                 amounts.Add(new OrderAmountDto(OrderAmountKind.Debt,          "Debt",           ReadDecimal(reader, "Debt"),             Percent: null));
             }
         }
+        headerSw.Stop();
 
         // Phase 3: accessories (collected first so we can attach them to their parent items).
+        var accSw = Stopwatch.StartNew();
         var accessoriesByItemId = new Dictionary<long, List<OrderItemDto>>();
         await using (var cmd = CreateProc(conn, AccessoriesProcName, summary.Id))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -202,8 +393,10 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                 bucket.Add(accessoryRow);
             }
         }
+        accSw.Stop();
 
         // Phase 4: items — each becomes one OrderItemGroupDto seeded with its parent line plus accessories.
+        var itemsSw = Stopwatch.StartNew();
         var itemGroups = new List<OrderItemGroupDto>();
         await using (var cmd = CreateProc(conn, ItemsProcName, summary.Id))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -250,8 +443,10 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                 displayOrder++;
             }
         }
+        itemsSw.Stop();
 
         // Phase 5: employees.
+        var empSw = Stopwatch.StartNew();
         var employees = new List<OrderEmployeeDto>();
         await using (var cmd = CreateProc(conn, EmployeesProcName, summary.Id))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
@@ -273,6 +468,16 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                     Amount:           ReadDecimal(reader, "AquiredAmount")));
             }
         }
+        empSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogInformation(
+            "[SalesPerf] sql.GetOrderDetails number={Number} found=True items={ItemGroups} accessories={AccessoryItems} employees={EmployeeCount} " +
+            "lookupMs={LookupMs} openMs={OpenMs} headerMs={HeaderMs} accMs={AccMs} itemsMs={ItemsMs} empMs={EmpMs} totalMs={TotalMs}",
+            number, itemGroups.Count, accessoriesByItemId.Sum(kv => kv.Value.Count), employees.Count,
+            lookupSw.ElapsedMilliseconds, openSw.ElapsedMilliseconds, headerSw.ElapsedMilliseconds,
+            accSw.ElapsedMilliseconds, itemsSw.ElapsedMilliseconds, empSw.ElapsedMilliseconds,
+            totalSw.ElapsedMilliseconds);
 
         return new OrderDetailsDto(
             Id:         summary.Id,
@@ -301,12 +506,88 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
     /// legacy proc has no documented column-name contract — the indexes match
     /// the legacy <c>OrdersController</c>'s <c>GetX(n)</c> calls one-for-one.
     /// </summary>
+    /// <summary>
+    /// Returns the materialised <c>dbo.weblb_Orders</c> result set, served from
+    /// an in-process snapshot whose lifetime is bounded by
+    /// <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>. Behind a
+    /// <see cref="SemaphoreSlim"/>: while one caller is fetching a fresh
+    /// snapshot, every concurrent caller waits and then reuses the same
+    /// list (single-flight). Set the TTL to <c>0</c> to disable the cache
+    /// and read from SQL on every call.
+    /// </summary>
     private async Task<List<OrderSummaryDto>> ReadAllOrdersAsync(CancellationToken cancellationToken)
     {
-        var rows = new List<OrderSummaryDto>(capacity: 256);
+        var ttlSeconds = _options.OrdersListCacheTtlSeconds;
+        if (ttlSeconds <= 0)
+        {
+            // Caching disabled — preserve original "fresh SQL on every call"
+            // behaviour. Useful for diagnostics and once a paged proc wrapper
+            // makes the in-process snapshot obsolete.
+            _logger.LogDebug("[SalesPerf] sql.cache disabled ttlSec={TtlSeconds}", ttlSeconds);
+            return await LoadAllOrdersFromSqlAsync(cancellationToken).ConfigureAwait(false);
+        }
 
+        // Fast-path: snapshot still fresh, no lock needed. Reads of the two
+        // fields are independently atomic on .NET 8 (reference + DateTime is
+        // 8 bytes), so worst case we serve a snapshot that just expired —
+        // identical to the post-lock branch under contention.
+        var nowUtc = DateTime.UtcNow;
+        var snapshotRows = _snapshotRows;
+        var snapshotExpiresUtc = _snapshotExpiresUtc;
+        if (nowUtc < snapshotExpiresUtc)
+        {
+            var ageMs = (long)(nowUtc - (snapshotExpiresUtc - TimeSpan.FromSeconds(ttlSeconds))).TotalMilliseconds;
+            _logger.LogInformation(
+                "[SalesPerf] sql.cache hit rows={Rows} ageMs={AgeMs} remainingMs={RemainingMs}",
+                snapshotRows.Count, ageMs, (long)(snapshotExpiresUtc - nowUtc).TotalMilliseconds);
+            return snapshotRows;
+        }
+
+        // Slow-path: stale or first call. Single-flight via SemaphoreSlim —
+        // only one caller fetches; the rest wait then return the new snapshot.
+        await _snapshotGate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Double-check: another caller may have refreshed the snapshot
+            // while we were waiting on the semaphore. If so, return that.
+            nowUtc = DateTime.UtcNow;
+            if (nowUtc < _snapshotExpiresUtc)
+            {
+                _logger.LogInformation(
+                    "[SalesPerf] sql.cache hit-after-wait rows={Rows} remainingMs={RemainingMs}",
+                    _snapshotRows.Count, (long)(_snapshotExpiresUtc - nowUtc).TotalMilliseconds);
+                return _snapshotRows;
+            }
+
+            var fresh = await LoadAllOrdersFromSqlAsync(cancellationToken).ConfigureAwait(false);
+            _snapshotRows = fresh;
+            _snapshotExpiresUtc = DateTime.UtcNow.AddSeconds(ttlSeconds);
+
+            _logger.LogInformation(
+                "[SalesPerf] sql.cache miss rows={Rows} ttlSec={TtlSeconds} expiresAtUtc={ExpiresAtUtc:O}",
+                fresh.Count, ttlSeconds, _snapshotExpiresUtc);
+            return fresh;
+        }
+        finally
+        {
+            _snapshotGate.Release();
+        }
+    }
+
+    private async Task<List<OrderSummaryDto>> LoadAllOrdersFromSqlAsync(CancellationToken cancellationToken)
+    {
+        // Phase 0 instrumentation — split SQL into Open / Exec (TTFB)
+        // / Materialise so we can tell *where* the time is going. These
+        // segments are cheap (Stopwatch.GetTimestamp() ticks) and emitted
+        // at Debug level only — the parent GetOrders/GetFilterOptions
+        // method already logs the rolled-up sqlMs at Information.
+        var rows = new List<OrderSummaryDto>(capacity: 1024);
+        var totalSw = Stopwatch.StartNew();
+
+        var openSw = Stopwatch.StartNew();
         await using var conn = new SqlConnection(_options.ConnectionString);
         await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        openSw.Stop();
 
         await using var cmd = new SqlCommand(OrdersProcName, conn)
         {
@@ -314,9 +595,12 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
             CommandTimeout = _options.CommandTimeoutSeconds,
         };
 
+        var execSw = Stopwatch.StartNew();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        execSw.Stop();
 
         var fieldCount = reader.FieldCount;
+        var matSw = Stopwatch.StartNew();
 
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
@@ -354,6 +638,13 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
                 Address:        address,
                 ProductsSearch: productsSearch));
         }
+        matSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogDebug(
+            "[SalesPerf] sql.weblb_Orders rows={Rows} openMs={OpenMs} execMs={ExecMs} materialiseMs={MaterialiseMs} totalMs={TotalMs}",
+            rows.Count, openSw.ElapsedMilliseconds, execSw.ElapsedMilliseconds,
+            matSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
 
         return rows;
     }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -76,23 +76,9 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
         openSw.Stop();
 
-        await using var cmd = new SqlCommand(OrdersPagedProcName, conn)
-        {
-            CommandType    = CommandType.StoredProcedure,
-            CommandTimeout = _options.CommandTimeoutSeconds,
-        };
-
-        // The SP normalises NULL / empty parameters internally (LTRIM/RTRIM
-        // and IS NULL guards), so we can pass DBNull straight through for the
-        // "no filter" case without pre-trimming on the client.
-        cmd.Parameters.Add(new SqlParameter("@Page",     SqlDbType.Int)            { Value = page });
-        cmd.Parameters.Add(new SqlParameter("@PageSize", SqlDbType.Int)            { Value = pageSize });
-        cmd.Parameters.Add(new SqlParameter("@Search",   SqlDbType.NVarChar, 200)  { Value = NullableNVarChar(query.Search) });
-        cmd.Parameters.Add(new SqlParameter("@Status",   SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(query.Status) });
-        cmd.Parameters.Add(new SqlParameter("@Store",    SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(query.Store) });
-        cmd.Parameters.Add(new SqlParameter("@HasDebt",  SqlDbType.Bit)            { Value = query.HasDebt ? (object)true : DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@DateFrom", SqlDbType.Date)           { Value = DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@DateTo",   SqlDbType.Date)           { Value = DBNull.Value });
+        await using var cmd = BuildPagedSpCommand(
+            conn, page, pageSize,
+            search: query.Search, status: query.Status, store: query.Store, hasDebt: query.HasDebt);
 
         var execSw = Stopwatch.StartNew();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
@@ -421,19 +407,9 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         string number,
         CancellationToken cancellationToken)
     {
-        await using var cmd = new SqlCommand(OrdersPagedProcName, conn)
-        {
-            CommandType    = CommandType.StoredProcedure,
-            CommandTimeout = _options.CommandTimeoutSeconds,
-        };
-        cmd.Parameters.Add(new SqlParameter("@Page",     SqlDbType.Int)            { Value = 1 });
-        cmd.Parameters.Add(new SqlParameter("@PageSize", SqlDbType.Int)            { Value = 5 });
-        cmd.Parameters.Add(new SqlParameter("@Search",   SqlDbType.NVarChar, 200)  { Value = number });
-        cmd.Parameters.Add(new SqlParameter("@Status",   SqlDbType.NVarChar, 100)  { Value = DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@Store",    SqlDbType.NVarChar, 100)  { Value = DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@HasDebt",  SqlDbType.Bit)            { Value = DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@DateFrom", SqlDbType.Date)           { Value = DBNull.Value });
-        cmd.Parameters.Add(new SqlParameter("@DateTo",   SqlDbType.Date)           { Value = DBNull.Value });
+        await using var cmd = BuildPagedSpCommand(
+            conn, page: 1, pageSize: 5,
+            search: number, status: null, store: null, hasDebt: false);
 
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -476,6 +452,40 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
             // for parity with the legacy weblb_Orders shape.
             Address:        ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty),
             ProductsSearch: ReadStringOrNullByOrdinal(reader, ordinal: 11));
+    }
+
+    /// <summary>
+    /// Builds the <see cref="SqlCommand"/> for <c>dbo.weblb_Orders_Paged</c>
+    /// with the full parameter list. Both list reads and the
+    /// number-to-summary lookup go through here so the parameter shape stays
+    /// in lock-step with the SP signature in <c>.scratch/sp-paged.sql</c>.
+    /// The SP normalises NULL / empty strings internally (LTRIM/RTRIM and
+    /// IS NULL guards), so we can pass <see cref="DBNull.Value"/> straight
+    /// through for "no filter" without pre-trimming on the client.
+    /// </summary>
+    private SqlCommand BuildPagedSpCommand(
+        SqlConnection conn,
+        int page,
+        int pageSize,
+        string? search,
+        string? status,
+        string? store,
+        bool hasDebt)
+    {
+        var cmd = new SqlCommand(OrdersPagedProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+        cmd.Parameters.Add(new SqlParameter("@Page",     SqlDbType.Int)            { Value = page });
+        cmd.Parameters.Add(new SqlParameter("@PageSize", SqlDbType.Int)            { Value = pageSize });
+        cmd.Parameters.Add(new SqlParameter("@Search",   SqlDbType.NVarChar, 200)  { Value = NullableNVarChar(search) });
+        cmd.Parameters.Add(new SqlParameter("@Status",   SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(status) });
+        cmd.Parameters.Add(new SqlParameter("@Store",    SqlDbType.NVarChar, 100)  { Value = NullableNVarChar(store) });
+        cmd.Parameters.Add(new SqlParameter("@HasDebt",  SqlDbType.Bit)            { Value = hasDebt ? (object)true : DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateFrom", SqlDbType.Date)           { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateTo",   SqlDbType.Date)           { Value = DBNull.Value });
+        return cmd;
     }
 
     /// <summary>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -92,12 +92,12 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         var rows = new List<OrderSummaryDto>(capacity: pageSize);
         var totalRows = 0;
 
+        // The SP repeats the windowed total count on every row, so any row
+        // works — keep the last one read (or zero if the page is empty).
         var matSw = Stopwatch.StartNew();
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
             rows.Add(ReadOrderSummary(reader));
-            // TotalRows is windowed COUNT(*) OVER () — same value on every row;
-            // we just keep the last one read (or zero if the page is empty).
             totalRows = (int)ReadInt64ByOrdinal(reader, ordinal: 12);
         }
         matSw.Stop();

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.Infrastructure/Sql/SqlOrdersQueryService.cs
@@ -10,72 +10,41 @@ using Microsoft.Extensions.Logging;
 namespace LKvitai.MES.Modules.Sales.Infrastructure.Sql;
 
 /// <summary>
-/// SQL Server adapter for <see cref="IOrdersQueryService"/> that calls the
-/// legacy <c>dbo.weblb_*</c> stored procedures (S-2). Mirrors the behaviour of
-/// <c>LKvitai.Web.Controllers.OrdersController</c> in the legacy ASP.NET app:
+/// SQL Server adapter for <see cref="IOrdersQueryService"/> over the legacy
+/// <c>LKvitaiDb</c> database. Calls dedicated server-side stored procedures
+/// for every read; nothing is cached or reshaped in C#.
+/// </summary>
+/// <remarks>
 /// <list type="bullet">
-///   <item><c>dbo.weblb_Orders</c> — full table read, no parameters (used for
-///   both the orders list and as the seed for the details summary).</item>
-///   <item><c>dbo.weblb_Order</c> with <c>@OrderId</c> — order header + amounts.</item>
-///   <item><c>dbo.weblb_Accessories</c> with <c>@OrderId</c> — accessory rows.</item>
-///   <item><c>dbo.weblb_Items</c> with <c>@OrderId</c> — item rows (each becomes
-///   one <see cref="OrderItemGroupDto"/>; matching accessories are appended).</item>
-///   <item><c>dbo.weblb_Employees</c> with <c>@OrderId</c> — employee assignments.</item>
+///   <item><c>dbo.weblb_Orders_Paged</c> — page + filter + sort the orders
+///   list. Returns only the requested page plus a windowed <c>TotalRows</c>
+///   value, so cost scales with page size instead of table size.</item>
+///   <item><c>dbo.weblb_Orders_Filters</c> — distinct status / store labels
+///   from the reference (<c>Zinynas_*</c>) tables, two result sets in one
+///   round-trip.</item>
+///   <item><c>dbo.weblb_Orders_LookupByNumber</c> — resolves a human-readable
+///   order number to the legacy <c>UzsakymasID</c> the details procs need.</item>
+///   <item><c>dbo.weblb_Order</c>, <c>dbo.weblb_Accessories</c>,
+///   <c>dbo.weblb_Items</c>, <c>dbo.weblb_Employees</c> — per-order details,
+///   each takes <c>@OrderId BIGINT</c> and is unchanged from the legacy app.</item>
 /// </list>
 /// All column reads are <see cref="DBNull"/>-guarded; missing or unexpected
 /// types degrade to safe defaults (<c>0m</c>, empty string, <c>null</c>) instead
 /// of throwing, so a single bad row never blanks the entire list.
-/// </summary>
-/// <remarks>
-/// <para>
-/// <b>Paging / filtering note (TODO).</b> <c>dbo.weblb_Orders</c> takes no
-/// parameters and returns the full result set. This adapter therefore
-/// materialises every row into memory, then applies search / status / store /
-/// has-debt filters and pages in C#. That matches the legacy app's behaviour and
-/// is acceptable while the table size is in the low thousands, but a long-term
-/// fix is to introduce a paged proc wrapper (e.g. <c>dbo.weblb_Orders_Paged</c>
-/// taking <c>@Skip</c>, <c>@Take</c>, <c>@Search</c>, …) so the database does
-/// the work and we stop shipping the entire table per request.
-/// </para>
-/// <para>
-/// <b>Date filter.</b> <see cref="OrdersQueryParams.Date"/> is intentionally
-/// ignored here — the legacy proc has no date range parameters and the WebUI
-/// keeps that filter disabled until a paged proc wrapper exists. A future
-/// revision should plumb a real range through both the proc and this adapter.
-/// </para>
-/// <para>
-/// <b>Customer flags.</b> The legacy proc does not return <c>IsVip</c>,
-/// <c>HasNote</c> or <c>IsOverdue</c>. We derive <c>HasDebt = Debt &gt; 0</c>
-/// and leave the other three at <c>false</c>. Unknown column ordinals 8 and 9
-/// of <c>weblb_Orders</c> may carry these — to be confirmed with the DBA.
-/// </para>
 /// </remarks>
 public sealed class SqlOrdersQueryService : IOrdersQueryService
 {
-    private const string OrdersProcName       = "dbo.weblb_Orders";
-    private const string OrdersPagedProcName  = "dbo.weblb_Orders_Paged";
-    private const string OrderProcName        = "dbo.weblb_Order";
-    private const string AccessoriesProcName  = "dbo.weblb_Accessories";
-    private const string ItemsProcName        = "dbo.weblb_Items";
-    private const string EmployeesProcName    = "dbo.weblb_Employees";
-    private const string OrderIdParameter     = "@OrderId";
+    private const string OrdersPagedProcName    = "dbo.weblb_Orders_Paged";
+    private const string OrdersFiltersProcName  = "dbo.weblb_Orders_Filters";
+    private const string OrdersLookupProcName   = "dbo.weblb_Orders_LookupByNumber";
+    private const string OrderProcName          = "dbo.weblb_Order";
+    private const string AccessoriesProcName    = "dbo.weblb_Accessories";
+    private const string ItemsProcName          = "dbo.weblb_Items";
+    private const string EmployeesProcName      = "dbo.weblb_Employees";
+    private const string OrderIdParameter       = "@OrderId";
 
     private readonly SalesSqlOptions _options;
     private readonly ILogger<SqlOrdersQueryService> _logger;
-
-    // Single-flight in-process snapshot cache for dbo.weblb_Orders. Guarded by
-    // a SemaphoreSlim so that N concurrent page-change requests behind a stale
-    // snapshot only trigger ONE SQL re-fetch — the rest wait, then return the
-    // freshly populated list. The cached list is treated as immutable (every
-    // reader uses LINQ enumeration; no mutation in ApplyFilterSortPage), so
-    // it is safe to share across concurrent callers without copying.
-    //
-    // Stop-gap until a paged dbo.weblb_Orders_Paged wrapper exists; see the
-    // class header TODO. TTL is configurable via SalesSqlOptions; 0 disables
-    // caching entirely.
-    private readonly SemaphoreSlim _snapshotGate = new(initialCount: 1, maxCount: 1);
-    private List<OrderSummaryDto> _snapshotRows = new(capacity: 0);
-    private DateTime _snapshotExpiresUtc = DateTime.MinValue;
 
     public SqlOrdersQueryService(SalesSqlOptions options, ILogger<SqlOrdersQueryService> logger)
     {
@@ -97,60 +66,6 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        // Two implementations live behind this method (selected by config —
-        // SalesSqlOptions.QueryMode). The behaviour seen by the caller is the
-        // same; only the latency profile and where the work happens differ.
-        return _options.QueryMode == OrdersQueryMode.Paged
-            ? await GetOrdersFromPagedSpAsync(query, cancellationToken).ConfigureAwait(false)
-            : await GetOrdersFromSnapshotAsync(query, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Snapshot path. Materialises <c>dbo.weblb_Orders</c> in full (cached for
-    /// <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>) and runs
-    /// filter / sort / page in C#. Trades freshness for simplicity — was the
-    /// only path before <c>dbo.weblb_Orders_Paged</c> existed.
-    /// </summary>
-    private async Task<PagedResult<OrderSummaryDto>> GetOrdersFromSnapshotAsync(
-        OrdersQueryParams query,
-        CancellationToken cancellationToken)
-    {
-        // Phase 0 instrumentation: split the SQL read from the in-memory
-        // filter/sort/page pass so we can attribute latency to whichever side
-        // is the actual cost. Connection string and credentials never logged.
-        var totalSw = Stopwatch.StartNew();
-        var sqlSw = Stopwatch.StartNew();
-        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
-        sqlSw.Stop();
-
-        var postSw = Stopwatch.StartNew();
-        var result = ApplyFilterSortPage(all, query);
-        postSw.Stop();
-        totalSw.Stop();
-
-        _logger.LogInformation(
-            "[SalesPerf] sql.GetOrders mode=snapshot rows={SourceRows} returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
-            "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} " +
-            "sqlMs={SqlMs} postProcMs={PostProcMs} totalMs={TotalMs}",
-            all.Count, result.Items.Count, result.Total, result.Page, result.PageSize,
-            !string.IsNullOrWhiteSpace(query.Search), !string.IsNullOrWhiteSpace(query.Status),
-            !string.IsNullOrWhiteSpace(query.Store), query.HasDebt,
-            sqlSw.ElapsedMilliseconds, postSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-
-        return result;
-    }
-
-    /// <summary>
-    /// Paged path. Calls <c>dbo.weblb_Orders_Paged</c> with the filter / page
-    /// parameters; the SP returns just the requested page plus a windowed
-    /// <c>TotalRows</c> value (replicated on every row). No in-process cache
-    /// for the orders list itself — every call is a fresh SP execution, so
-    /// the cost scales with <c>PageSize</c>, not with the table size.
-    /// </summary>
-    private async Task<PagedResult<OrderSummaryDto>> GetOrdersFromPagedSpAsync(
-        OrdersQueryParams query,
-        CancellationToken cancellationToken)
-    {
         var pageSize = query.PageSize <= 0 ? 100 : query.PageSize;
         var page     = query.Page     <= 0 ? 1   : query.Page;
 
@@ -194,45 +109,16 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         var matSw = Stopwatch.StartNew();
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var id             = ReadInt64ByOrdinal(reader, ordinal: 0);
-            var number         = ReadStringByOrdinal(reader, ordinal: 1, fallback: string.Empty);
-            var date           = ReadDateOnlyByOrdinal(reader, ordinal: 2);
-            var price          = ReadDecimalByOrdinal(reader, ordinal: 3);
-            var debt           = ReadDecimalByOrdinal(reader, ordinal: 4);
-            var customer       = ReadStringByOrdinal(reader, ordinal: 5, fallback: string.Empty);
-            var status         = ReadStringByOrdinal(reader, ordinal: 6, fallback: string.Empty);
-            var store          = ReadStringByOrdinal(reader, ordinal: 7, fallback: string.Empty);
-            // ordinals 8 (IsCancelled) and 9 (sImageKey) are returned by the
-            // SP but currently unused by the C# DTO — left in the result set
-            // for parity with the legacy weblb_Orders shape.
-            var address        = ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty);
-            var productsSearch = ReadStringOrNullByOrdinal(reader, ordinal: 11);
+            rows.Add(ReadOrderSummary(reader));
             // TotalRows is windowed COUNT(*) OVER () — same value on every row;
             // we just keep the last one read (or zero if the page is empty).
             totalRows = (int)ReadInt64ByOrdinal(reader, ordinal: 12);
-
-            rows.Add(new OrderSummaryDto(
-                Id:             id,
-                Number:         number,
-                Date:           date,
-                Price:          price,
-                Debt:           debt,
-                IsOverdue:      false,
-                Customer:       customer,
-                HasDebt:        debt > 0m,
-                IsVip:          false,
-                HasNote:        false,
-                Status:         status,
-                StatusCode:     SalesOrderStatusMap.ToStatusCode(status),
-                Store:          store,
-                Address:        address,
-                ProductsSearch: productsSearch));
         }
         matSw.Stop();
         totalSw.Stop();
 
         _logger.LogInformation(
-            "[SalesPerf] sql.GetOrders mode=paged returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
+            "[SalesPerf] sql.GetOrders returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
             "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} " +
             "openMs={OpenMs} execMs={ExecMs} materialiseMs={MaterialiseMs} totalMs={TotalMs}",
             rows.Count, totalRows, page, pageSize,
@@ -244,49 +130,44 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         return new PagedResult<OrderSummaryDto>(rows, totalRows, page, pageSize);
     }
 
-    /// <summary>
-    /// SQL parameter helper: emit <see cref="DBNull.Value"/> for null / blank
-    /// strings so the SP's <c>IS NULL</c> branches fire instead of looking
-    /// for the literal <c>N''</c>.
-    /// </summary>
-    private static object NullableNVarChar(string? value)
-        => string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
-
     public async Task<OrdersFilterOptionsDto> GetFilterOptionsAsync(CancellationToken cancellationToken)
     {
-        // Same full-table read as GetOrdersAsync (weblb_Orders has no parameters).
-        // We project the two label sets the WebUI toolbar needs; the data is
-        // small enough that an ad-hoc DISTINCT in C# is cheaper than another
-        // round trip. When the paged proc wrapper lands (TODO above), expose
-        // dedicated dbo.weblb_StatusList / dbo.weblb_StoreList and wire them
-        // here instead.
+        // dbo.weblb_Orders_Filters returns two result sets:
+        //   1) statuses : single column [Status] from dbo.Zinynas_busenos
+        //   2) stores   : single column [Store]  from dbo.Zinynas_vieta
+        // Both already trimmed and ordered server-side — no projection here.
         var totalSw = Stopwatch.StartNew();
-        var sqlSw = Stopwatch.StartNew();
-        var all = await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false);
-        sqlSw.Stop();
 
-        var projSw = Stopwatch.StartNew();
-        var statuses = all
-            .Select(o => o.Status)
-            .Where(static s => !string.IsNullOrWhiteSpace(s))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(static s => s, StringComparer.CurrentCulture)
-            .ToList();
+        await using var conn = new SqlConnection(_options.ConnectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
 
-        var stores = all
-            .Select(o => o.Store)
-            .Where(static s => !string.IsNullOrWhiteSpace(s))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(static s => s, StringComparer.CurrentCulture)
-            .ToList();
-        projSw.Stop();
+        await using var cmd = new SqlCommand(OrdersFiltersProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+
+        var statuses = new List<string>(capacity: 16);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            statuses.Add(reader.GetString(0));
+        }
+
+        await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+
+        var stores = new List<string>(capacity: 32);
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            stores.Add(reader.GetString(0));
+        }
+
         totalSw.Stop();
 
         _logger.LogInformation(
-            "[SalesPerf] sql.GetFilterOptions rows={SourceRows} statuses={StatusCount} stores={StoreCount} " +
-            "sqlMs={SqlMs} projectMs={ProjectMs} totalMs={TotalMs}",
-            all.Count, statuses.Count, stores.Count,
-            sqlSw.ElapsedMilliseconds, projSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+            "[SalesPerf] sql.GetFilterOptions statuses={StatusCount} stores={StoreCount} totalMs={TotalMs}",
+            statuses.Count, stores.Count, totalSw.ElapsedMilliseconds);
 
         return new OrdersFilterOptionsDto(statuses, stores);
     }
@@ -302,29 +183,56 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
 
         var totalSw = Stopwatch.StartNew();
 
-        // Phase 1: locate the summary row in weblb_Orders so we can resolve the
-        // legacy Id (the @OrderId parameter all other procs require) and seed
-        // the price / debt / store / status fields the details proc does not
-        // return.
-        var lookupSw = Stopwatch.StartNew();
-        var summary = (await ReadAllOrdersAsync(cancellationToken).ConfigureAwait(false))
-            .FirstOrDefault(o => string.Equals(o.Number, number, StringComparison.OrdinalIgnoreCase));
-        lookupSw.Stop();
-
-        if (summary is null)
-        {
-            _logger.LogInformation(
-                "[SalesPerf] sql.GetOrderDetails number={Number} found=False lookupMs={LookupMs} totalMs={TotalMs}",
-                number, lookupSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-            return null;
-        }
-
         var openSw = Stopwatch.StartNew();
         await using var conn = new SqlConnection(_options.ConnectionString);
         await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
         openSw.Stop();
 
-        // Phase 2: header (operator + amounts + authoritative address override).
+        // Phase 1: resolve Number → UzsakymasID via the dedicated lookup SP.
+        // The legacy details procs (weblb_Order/Items/Accessories/Employees)
+        // all key on @OrderId, so we pay one cheap index seek up-front rather
+        // than scanning the orders list.
+        var lookupSw = Stopwatch.StartNew();
+        long orderId;
+        await using (var cmd = new SqlCommand(OrdersLookupProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        })
+        {
+            cmd.Parameters.Add(new SqlParameter("@Number", SqlDbType.NVarChar, 100) { Value = number });
+            var result = await cmd.ExecuteScalarAsync(cancellationToken).ConfigureAwait(false);
+            if (result is null || result is DBNull)
+            {
+                lookupSw.Stop();
+                _logger.LogInformation(
+                    "[SalesPerf] sql.GetOrderDetails number={Number} found=False lookupMs={LookupMs} totalMs={TotalMs}",
+                    number, lookupSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+                return null;
+            }
+            orderId = Convert.ToInt64(result, CultureInfo.InvariantCulture);
+        }
+        lookupSw.Stop();
+
+        // Phase 2: the legacy weblb_Order proc returns the authoritative
+        // header (operator + amounts + address override). The summary fields
+        // we still need (number, date, price, debt, store, status) are
+        // re-projected from a single-row dbo.weblb_Orders_Paged search call
+        // so this method does not need its own copy of the projection logic.
+        var summarySw = Stopwatch.StartNew();
+        OrderSummaryDto? summary = await ReadSummaryByNumberAsync(conn, number, cancellationToken).ConfigureAwait(false);
+        summarySw.Stop();
+
+        if (summary is null)
+        {
+            // Shouldn't happen — the lookup just told us the order exists —
+            // but guard anyway so we don't NRE on a stale read.
+            _logger.LogWarning(
+                "[SalesPerf] sql.GetOrderDetails number={Number} lookupOk=True summary=null lookupMs={LookupMs} summaryMs={SummaryMs} totalMs={TotalMs}",
+                number, lookupSw.ElapsedMilliseconds, summarySw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+            return null;
+        }
+
         OrderOperatorDto? @operator = null;
         var amounts = new List<OrderAmountDto>(6);
         var headerCustomer = summary.Customer;
@@ -332,7 +240,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         var headerAddress  = summary.Address;
 
         var headerSw = Stopwatch.StartNew();
-        await using (var cmd = CreateProc(conn, OrderProcName, summary.Id))
+        await using (var cmd = CreateProc(conn, OrderProcName, orderId))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
         {
             if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -361,7 +269,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         // Phase 3: accessories (collected first so we can attach them to their parent items).
         var accSw = Stopwatch.StartNew();
         var accessoriesByItemId = new Dictionary<long, List<OrderItemDto>>();
-        await using (var cmd = CreateProc(conn, AccessoriesProcName, summary.Id))
+        await using (var cmd = CreateProc(conn, AccessoriesProcName, orderId))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
         {
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -398,7 +306,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         // Phase 4: items — each becomes one OrderItemGroupDto seeded with its parent line plus accessories.
         var itemsSw = Stopwatch.StartNew();
         var itemGroups = new List<OrderItemGroupDto>();
-        await using (var cmd = CreateProc(conn, ItemsProcName, summary.Id))
+        await using (var cmd = CreateProc(conn, ItemsProcName, orderId))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
         {
             var displayOrder = 1;
@@ -448,7 +356,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         // Phase 5: employees.
         var empSw = Stopwatch.StartNew();
         var employees = new List<OrderEmployeeDto>();
-        await using (var cmd = CreateProc(conn, EmployeesProcName, summary.Id))
+        await using (var cmd = CreateProc(conn, EmployeesProcName, orderId))
         await using (var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false))
         {
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
@@ -473,14 +381,14 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
 
         _logger.LogInformation(
             "[SalesPerf] sql.GetOrderDetails number={Number} found=True items={ItemGroups} accessories={AccessoryItems} employees={EmployeeCount} " +
-            "lookupMs={LookupMs} openMs={OpenMs} headerMs={HeaderMs} accMs={AccMs} itemsMs={ItemsMs} empMs={EmpMs} totalMs={TotalMs}",
+            "lookupMs={LookupMs} summaryMs={SummaryMs} openMs={OpenMs} headerMs={HeaderMs} accMs={AccMs} itemsMs={ItemsMs} empMs={EmpMs} totalMs={TotalMs}",
             number, itemGroups.Count, accessoriesByItemId.Sum(kv => kv.Value.Count), employees.Count,
-            lookupSw.ElapsedMilliseconds, openSw.ElapsedMilliseconds, headerSw.ElapsedMilliseconds,
-            accSw.ElapsedMilliseconds, itemsSw.ElapsedMilliseconds, empSw.ElapsedMilliseconds,
-            totalSw.ElapsedMilliseconds);
+            lookupSw.ElapsedMilliseconds, summarySw.ElapsedMilliseconds, openSw.ElapsedMilliseconds,
+            headerSw.ElapsedMilliseconds, accSw.ElapsedMilliseconds, itemsSw.ElapsedMilliseconds,
+            empSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
 
         return new OrderDetailsDto(
-            Id:         summary.Id,
+            Id:         orderId,
             Number:     summary.Number,
             Date:       summary.Date,
             Price:      summary.Price,
@@ -501,218 +409,82 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
     }
 
     /// <summary>
-    /// Reads <c>dbo.weblb_Orders</c> in full and projects each row to an
-    /// <see cref="OrderSummaryDto"/>. Column reads are by ordinal because the
-    /// legacy proc has no documented column-name contract — the indexes match
-    /// the legacy <c>OrdersController</c>'s <c>GetX(n)</c> calls one-for-one.
+    /// Pulls a single-row summary from <c>dbo.weblb_Orders_Paged</c> by passing
+    /// the human-readable order number through as the <c>@Search</c> filter
+    /// (LIKE-search on Number / Customer / Address). Filtered to one row by
+    /// <c>@PageSize = 1</c>, then post-filtered to the exact match in C# so a
+    /// substring collision (e.g. another order whose Customer text contains
+    /// our number) cannot win.
     /// </summary>
-    /// <summary>
-    /// Returns the materialised <c>dbo.weblb_Orders</c> result set, served from
-    /// an in-process snapshot whose lifetime is bounded by
-    /// <see cref="SalesSqlOptions.OrdersListCacheTtlSeconds"/>. Behind a
-    /// <see cref="SemaphoreSlim"/>: while one caller is fetching a fresh
-    /// snapshot, every concurrent caller waits and then reuses the same
-    /// list (single-flight). Set the TTL to <c>0</c> to disable the cache
-    /// and read from SQL on every call.
-    /// </summary>
-    private async Task<List<OrderSummaryDto>> ReadAllOrdersAsync(CancellationToken cancellationToken)
+    private async Task<OrderSummaryDto?> ReadSummaryByNumberAsync(
+        SqlConnection conn,
+        string number,
+        CancellationToken cancellationToken)
     {
-        var ttlSeconds = _options.OrdersListCacheTtlSeconds;
-        if (ttlSeconds <= 0)
-        {
-            // Caching disabled — preserve original "fresh SQL on every call"
-            // behaviour. Useful for diagnostics and once a paged proc wrapper
-            // makes the in-process snapshot obsolete.
-            _logger.LogDebug("[SalesPerf] sql.cache disabled ttlSec={TtlSeconds}", ttlSeconds);
-            return await LoadAllOrdersFromSqlAsync(cancellationToken).ConfigureAwait(false);
-        }
-
-        // Fast-path: snapshot still fresh, no lock needed. Reads of the two
-        // fields are independently atomic on .NET 8 (reference + DateTime is
-        // 8 bytes), so worst case we serve a snapshot that just expired —
-        // identical to the post-lock branch under contention.
-        var nowUtc = DateTime.UtcNow;
-        var snapshotRows = _snapshotRows;
-        var snapshotExpiresUtc = _snapshotExpiresUtc;
-        if (nowUtc < snapshotExpiresUtc)
-        {
-            var ageMs = (long)(nowUtc - (snapshotExpiresUtc - TimeSpan.FromSeconds(ttlSeconds))).TotalMilliseconds;
-            _logger.LogInformation(
-                "[SalesPerf] sql.cache hit rows={Rows} ageMs={AgeMs} remainingMs={RemainingMs}",
-                snapshotRows.Count, ageMs, (long)(snapshotExpiresUtc - nowUtc).TotalMilliseconds);
-            return snapshotRows;
-        }
-
-        // Slow-path: stale or first call. Single-flight via SemaphoreSlim —
-        // only one caller fetches; the rest wait then return the new snapshot.
-        await _snapshotGate.WaitAsync(cancellationToken).ConfigureAwait(false);
-        try
-        {
-            // Double-check: another caller may have refreshed the snapshot
-            // while we were waiting on the semaphore. If so, return that.
-            nowUtc = DateTime.UtcNow;
-            if (nowUtc < _snapshotExpiresUtc)
-            {
-                _logger.LogInformation(
-                    "[SalesPerf] sql.cache hit-after-wait rows={Rows} remainingMs={RemainingMs}",
-                    _snapshotRows.Count, (long)(_snapshotExpiresUtc - nowUtc).TotalMilliseconds);
-                return _snapshotRows;
-            }
-
-            var fresh = await LoadAllOrdersFromSqlAsync(cancellationToken).ConfigureAwait(false);
-            _snapshotRows = fresh;
-            _snapshotExpiresUtc = DateTime.UtcNow.AddSeconds(ttlSeconds);
-
-            _logger.LogInformation(
-                "[SalesPerf] sql.cache miss rows={Rows} ttlSec={TtlSeconds} expiresAtUtc={ExpiresAtUtc:O}",
-                fresh.Count, ttlSeconds, _snapshotExpiresUtc);
-            return fresh;
-        }
-        finally
-        {
-            _snapshotGate.Release();
-        }
-    }
-
-    private async Task<List<OrderSummaryDto>> LoadAllOrdersFromSqlAsync(CancellationToken cancellationToken)
-    {
-        // Phase 0 instrumentation — split SQL into Open / Exec (TTFB)
-        // / Materialise so we can tell *where* the time is going. These
-        // segments are cheap (Stopwatch.GetTimestamp() ticks) and emitted
-        // at Debug level only — the parent GetOrders/GetFilterOptions
-        // method already logs the rolled-up sqlMs at Information.
-        var rows = new List<OrderSummaryDto>(capacity: 1024);
-        var totalSw = Stopwatch.StartNew();
-
-        var openSw = Stopwatch.StartNew();
-        await using var conn = new SqlConnection(_options.ConnectionString);
-        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
-        openSw.Stop();
-
-        await using var cmd = new SqlCommand(OrdersProcName, conn)
+        await using var cmd = new SqlCommand(OrdersPagedProcName, conn)
         {
             CommandType    = CommandType.StoredProcedure,
             CommandTimeout = _options.CommandTimeoutSeconds,
         };
+        cmd.Parameters.Add(new SqlParameter("@Page",     SqlDbType.Int)            { Value = 1 });
+        cmd.Parameters.Add(new SqlParameter("@PageSize", SqlDbType.Int)            { Value = 5 });
+        cmd.Parameters.Add(new SqlParameter("@Search",   SqlDbType.NVarChar, 200)  { Value = number });
+        cmd.Parameters.Add(new SqlParameter("@Status",   SqlDbType.NVarChar, 100)  { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@Store",    SqlDbType.NVarChar, 100)  { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@HasDebt",  SqlDbType.Bit)            { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateFrom", SqlDbType.Date)           { Value = DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@DateTo",   SqlDbType.Date)           { Value = DBNull.Value });
 
-        var execSw = Stopwatch.StartNew();
         await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
-        execSw.Stop();
-
-        var fieldCount = reader.FieldCount;
-        var matSw = Stopwatch.StartNew();
-
         while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
         {
-            var id             = ReadInt64ByOrdinal(reader, ordinal: 0);
-            var number         = ReadStringByOrdinal(reader, ordinal: 1, fallback: string.Empty);
-            var date           = ReadDateOnlyByOrdinal(reader, ordinal: 2);
-            var price          = ReadDecimalByOrdinal(reader, ordinal: 3);
-            var debt           = ReadDecimalByOrdinal(reader, ordinal: 4);
-            var customer       = ReadStringByOrdinal(reader, ordinal: 5, fallback: string.Empty);
-            var status         = ReadStringByOrdinal(reader, ordinal: 6, fallback: string.Empty);
-            var store          = ReadStringByOrdinal(reader, ordinal: 7, fallback: string.Empty);
-            // ordinals 8 and 9 are unused by the legacy controller — possibly
-            // IsVip / HasNote / DueDate. To be confirmed with the DBA.
-            var address        = fieldCount > 10
-                ? ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty)
-                : string.Empty;
-            var productsSearch = fieldCount > 11
-                ? ReadStringOrNullByOrdinal(reader, ordinal: 11)
-                : null;
-
-            rows.Add(new OrderSummaryDto(
-                Id:             id,
-                Number:         number,
-                Date:           date,
-                Price:          price,
-                Debt:           debt,
-                IsOverdue:      false,
-                Customer:       customer,
-                HasDebt:        debt > 0m,
-                IsVip:          false,
-                HasNote:        false,
-                Status:         status,
-                StatusCode:     SalesOrderStatusMap.ToStatusCode(status),
-                Store:          store,
-                Address:        address,
-                ProductsSearch: productsSearch));
+            var summary = ReadOrderSummary(reader);
+            if (string.Equals(summary.Number, number, StringComparison.OrdinalIgnoreCase))
+            {
+                return summary;
+            }
         }
-        matSw.Stop();
-        totalSw.Stop();
-
-        _logger.LogDebug(
-            "[SalesPerf] sql.weblb_Orders rows={Rows} openMs={OpenMs} execMs={ExecMs} materialiseMs={MaterialiseMs} totalMs={TotalMs}",
-            rows.Count, openSw.ElapsedMilliseconds, execSw.ElapsedMilliseconds,
-            matSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-
-        return rows;
+        return null;
     }
 
     /// <summary>
-    /// Applies the in-memory equivalent of the legacy WHERE / ORDER BY / TOP
-    /// clauses to the materialised order list. Mirrors the contract documented
-    /// on <see cref="OrdersQueryParams"/> and lets the WebUI render real paging
-    /// metadata (Total / Page / PageSize) without an extra count round-trip.
+    /// Projects a row of <c>dbo.weblb_Orders_Paged</c> output into the
+    /// <see cref="OrderSummaryDto"/> shape the WebUI expects. Column ordinals
+    /// are kept in sync with the SP definition (see <c>.scratch/sp-paged.sql</c>).
     /// </summary>
-    private static PagedResult<OrderSummaryDto> ApplyFilterSortPage(
-        IReadOnlyList<OrderSummaryDto> all,
-        OrdersQueryParams query)
+    private static OrderSummaryDto ReadOrderSummary(SqlDataReader reader)
     {
-        IEnumerable<OrderSummaryDto> filtered = all;
+        var debt = ReadDecimalByOrdinal(reader, ordinal: 4);
+        var status = ReadStringByOrdinal(reader, ordinal: 6, fallback: string.Empty);
 
-        if (!string.IsNullOrWhiteSpace(query.Search))
-        {
-            var needle = query.Search.Trim();
-            filtered = filtered.Where(o =>
-                o.Number.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
-                o.Customer.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
-                o.Address.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
-                (o.ProductsSearch is { Length: > 0 } &&
-                    o.ProductsSearch.Contains(needle, StringComparison.OrdinalIgnoreCase)));
-        }
-
-        // Trim both sides — legacy nchar/char columns are right-padded with
-        // spaces, which would otherwise make an exact-equality dropdown filter
-        // silently return zero rows.
-        if (!string.IsNullOrWhiteSpace(query.Status))
-        {
-            var status = query.Status.Trim();
-            filtered = filtered.Where(o =>
-                string.Equals(o.Status?.Trim(), status, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (!string.IsNullOrWhiteSpace(query.Store))
-        {
-            var store = query.Store.Trim();
-            filtered = filtered.Where(o =>
-                string.Equals(o.Store?.Trim(), store, StringComparison.OrdinalIgnoreCase));
-        }
-
-        if (query.HasDebt)
-        {
-            filtered = filtered.Where(o => o.HasDebt);
-        }
-
-        // S-2 ignores the Date preset on purpose — the legacy proc has no date
-        // range parameter and a real range arrives once a paged proc wrapper
-        // exists. Until then the WebUI keeps that selector disabled.
-
-        var sorted = filtered
-            .OrderByDescending(o => o.Date)
-            .ThenByDescending(o => o.Number, StringComparer.Ordinal)
-            .ToList();
-
-        var pageSize = query.PageSize <= 0 ? 100 : query.PageSize;
-        var page     = query.Page     <= 0 ? 1   : query.Page;
-
-        var paged = sorted
-            .Skip((page - 1) * pageSize)
-            .Take(pageSize)
-            .ToList();
-
-        return new PagedResult<OrderSummaryDto>(paged, sorted.Count, page, pageSize);
+        return new OrderSummaryDto(
+            Id:             ReadInt64ByOrdinal(reader, ordinal: 0),
+            Number:         ReadStringByOrdinal(reader, ordinal: 1, fallback: string.Empty),
+            Date:           ReadDateOnlyByOrdinal(reader, ordinal: 2),
+            Price:          ReadDecimalByOrdinal(reader, ordinal: 3),
+            Debt:           debt,
+            IsOverdue:      false,
+            Customer:       ReadStringByOrdinal(reader, ordinal: 5, fallback: string.Empty),
+            HasDebt:        debt > 0m,
+            IsVip:          false,
+            HasNote:        false,
+            Status:         status,
+            StatusCode:     SalesOrderStatusMap.ToStatusCode(status),
+            Store:          ReadStringByOrdinal(reader, ordinal: 7, fallback: string.Empty),
+            // ordinals 8 (IsCancelled) and 9 (sImageKey) are returned by the
+            // SP but currently unused by the C# DTO — left in the result set
+            // for parity with the legacy weblb_Orders shape.
+            Address:        ReadStringByOrdinal(reader, ordinal: 10, fallback: string.Empty),
+            ProductsSearch: ReadStringOrNullByOrdinal(reader, ordinal: 11));
     }
+
+    /// <summary>
+    /// SQL parameter helper: emit <see cref="DBNull.Value"/> for null / blank
+    /// strings so the SP's <c>IS NULL</c> branches fire instead of looking
+    /// for the literal <c>N''</c>.
+    /// </summary>
+    private static object NullableNVarChar(string? value)
+        => string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
 
     private SqlCommand CreateProc(SqlConnection conn, string procName, long orderId)
     {
@@ -830,7 +602,7 @@ public sealed class SqlOrdersQueryService : IOrdersQueryService
         if (lower.Contains("montuot") || lower.Contains("install"))     return "mont";
         if (lower.Contains("transport"))                                return "trans";
 
-        return string.Empty; // neutral dot — keeps the row legible without guessing
+        return string.Empty;
     }
 
     private static DateOnly? ParseLegacyDate(string? text)

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -1,6 +1,7 @@
 @page "/"
 @inject SalesApiClient Api
 @inject PersistentComponentState ApplicationState
+@inject ILogger<Index> Log
 @implements IAsyncDisposable
 
 <PageTitle>Sales · Orders</PageTitle>
@@ -194,7 +195,18 @@
 @code {
     private const int    PageSize             = 100;
     private const int    SearchDebounceMs     = 250;
-    private const int    LoadingMinVisibleMs  = 200; // floor for the loading bar
+
+    // Loading-bar UX: skip the indicator entirely when the API responds within
+    // LoadingShowAfterMs (e.g. snapshot cache hit ≈ 12 ms — showing a bar would
+    // make a near-instant page feel slow). If the response *does* take longer,
+    // surface the bar and keep it on screen for at least LoadingMinVisibleMs
+    // total so it never flashes on/off in a single frame.
+    //
+    // Numbers: 150 ms is the lower bound where humans start perceiving lag;
+    // a 350 ms minimum visible window lets the eye lock onto the bar without
+    // creating a "double-blink" effect on borderline-slow responses.
+    private const int    LoadingShowAfterMs   = 150;
+    private const int    LoadingMinVisibleMs  = 350;
     private const string PersistKeyOrders     = "sales.orders.list";
     private const string PersistKeyFilters    = "sales.orders.filterOptions";
 
@@ -543,8 +555,9 @@
         var token = _reloadCts.Token;
 
         var thisReloadId = ++_latestReloadId;
-        _isRefreshing = true;
-        StateHasChanged(); // immediately show progress bar / dim rows
+        // NOTE: do NOT flip _isRefreshing here. We schedule it after
+        // LoadingShowAfterMs so a fast (cache-hit) response never paints
+        // a loading bar at all — page changes feel instant.
 
         var query = new OrdersQueryParams
         {
@@ -557,26 +570,71 @@
             PageSize = _pageSize,
         };
 
+        // Phase 0 instrumentation: end-to-end ReloadAsync timing as the user
+        // experiences it. apiMs is the real cost; barShown reveals when the
+        // loading affordance was actually painted (vs skipped for a fast hit).
+        var totalSw = System.Diagnostics.Stopwatch.StartNew();
+        var apiSw = System.Diagnostics.Stopwatch.StartNew();
         PagedResult<OrderSummaryDto>? result;
+        long apiOnlyMs;
+        var barShown = false;
+        long? barShownAtMs = null;
         try
         {
-            // Run the API call in parallel with a minimum-visibility delay so
-            // very fast responses still leave the loading bar on screen long
-            // enough for the user to register that the click was registered.
-            // The delay is cancelled along with the API call when superseded.
-            var apiTask   = Api.GetOrdersAsync(query, token);
-            var floorTask = Task.Delay(LoadingMinVisibleMs, token);
-            await Task.WhenAll(apiTask, floorTask);
+            // Race the API call against a "show loading bar" delay. If the API
+            // responds first (cache hit, fast network), no bar is ever shown.
+            // Otherwise, flip _isRefreshing once and force a re-render so the
+            // bar appears, then keep it visible for the rest of the call.
+            var apiTask  = Api.GetOrdersAsync(query, token);
+            var showTask = Task.Delay(LoadingShowAfterMs, token);
+
+            var winner = await Task.WhenAny(apiTask, showTask);
+            if (winner == showTask && !showTask.IsCanceled)
+            {
+                _isRefreshing = true;
+                barShown = true;
+                barShownAtMs = totalSw.ElapsedMilliseconds;
+                StateHasChanged();
+            }
+
             result = await apiTask;
+            apiSw.Stop();
+            apiOnlyMs = apiSw.ElapsedMilliseconds;
+
+            // If the bar did appear, keep it visible long enough that the user
+            // actually registers it — otherwise it would flash off the moment
+            // the API finished, which feels glitchy.
+            if (barShown && barShownAtMs is { } shownAt)
+            {
+                var visibleSoFar = totalSw.ElapsedMilliseconds - shownAt;
+                var remaining = LoadingMinVisibleMs - (int)visibleSoFar;
+                if (remaining > 0)
+                {
+                    try { await Task.Delay(remaining, token); }
+                    catch (OperationCanceledException) { /* superseded; fall through */ }
+                }
+            }
         }
         catch (OperationCanceledException)
         {
+            apiSw.Stop();
+            totalSw.Stop();
+            Log.LogDebug(
+                "[SalesPerf] webui ReloadAsync cancelled reloadId={ReloadId} elapsedMs={ElapsedMs}",
+                thisReloadId, totalSw.ElapsedMilliseconds);
             return; // superseded
         }
 
         // Stale-response guard: if a newer request started while we were waiting,
         // discard this result quietly without touching shared state.
-        if (thisReloadId != _latestReloadId) return;
+        if (thisReloadId != _latestReloadId)
+        {
+            totalSw.Stop();
+            Log.LogDebug(
+                "[SalesPerf] webui ReloadAsync superseded reloadId={ReloadId} latest={Latest} elapsedMs={ElapsedMs}",
+                thisReloadId, _latestReloadId, totalSw.ElapsedMilliseconds);
+            return;
+        }
 
         if (result is null)
         {
@@ -603,6 +661,17 @@
 
         _isRefreshing = false;
         _hasEverLoaded = true;
+        totalSw.Stop();
+
+        Log.LogInformation(
+            "[SalesPerf] webui ReloadAsync done reloadId={ReloadId} page={Page} pageSize={PageSize} returned={Returned} total={Total} " +
+            "search={HasSearch} status={HasStatus} store={HasStore} hasDebt={HasDebt} loadFailed={LoadFailed} " +
+            "apiMs={ApiMs} barShown={BarShown} elapsedMs={ElapsedMs}",
+            thisReloadId, _page, _pageSize, _orders.Count, _total,
+            !string.IsNullOrWhiteSpace(_search), !string.IsNullOrEmpty(_statusFilter),
+            !string.IsNullOrEmpty(_storeFilter), _hasDebtFilter, _loadFailed,
+            apiOnlyMs, barShown, totalSw.ElapsedMilliseconds);
+
         StateHasChanged();
     }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -578,48 +578,18 @@
         PagedResult<OrderSummaryDto>? result;
         long apiOnlyMs;
         var barShown = false;
-        long? barShownAtMs = null;
         try
         {
-            // Race the API call against a "show loading bar" delay. If the API
-            // responds first (cache hit, fast network), no bar is ever shown.
-            // Otherwise, flip _isRefreshing once and force a re-render so the
-            // bar appears, then keep it visible for the rest of the call.
-            var apiTask  = Api.GetOrdersAsync(query, token);
-            var showTask = Task.Delay(LoadingShowAfterMs, token);
-
-            var winner = await Task.WhenAny(apiTask, showTask);
-            if (winner == showTask && !showTask.IsCanceled)
-            {
-                _isRefreshing = true;
-                barShown = true;
-                barShownAtMs = totalSw.ElapsedMilliseconds;
-                StateHasChanged();
-            }
-
-            result = await apiTask;
+            (result, barShown) = await FetchWithDeferredLoadingBarAsync(query, totalSw, token);
             apiSw.Stop();
             apiOnlyMs = apiSw.ElapsedMilliseconds;
-
-            // If the bar did appear, keep it visible long enough that the user
-            // actually registers it — otherwise it would flash off the moment
-            // the API finished, which feels glitchy.
-            if (barShown && barShownAtMs is { } shownAt)
-            {
-                var visibleSoFar = totalSw.ElapsedMilliseconds - shownAt;
-                var remaining = LoadingMinVisibleMs - (int)visibleSoFar;
-                if (remaining > 0)
-                {
-                    try { await Task.Delay(remaining, token); }
-                    catch (OperationCanceledException) { /* superseded; fall through */ }
-                }
-            }
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException ex)
         {
             apiSw.Stop();
             totalSw.Stop();
             Log.LogDebug(
+                ex,
                 "[SalesPerf] webui ReloadAsync cancelled reloadId={ReloadId} elapsedMs={ElapsedMs}",
                 thisReloadId, totalSw.ElapsedMilliseconds);
             return; // superseded
@@ -673,5 +643,48 @@
             apiOnlyMs, barShown, totalSw.ElapsedMilliseconds);
 
         StateHasChanged();
+    }
+
+    /// <summary>
+    /// Races the orders API call against a "show loading bar" delay so a fast
+    /// (cache-hit) response never paints a loading affordance, while a slow one
+    /// still gets a stable bar that stays visible for at least
+    /// <see cref="LoadingMinVisibleMs"/>. Returns the fetched page (may be
+    /// <c>null</c> if the API client signals failure) plus whether the bar was
+    /// actually shown so the caller can attribute timings in the perf log.
+    /// </summary>
+    private async Task<(PagedResult<OrderSummaryDto>? Result, bool BarShown)> FetchWithDeferredLoadingBarAsync(
+        OrdersQueryParams query,
+        System.Diagnostics.Stopwatch totalSw,
+        CancellationToken token)
+    {
+        var apiTask  = Api.GetOrdersAsync(query, token);
+        var showTask = Task.Delay(LoadingShowAfterMs, token);
+
+        long? barShownAtMs = null;
+        if (await Task.WhenAny(apiTask, showTask) == showTask && !showTask.IsCanceled)
+        {
+            _isRefreshing = true;
+            barShownAtMs = totalSw.ElapsedMilliseconds;
+            StateHasChanged();
+        }
+
+        var result = await apiTask;
+
+        if (barShownAtMs is { } shownAt)
+        {
+            // Once the bar is up, keep it visible long enough to register —
+            // otherwise it flashes off the moment the API completes, which
+            // feels glitchy. Cancellation here just means we were superseded;
+            // the caller will return early on the stale-response guard.
+            var remaining = LoadingMinVisibleMs - (int)(totalSw.ElapsedMilliseconds - shownAt);
+            if (remaining > 0)
+            {
+                try { await Task.Delay(remaining, token); }
+                catch (OperationCanceledException) { /* superseded; fall through */ }
+            }
+        }
+
+        return (result, barShownAtMs is not null);
     }
 }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Net;
 using System.Net.Http.Json;
 using LKvitai.MES.Modules.Sales.Contracts.Common;
@@ -62,25 +63,44 @@ public sealed class SalesApiClient
         var client = _httpClientFactory.CreateClient(HttpClientName);
         var url = BuildOrdersListUrl(query);
 
+        var totalSw = Stopwatch.StartNew();
+        var httpSw = Stopwatch.StartNew();
         try
         {
             using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            httpSw.Stop();
+
             if (!response.IsSuccessStatusCode)
             {
+                totalSw.Stop();
                 _logger.LogWarning(
-                    "Sales API returned {StatusCode} for {Url}",
-                    response.StatusCode,
-                    url);
+                    "[SalesPerf] webui-http GET orders failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
+                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
                 return null;
             }
 
-            return await response.Content
+            var deserSw = Stopwatch.StartNew();
+            var body = await response.Content
                 .ReadFromJsonAsync<PagedResult<OrderSummaryDto>>(cancellationToken)
                 .ConfigureAwait(false);
+            deserSw.Stop();
+            totalSw.Stop();
+
+            _logger.LogInformation(
+                "[SalesPerf] webui-http GET orders ok page={Page} pageSize={PageSize} returned={Returned} total={Total} " +
+                "httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
+                query.Page, query.PageSize, body?.Items.Count ?? 0, body?.Total ?? 0,
+                httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds,
+                response.Content.Headers.ContentLength ?? -1);
+
+            return body;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            _logger.LogError(ex, "Sales API call to {Url} failed", url);
+            totalSw.Stop();
+            _logger.LogError(ex,
+                "[SalesPerf] webui-http GET orders exception url={Url} totalMs={TotalMs}",
+                url, totalSw.ElapsedMilliseconds);
             return null;
         }
     }
@@ -102,26 +122,42 @@ public sealed class SalesApiClient
         var client = _httpClientFactory.CreateClient(HttpClientName);
         var url = $"/api/sales/orders/{Uri.EscapeDataString(number)}";
 
+        var totalSw = Stopwatch.StartNew();
+        var httpSw = Stopwatch.StartNew();
         try
         {
             using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            httpSw.Stop();
+
             if (response.StatusCode == HttpStatusCode.NotFound)
             {
+                totalSw.Stop();
+                _logger.LogInformation(
+                    "[SalesPerf] webui-http GET order not-found number={Number} httpMs={HttpMs} totalMs={TotalMs}",
+                    number, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
                 return SalesApiResult<OrderDetailsDto>.NotFound();
             }
 
             if (!response.IsSuccessStatusCode)
             {
+                totalSw.Stop();
                 _logger.LogWarning(
-                    "Sales API returned {StatusCode} for {Url}",
-                    response.StatusCode,
-                    url);
+                    "[SalesPerf] webui-http GET order failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
+                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
                 return SalesApiResult<OrderDetailsDto>.Failed();
             }
 
+            var deserSw = Stopwatch.StartNew();
             var body = await response.Content
                 .ReadFromJsonAsync<OrderDetailsDto>(cancellationToken)
                 .ConfigureAwait(false);
+            deserSw.Stop();
+            totalSw.Stop();
+
+            _logger.LogInformation(
+                "[SalesPerf] webui-http GET order ok number={Number} found={Found} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
+                number, body is not null, httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds,
+                totalSw.ElapsedMilliseconds, response.Content.Headers.ContentLength ?? -1);
 
             return body is null
                 ? SalesApiResult<OrderDetailsDto>.Failed()
@@ -129,7 +165,10 @@ public sealed class SalesApiClient
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            _logger.LogError(ex, "Sales API call to {Url} failed", url);
+            totalSw.Stop();
+            _logger.LogError(ex,
+                "[SalesPerf] webui-http GET order exception url={Url} totalMs={TotalMs}",
+                url, totalSw.ElapsedMilliseconds);
             return SalesApiResult<OrderDetailsDto>.Failed();
         }
     }
@@ -145,25 +184,42 @@ public sealed class SalesApiClient
         var client = _httpClientFactory.CreateClient(HttpClientName);
         const string url = "/api/sales/orders/filters";
 
+        var totalSw = Stopwatch.StartNew();
+        var httpSw = Stopwatch.StartNew();
         try
         {
             using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
+            httpSw.Stop();
+
             if (!response.IsSuccessStatusCode)
             {
+                totalSw.Stop();
                 _logger.LogWarning(
-                    "Sales API returned {StatusCode} for {Url}",
-                    response.StatusCode,
-                    url);
+                    "[SalesPerf] webui-http GET filters failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
+                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
                 return null;
             }
 
-            return await response.Content
+            var deserSw = Stopwatch.StartNew();
+            var body = await response.Content
                 .ReadFromJsonAsync<OrdersFilterOptionsDto>(cancellationToken)
                 .ConfigureAwait(false);
+            deserSw.Stop();
+            totalSw.Stop();
+
+            _logger.LogInformation(
+                "[SalesPerf] webui-http GET filters ok statuses={StatusCount} stores={StoreCount} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs}",
+                body?.Statuses.Count ?? 0, body?.Stores.Count ?? 0,
+                httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+
+            return body;
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
-            _logger.LogError(ex, "Sales API call to {Url} failed", url);
+            totalSw.Stop();
+            _logger.LogError(ex,
+                "[SalesPerf] webui-http GET filters exception url={Url} totalMs={TotalMs}",
+                url, totalSw.ElapsedMilliseconds);
             return null;
         }
     }

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Services/SalesApiClient.cs
@@ -51,6 +51,27 @@ public sealed class SalesApiClient
     }
 
     /// <summary>
+    /// Captures the outcome of one <see cref="HttpClient.GetAsync(string)"/>
+    /// + <c>ReadFromJsonAsync</c> round-trip plus the per-phase timings the
+    /// <c>[SalesPerf]</c> log lines surface. Designed so callers log the
+    /// success line themselves with their own structured fields, while the
+    /// generic transport / non-success branches stay in <see cref="SendJsonGetAsync{T}"/>.
+    /// </summary>
+    private readonly record struct ApiFetch<T>(
+        HttpStatusCode Status,
+        T? Body,
+        long HttpMs,
+        long DeserMs,
+        long TotalMs,
+        long ContentLength,
+        bool TransportFailed)
+    {
+        public bool IsSuccess => !TransportFailed
+            && (int)Status >= 200
+            && (int)Status < 300;
+    }
+
+    /// <summary>
     /// Fetches a page of order summaries from <c>GET /api/sales/orders</c>.
     /// Returns <c>null</c> when the API is unreachable or returns a non-success status.
     /// </summary>
@@ -60,49 +81,19 @@ public sealed class SalesApiClient
     {
         ArgumentNullException.ThrowIfNull(query);
 
-        var client = _httpClientFactory.CreateClient(HttpClientName);
         var url = BuildOrdersListUrl(query);
+        var fetch = await SendJsonGetAsync<PagedResult<OrderSummaryDto>>(url, opLabel: "orders", cancellationToken)
+            .ConfigureAwait(false);
 
-        var totalSw = Stopwatch.StartNew();
-        var httpSw = Stopwatch.StartNew();
-        try
-        {
-            using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
-            httpSw.Stop();
+        if (!fetch.IsSuccess) return null;
 
-            if (!response.IsSuccessStatusCode)
-            {
-                totalSw.Stop();
-                _logger.LogWarning(
-                    "[SalesPerf] webui-http GET orders failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
-                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-                return null;
-            }
+        _logger.LogInformation(
+            "[SalesPerf] webui-http GET orders ok page={Page} pageSize={PageSize} returned={Returned} total={Total} " +
+            "httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
+            query.Page, query.PageSize, fetch.Body?.Items.Count ?? 0, fetch.Body?.Total ?? 0,
+            fetch.HttpMs, fetch.DeserMs, fetch.TotalMs, fetch.ContentLength);
 
-            var deserSw = Stopwatch.StartNew();
-            var body = await response.Content
-                .ReadFromJsonAsync<PagedResult<OrderSummaryDto>>(cancellationToken)
-                .ConfigureAwait(false);
-            deserSw.Stop();
-            totalSw.Stop();
-
-            _logger.LogInformation(
-                "[SalesPerf] webui-http GET orders ok page={Page} pageSize={PageSize} returned={Returned} total={Total} " +
-                "httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
-                query.Page, query.PageSize, body?.Items.Count ?? 0, body?.Total ?? 0,
-                httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds,
-                response.Content.Headers.ContentLength ?? -1);
-
-            return body;
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-        {
-            totalSw.Stop();
-            _logger.LogError(ex,
-                "[SalesPerf] webui-http GET orders exception url={Url} totalMs={TotalMs}",
-                url, totalSw.ElapsedMilliseconds);
-            return null;
-        }
+        return fetch.Body;
     }
 
     /// <summary>
@@ -119,58 +110,27 @@ public sealed class SalesApiClient
             return SalesApiResult<OrderDetailsDto>.NotFound();
         }
 
-        var client = _httpClientFactory.CreateClient(HttpClientName);
         var url = $"/api/sales/orders/{Uri.EscapeDataString(number)}";
+        var fetch = await SendJsonGetAsync<OrderDetailsDto>(url, opLabel: "order", cancellationToken)
+            .ConfigureAwait(false);
 
-        var totalSw = Stopwatch.StartNew();
-        var httpSw = Stopwatch.StartNew();
-        try
+        if (fetch.Status == HttpStatusCode.NotFound)
         {
-            using var response = await client.GetAsync(url, cancellationToken).ConfigureAwait(false);
-            httpSw.Stop();
-
-            if (response.StatusCode == HttpStatusCode.NotFound)
-            {
-                totalSw.Stop();
-                _logger.LogInformation(
-                    "[SalesPerf] webui-http GET order not-found number={Number} httpMs={HttpMs} totalMs={TotalMs}",
-                    number, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-                return SalesApiResult<OrderDetailsDto>.NotFound();
-            }
-
-            if (!response.IsSuccessStatusCode)
-            {
-                totalSw.Stop();
-                _logger.LogWarning(
-                    "[SalesPerf] webui-http GET order failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
-                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-                return SalesApiResult<OrderDetailsDto>.Failed();
-            }
-
-            var deserSw = Stopwatch.StartNew();
-            var body = await response.Content
-                .ReadFromJsonAsync<OrderDetailsDto>(cancellationToken)
-                .ConfigureAwait(false);
-            deserSw.Stop();
-            totalSw.Stop();
-
             _logger.LogInformation(
-                "[SalesPerf] webui-http GET order ok number={Number} found={Found} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
-                number, body is not null, httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds,
-                totalSw.ElapsedMilliseconds, response.Content.Headers.ContentLength ?? -1);
+                "[SalesPerf] webui-http GET order not-found number={Number} httpMs={HttpMs} totalMs={TotalMs}",
+                number, fetch.HttpMs, fetch.TotalMs);
+            return SalesApiResult<OrderDetailsDto>.NotFound();
+        }
 
-            return body is null
-                ? SalesApiResult<OrderDetailsDto>.Failed()
-                : SalesApiResult<OrderDetailsDto>.Ok(body);
-        }
-        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
-        {
-            totalSw.Stop();
-            _logger.LogError(ex,
-                "[SalesPerf] webui-http GET order exception url={Url} totalMs={TotalMs}",
-                url, totalSw.ElapsedMilliseconds);
-            return SalesApiResult<OrderDetailsDto>.Failed();
-        }
+        if (!fetch.IsSuccess) return SalesApiResult<OrderDetailsDto>.Failed();
+
+        _logger.LogInformation(
+            "[SalesPerf] webui-http GET order ok number={Number} found={Found} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs} contentLength={ContentLength}",
+            number, fetch.Body is not null, fetch.HttpMs, fetch.DeserMs, fetch.TotalMs, fetch.ContentLength);
+
+        return fetch.Body is null
+            ? SalesApiResult<OrderDetailsDto>.Failed()
+            : SalesApiResult<OrderDetailsDto>.Ok(fetch.Body);
     }
 
     /// <summary>
@@ -181,8 +141,33 @@ public sealed class SalesApiClient
     /// </summary>
     public async Task<OrdersFilterOptionsDto?> GetFilterOptionsAsync(CancellationToken cancellationToken)
     {
-        var client = _httpClientFactory.CreateClient(HttpClientName);
         const string url = "/api/sales/orders/filters";
+        var fetch = await SendJsonGetAsync<OrdersFilterOptionsDto>(url, opLabel: "filters", cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!fetch.IsSuccess) return null;
+
+        _logger.LogInformation(
+            "[SalesPerf] webui-http GET filters ok statuses={StatusCount} stores={StoreCount} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs}",
+            fetch.Body?.Statuses.Count ?? 0, fetch.Body?.Stores.Count ?? 0,
+            fetch.HttpMs, fetch.DeserMs, fetch.TotalMs);
+
+        return fetch.Body;
+    }
+
+    /// <summary>
+    /// Common transport for every <c>GET /api/sales/...</c> call: dispatch the
+    /// request, time the HTTP and JSON-deserialise phases, and log the failure
+    /// branches once. Success logs stay with the calling method so each
+    /// endpoint emits its own structured line with the fields it cares about.
+    /// </summary>
+    private async Task<ApiFetch<T>> SendJsonGetAsync<T>(
+        string url,
+        string opLabel,
+        CancellationToken cancellationToken)
+        where T : class
+    {
+        var client = _httpClientFactory.CreateClient(HttpClientName);
 
         var totalSw = Stopwatch.StartNew();
         var httpSw = Stopwatch.StartNew();
@@ -194,33 +179,54 @@ public sealed class SalesApiClient
             if (!response.IsSuccessStatusCode)
             {
                 totalSw.Stop();
-                _logger.LogWarning(
-                    "[SalesPerf] webui-http GET filters failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
-                    response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-                return null;
+                // 404 is a legitimate outcome for the by-number lookup, so
+                // skip the warning log there — caller logs its own info line.
+                if (response.StatusCode != HttpStatusCode.NotFound)
+                {
+                    _logger.LogWarning(
+                        "[SalesPerf] webui-http GET {Op} failed status={StatusCode} url={Url} httpMs={HttpMs} totalMs={TotalMs}",
+                        opLabel, response.StatusCode, url, httpSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+                }
+                return new ApiFetch<T>(
+                    Status:           response.StatusCode,
+                    Body:             null,
+                    HttpMs:           httpSw.ElapsedMilliseconds,
+                    DeserMs:          0,
+                    TotalMs:          totalSw.ElapsedMilliseconds,
+                    ContentLength:    response.Content.Headers.ContentLength ?? -1,
+                    TransportFailed:  false);
             }
 
             var deserSw = Stopwatch.StartNew();
             var body = await response.Content
-                .ReadFromJsonAsync<OrdersFilterOptionsDto>(cancellationToken)
+                .ReadFromJsonAsync<T>(cancellationToken)
                 .ConfigureAwait(false);
             deserSw.Stop();
             totalSw.Stop();
 
-            _logger.LogInformation(
-                "[SalesPerf] webui-http GET filters ok statuses={StatusCount} stores={StoreCount} httpMs={HttpMs} deserMs={DeserMs} totalMs={TotalMs}",
-                body?.Statuses.Count ?? 0, body?.Stores.Count ?? 0,
-                httpSw.ElapsedMilliseconds, deserSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
-
-            return body;
+            return new ApiFetch<T>(
+                Status:           response.StatusCode,
+                Body:             body,
+                HttpMs:           httpSw.ElapsedMilliseconds,
+                DeserMs:          deserSw.ElapsedMilliseconds,
+                TotalMs:          totalSw.ElapsedMilliseconds,
+                ContentLength:    response.Content.Headers.ContentLength ?? -1,
+                TransportFailed:  false);
         }
         catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
         {
             totalSw.Stop();
             _logger.LogError(ex,
-                "[SalesPerf] webui-http GET filters exception url={Url} totalMs={TotalMs}",
-                url, totalSw.ElapsedMilliseconds);
-            return null;
+                "[SalesPerf] webui-http GET {Op} exception url={Url} totalMs={TotalMs}",
+                opLabel, url, totalSw.ElapsedMilliseconds);
+            return new ApiFetch<T>(
+                Status:           default,
+                Body:             null,
+                HttpMs:           httpSw.ElapsedMilliseconds,
+                DeserMs:          0,
+                TotalMs:          totalSw.ElapsedMilliseconds,
+                ContentLength:    -1,
+                TransportFailed:  true);
         }
     }
 


### PR DESCRIPTION
## Summary

Three-part change to make the Sales Orders list both observable and fast against the real legacy SQL Server.

- **Phase 0 — instrumentation.** `Stopwatch` + structured `[SalesPerf]` logs across the SQL adapter, API endpoint, WebUI HTTP client, and the Razor page so list latency can be attributed end-to-end (SQL open / exec / materialise → API → HTTP → render).
- **Phase 2 — snapshot cache.** The legacy `dbo.weblb_Orders` snapshot is kept in-process behind a `SemaphoreSlim` single-flight gate. TTL is configurable via `Sales:Sql:OrdersListCacheTtlSeconds` (default `30s`); set to `0` to disable. Concurrent page changes coalesce into one SQL call; the existing list is treated as immutable so readers can share it without copying. A startup banner reminds operators outside Development that the cache is a stop-gap.
- **Phase 3 — paged SP mode.** New `SalesSqlOptions.QueryMode` enum (`Snapshot | Paged`). When set to `Paged`, every list call invokes `dbo.weblb_Orders_Paged` (deployed separately — see `.scratch/sp-paged.sql`) with `@Page/@PageSize/@Search/@Status/@Store/@HasDebt/@DateFrom/@DateTo` and reads `TotalRows` from a windowed `COUNT(*) OVER ()`. The DB returns only the requested page; cost scales with page size, not table size. `Sales:Sql:OrdersQueryMode` defaults to `Snapshot` for safe rollback; `appsettings.Development` flips the dev API to `Paged`.

UX side: the loading bar in `Pages/Index.razor` uses a show-after pattern (150 ms gate, 350 ms minimum visible) so fast responses no longer flash the indicator.

## Local results (E2E HTTP, 22 383 orders, paged mode)

| Scenario | API SQL `execMs` | E2E HTTP |
|---|---|---|
| `p1/100` cold | 190 | 494 |
| `p1/100` warm | 311 | 320 |
| `p10/100` | 141 | 146 |
| `p100/100` | 136 | 138 |
| `p223/100` (last page, oldest order = 2020-04-24) | 109 | 112 |
| `search=VL` | 282 | 286 |
| `hasDebt=true` | 31 | 35 |
| `/filters` (snapshot, cold) | 725 | 765 |

For comparison, the original `dbo.weblb_Orders` paged-in-C# path took ~1.5 s for `p1/100` after dataset doubled with the year-clip removed.

## Notes / follow-up

- The matching `dbo.weblb_Orders_Paged` SP and `IX_Uzsakymai_UzsakymoData_DESC` index live in `.scratch/sp-paged.sql` and must be deployed to the target database **before** flipping `Sales:Sql:OrdersQueryMode` to `Paged`. The script is idempotent (`IF NOT EXISTS` for the index, `IF OBJECT_ID … DROP` then `CREATE` for the SP) and leaves the original `dbo.weblb_Orders` untouched.
- Filter dropdowns and details-by-number lookup still go through the snapshot cache regardless of `QueryMode` — they are not on the page-change hot path and benefit from the 30 s TTL.
- The snapshot startup banner now only fires when `QueryMode == Snapshot`; once `Paged` is the default everywhere we can drop both the cache and the banner.

## Test plan

- [ ] `dotnet build src/LKvitai.MES.sln -c Release` — clean (verified locally; only pre-existing warnings).
- [ ] Deploy `.scratch/sp-paged.sql` to test DB (creates `IX_Uzsakymai_UzsakymoData_DESC` + `dbo.weblb_Orders_Paged`).
- [ ] Smoke `/api/sales/orders?page=1&pageSize=100` and verify `[SalesPerf] sql.GetOrders mode=paged …` log line.
- [ ] Toggle `Sales:Sql:OrdersQueryMode` between `Snapshot` and `Paged`; confirm both paths return the same shape and the WebUI table renders identically.
- [ ] Page through to the last page in the WebUI; confirm dates extend back beyond 2022 (year-clip is removed).
- [ ] Verify the loading bar no longer flashes for sub-150 ms responses (paged mode hot cache, filter changes).
