### PR TITLE
feat(sales/orders): keyboard shortcuts on orders list (S-3.3)

### DIFF
--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Pages/Index.razor
@@ -2,6 +2,7 @@
 @inject SalesApiClient Api
 @inject PersistentComponentState ApplicationState
 @inject ILogger<Index> Log
+@inject IJSRuntime JS
 @implements IAsyncDisposable
 
 <PageTitle>Sales · Orders</PageTitle>
@@ -37,6 +38,7 @@
             <label class="field field--search">
                 <span class="key-hint" aria-hidden="true">/</span>
                 <input type="search" value="@_search" aria-label="Search orders"
+                       @ref="_searchInput"
                        @oninput="OnSearch" placeholder="Search orders" />
             </label>
 
@@ -309,6 +311,14 @@
     // PersistentComponentState subscription — disposed in DisposeAsync.
     private PersistingComponentStateSubscription _persistingSub;
 
+    // S-3.3 keyboard shortcuts. The JS module is loaded once on first render
+    // and re-used for the lifetime of the circuit; both the module reference
+    // and the .NET callback are released in DisposeAsync to avoid leaking
+    // GCHandles when the user navigates away from the orders list.
+    private ElementReference            _searchInput;
+    private IJSObjectReference?         _shortcutsModule;
+    private DotNetObjectReference<Index>? _shortcutsRef;
+
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_total / (double)_pageSize));
     private int _from       => _total == 0 ? 0 : ((_page - 1) * _pageSize) + 1;
     private int _to         => Math.Min(_page * _pageSize, _total);
@@ -464,6 +474,164 @@
             _reloadCts.Dispose();
             _reloadCts = null;
         }
+
+        // Order matters: stop dispatching first so a late JS keydown cannot
+        // hit a disposed DotNetObjectReference, then drop the module, then
+        // the .NET callback object.
+        if (_shortcutsModule is not null)
+        {
+            try   { await _shortcutsModule.InvokeVoidAsync("unregister"); }
+            catch (JSDisconnectedException)        { /* circuit already gone */ }
+            catch (TaskCanceledException)          { /* circuit already gone */ }
+            try   { await _shortcutsModule.DisposeAsync(); }
+            catch (JSDisconnectedException)        { /* circuit already gone */ }
+            catch (TaskCanceledException)          { /* circuit already gone */ }
+            _shortcutsModule = null;
+        }
+
+        _shortcutsRef?.Dispose();
+        _shortcutsRef = null;
+    }
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (!firstRender) return;
+
+        // Wrapped because OnAfterRenderAsync runs during prerender on some
+        // hosting models — calling JS there would throw InvalidOperationException
+        // ("JavaScript interop calls cannot be issued at this time"). Catching
+        // here is cheaper than gating on RendererInfo and keeps the rest of the
+        // page interactive even if the shortcut bridge fails to load.
+        try
+        {
+            _shortcutsModule = await JS.InvokeAsync<IJSObjectReference>(
+                "import", "./js/orders-shortcuts.js");
+            _shortcutsRef    = DotNetObjectReference.Create(this);
+            await _shortcutsModule.InvokeVoidAsync("register", _shortcutsRef);
+        }
+        catch (InvalidOperationException ex)
+        {
+            Log.LogDebug(ex, "[SalesShortcuts] JS interop unavailable on first render — shortcuts disabled");
+        }
+        catch (JSException ex)
+        {
+            Log.LogWarning(ex, "[SalesShortcuts] failed to load orders-shortcuts.js — keyboard shortcuts disabled");
+        }
+    }
+
+    /// <summary>
+    /// Single entry point invoked from <c>orders-shortcuts.js</c>. Action codes
+    /// are kept intentionally short ("slash", "escape", "up", "down", "enter")
+    /// so the JS bridge never has to know about C# enum values; if the codes
+    /// change here they must change in lock-step in the JS module.
+    /// </summary>
+    [JSInvokable]
+    public async Task HandleShortcut(string action)
+    {
+        switch (action)
+        {
+            case "slash":
+                try { await _searchInput.FocusAsync(); }
+                catch (JSDisconnectedException)        { /* circuit gone, ignore */ }
+                catch (InvalidOperationException)      { /* element not yet rendered */ }
+                break;
+
+            case "escape":
+                await HandleEscapeAsync();
+                break;
+
+            case "up":
+                if (MoveSelection(-1)) await ScrollSelectedIntoViewAsync();
+                break;
+
+            case "down":
+                if (MoveSelection(+1)) await ScrollSelectedIntoViewAsync();
+                break;
+
+            case "enter":
+                await OpenSelectedAsync();
+                break;
+        }
+    }
+
+    /// <summary>
+    /// Esc unifies two intents:
+    /// 1) clear an active text search (the most disruptive open filter); and
+    /// 2) deselect the current row (a softer, mostly visual reset).
+    /// We only do one of them per press so a hammered Esc does not nuke both
+    /// the search filter and the selection in the same frame, which would
+    /// feel destructive. Search clear takes precedence because it is what
+    /// stops a long-running query and "frees" the UI back to the full list.
+    /// </summary>
+    private async Task HandleEscapeAsync()
+    {
+        if (!string.IsNullOrEmpty(_search))
+        {
+            _search = "";
+            _page   = 1;
+
+            if (_searchDebounceCts is not null)
+            {
+                await _searchDebounceCts.CancelAsync();
+                _searchDebounceCts.Dispose();
+                _searchDebounceCts = null;
+            }
+
+            await ReloadAsync();
+            return;
+        }
+
+        if (_selectedId is not null)
+        {
+            _selectedId = null;
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// Returns <c>true</c> if the selection actually moved (so the caller can
+    /// decide whether to scroll). No-op on empty lists; from no selection,
+    /// ArrowDown lands on row 0 and ArrowUp on the last row, matching the
+    /// usual desktop list-box convention.
+    /// </summary>
+    private bool MoveSelection(int delta)
+    {
+        if (_orders.Count == 0) return false;
+
+        var idx = _selectedId is long sid ? _orders.FindIndex(o => o.Id == sid) : -1;
+        var next = idx < 0
+            ? (delta > 0 ? 0 : _orders.Count - 1)
+            : Math.Clamp(idx + delta, 0, _orders.Count - 1);
+
+        if (next == idx) return false;
+
+        _selectedId = _orders[next].Id;
+        StateHasChanged();
+        return true;
+    }
+
+    private async Task ScrollSelectedIntoViewAsync()
+    {
+        if (_shortcutsModule is null) return;
+        try { await _shortcutsModule.InvokeVoidAsync("scrollSelectedIntoView"); }
+        catch (JSDisconnectedException) { /* circuit gone */ }
+    }
+
+    /// <summary>
+    /// Mirrors clicking the order-number link in the table: opens the detail
+    /// page in a new tab via window.open so the list keeps the user's place
+    /// (selection, scroll, page). The href on the &lt;a&gt; element is the
+    /// same target — Enter just triggers it programmatically.
+    /// </summary>
+    private async Task OpenSelectedAsync()
+    {
+        if (_shortcutsModule is null || _selectedId is not long id) return;
+
+        var sel = _orders.FirstOrDefault(o => o.Id == id);
+        if (sel is null) return;
+
+        try { await _shortcutsModule.InvokeVoidAsync("openInNewTab", $"orders/{sel.Number}"); }
+        catch (JSDisconnectedException) { /* circuit gone */ }
     }
 
     private async Task OnStatusChanged(string value)

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/js/orders-shortcuts.js
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/wwwroot/js/orders-shortcuts.js
@@ -1,0 +1,109 @@
+// Sales Orders keyboard shortcut bridge (S-3.3).
+//
+// Loaded once per circuit by Index.razor via dynamic import. Owns a single
+// document-level keydown listener that dispatches into the .NET component
+// via DotNetObjectReference. The module keeps mutable state in module scope
+// so re-importing during hot-reload or accidental double-register replaces
+// the previous handler instead of stacking them.
+//
+// Shortcut grammar (codex §S-3.3):
+//   /        — focus the orders search input (only when not already typing)
+//   Esc      — clear active search if any; else deselect current row;
+//              forwarded from inside the search input too so Esc clears it
+//   ArrowUp  — move row selection one up
+//   ArrowDn  — move row selection one down
+//   Enter    — open the currently selected order in a new tab
+//
+// Editable-element guard: ArrowUp/Down/Enter are intentionally NOT swallowed
+// when the user is typing in an input/textarea/select/contenteditable, so
+// keyboard navigation inside the search field, dropdowns, and any future
+// inline editors keeps working as expected.
+
+let _handler = null;
+let _dotnetRef = null;
+
+export function register(ref) {
+    unregister();
+    _dotnetRef = ref;
+    _handler = onKey;
+    document.addEventListener('keydown', _handler);
+}
+
+export function unregister() {
+    if (_handler) {
+        document.removeEventListener('keydown', _handler);
+    }
+    _handler = null;
+    _dotnetRef = null;
+}
+
+export function focusElement(element) {
+    if (element && typeof element.focus === 'function') {
+        element.focus();
+        if (typeof element.select === 'function') {
+            element.select();
+        }
+    }
+}
+
+export function openInNewTab(url) {
+    if (url) {
+        window.open(url, '_blank', 'noopener,noreferrer');
+    }
+}
+
+// requestAnimationFrame so we wait for Blazor to commit the new is-selected
+// class before measuring; without it we'd scroll the previously-selected row.
+export function scrollSelectedIntoView() {
+    requestAnimationFrame(() => {
+        const el = document.querySelector('.orders-list__body tr.is-selected');
+        if (el && typeof el.scrollIntoView === 'function') {
+            el.scrollIntoView({ block: 'nearest' });
+        }
+    });
+}
+
+function onKey(e) {
+    if (!_dotnetRef) return;
+
+    const target = e.target;
+    const isEditable = !!(target && target.matches && target.matches(
+        'input, textarea, select, [contenteditable="true"]'));
+
+    // Esc is forwarded unconditionally so it can both clear the search input
+    // (focused) and deselect a row (focus elsewhere) from the same handler.
+    if (e.key === 'Escape') {
+        e.preventDefault();
+        _dotnetRef.invokeMethodAsync('HandleShortcut', 'escape');
+        return;
+    }
+
+    // '/' from a non-editable element jumps focus into the search box. While
+    // already typing we let it through so the user can actually search for
+    // strings containing '/'.
+    if (e.key === '/' && !isEditable) {
+        e.preventDefault();
+        _dotnetRef.invokeMethodAsync('HandleShortcut', 'slash');
+        return;
+    }
+
+    if (isEditable) return;
+
+    switch (e.key) {
+        case 'ArrowUp':
+            e.preventDefault();
+            _dotnetRef.invokeMethodAsync('HandleShortcut', 'up');
+            break;
+        case 'ArrowDown':
+            e.preventDefault();
+            _dotnetRef.invokeMethodAsync('HandleShortcut', 'down');
+            break;
+        case 'Enter':
+            e.preventDefault();
+            _dotnetRef.invokeMethodAsync('HandleShortcut', 'enter');
+            break;
+        default:
+            // not ours
+            break;
+    }
+}


### PR DESCRIPTION
## Summary

Implements migration plan item **S-3.3** (`.cursor/plans/sales_&_fabric_migration_plan_aa705a91.plan.md`) — keyboard shortcuts on the Sales Orders list.

| Key | Behaviour |
|-----|-----------|
| `/` | Focus the search input (only when not already typing — `/` inside an input is allowed so users can search for strings containing slashes) |
| `Esc` | Clear active search; if search is already empty, deselect the current row |
| `↑` | Move row selection up |
| `↓` | Move row selection down (and scroll into view) |
| `Enter` | Open the selected order in a new tab — same target as the existing `target="_blank"` order-number link |

## Implementation notes

- New ES module `wwwroot/js/orders-shortcuts.js` owns a single `document.keydown` listener and dispatches into Blazor via a `DotNetObjectReference`. The editable-element guard (`input, textarea, select, [contenteditable]`) skips Arrow/Enter so typing in fields and dropdowns is unaffected.
- `Index.razor` loads the module on first render, exposes one `[JSInvokable] HandleShortcut(string)` entry point, and cleans up both the `IJSObjectReference` and `DotNetObjectReference` in `DisposeAsync`. All teardown JS calls are wrapped in `JSDisconnectedException` / `TaskCanceledException` catches so a circuit-tear race can never crash the page.
- Esc additionally cancels the in-flight search debounce CTS before reloading, so a stale keystroke can't fire a second `ReloadAsync` after the user explicitly cleared the field.

## Test plan

- [x] `dotnet build src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI` — clean (0 warnings, 0 errors)
- [ ] Local Sales.WebUI smoke: `/`, `Esc`, `↑`/`↓`, `Enter` from list page
- [ ] Verify `/` works from a non-input element and is passed through when typing in the search box
- [ ] Verify `Esc` clears search, then on a second press deselects the row
- [ ] Verify `Enter` opens the selected order in a new tab and does not navigate the current tab
- [ ] Verify `↑`/`↓` inside the `Status` and `Store` dropdowns still cycle dropdown options (not row selection)

## Related

Closes the S-3.3 plan item. Remaining S-3 items tracked separately:

- #83 — Sales Orders: implement "Open in PoS" detail action (S-3.2)
- #84 — Sales Orders: polish empty/error/loading states per codex §7 (S-3.4)
- #85 — CI: build-and-push retry on transient MCR 403
