### PR TITLE
ci(build-and-push): retry build step on transient MCR 403

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -124,7 +124,10 @@ jobs:
       - name: Build and push ${{ matrix.name }} image (attempt 1/3)
         id: build1
         continue-on-error: true
-        uses: docker/build-push-action@v5
+        # Pinned to a commit SHA (v5.4.0) per Sonar githubactions:S7637 — protects
+        # the CI/CD pipeline from a potential supply-chain compromise of the
+        # docker/build-push-action repo. Bump when you intentionally upgrade.
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -145,7 +148,7 @@ jobs:
         id: build2
         if: steps.build1.outcome == 'failure'
         continue-on-error: true
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -167,7 +170,7 @@ jobs:
       # ultimately reports against.
       - name: Build and push ${{ matrix.name }} image (attempt 3/3, final)
         if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5.4.0
         with:
           context: .
           file: ${{ matrix.dockerfile }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -103,7 +103,70 @@ jobs:
             done
           done
 
-      - name: Build and push ${{ matrix.name }} image
+      # Build the image with up to 3 attempts.
+      #
+      # The probe step above already retries `imagetools inspect` 5 times,
+      # but BuildKit (running inside the docker-container driver) keeps its
+      # own short-lived manifest cache and re-issues a HEAD against MCR when
+      # the actual build kicks off. When MCR's Front Door is moody (we have
+      # seen this twice in two days, https://github.com/lauresta/lkvitai-mes/issues/85)
+      # it returns HTML 403 instead of a manifest, the action has no built-in
+      # retry, and the matrix entry dies — forcing a manual `gh run rerun`
+      # before main can move forward.
+      #
+      # The pattern below retries the EXACT SAME action invocation up to two
+      # additional times with growing back-off (30s, 60s). Each attempt is
+      # gated on the previous one having failed, so a successful first pass
+      # adds zero latency. The final attempt drops `continue-on-error` so a
+      # genuine, persistent failure still fails the matrix entry within
+      # ~3 min of wait + 3 attempts of build time, matching the budget on
+      # issue #85.
+      - name: Build and push ${{ matrix.name }} image (attempt 1/3)
+        id: build1
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Wait before retry (attempt 2)
+        if: steps.build1.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::attempt 1 failed, sleeping 30s before retry"
+          sleep 30
+
+      - name: Build and push ${{ matrix.name }} image (attempt 2/3)
+        id: build2
+        if: steps.build1.outcome == 'failure'
+        continue-on-error: true
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.name }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.name }}
+
+      - name: Wait before retry (attempt 3)
+        if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure'
+        shell: bash
+        run: |
+          echo "::warning::attempts 1 and 2 failed, sleeping 60s before final retry"
+          sleep 60
+
+      # Final attempt — no continue-on-error so a sustained outage still fails
+      # the matrix entry. This is the step whose outcome the job exit code
+      # ultimately reports against.
+      - name: Build and push ${{ matrix.name }} image (attempt 3/3, final)
+        if: steps.build1.outcome == 'failure' && steps.build2.outcome == 'failure'
         uses: docker/build-push-action@v5
         with:
           context: .


### PR DESCRIPTION
## Summary

Closes #85.

Wraps the `docker/build-push-action@v5` step in `.github/workflows/build-and-push.yml` in a bounded 3-attempt retry so a transient MCR 403 on the BuildKit metadata HEAD does not require a manual `gh run rerun --failed` to unblock `main`.

| Scenario | Wait | Conclusion |
|---|---|---|
| attempt 1 ✅ | 0s | success — zero overhead on the happy path |
| attempt 1 ❌, 2 ✅ | 30s | success |
| attempt 1 ❌, 2 ❌, 3 ✅ | 90s | success |
| all 3 ❌ | 90s | failure (final attempt drops `continue-on-error` so a sustained outage still surfaces) |

Total wait budget on a sustained outage is bounded at **90s**, fitting the acceptance criterion in #85 ("max 3 attempts, total wait ≤ 3 min").

## Why not …

- … bump the existing probe step further? Probe uses `imagetools inspect` against the same buildkit container that runs the build, but BuildKit's own manifest cache is short-lived and re-issues a HEAD on the actual build — probe success does not protect the build itself.
- … pre-pull into the host docker daemon? `docker-container` driver does not share image cache with the host daemon, so prefetching is invisible to the build.
- … use `nick-fields/retry@v3` wrapping a hand-rolled `docker buildx build`? Cleaner DRY-wise but loses the action's free provenance attestation, label/tag wiring, and GHA cache plumbing. Trade-off not worth it for a transient registry issue.
- … pin manifest digests in the Dockerfiles? Doesn't help — buildx still issues a HEAD against MCR to verify the digest, which is the request that 403s.

## Test plan

- [ ] Wait for first post-merge build run and confirm a clean (single-attempt) build still finishes in the same time as before
- [ ] Next time MCR 403s on attempt 1, confirm attempt 2 succeeds without manual intervention (we'll see this in the run log as a `::warning::` line plus an extra `Build and push` step)
- [ ] If three consecutive attempts fail (real outage), confirm the matrix entry fails and surfaces the genuine error in the failed-job log

## Notes

The `with` block is repeated 3 times because GitHub Actions does not support YAML anchors. Acceptable given the small block size (8 lines × 3) and the alternative requires either a third-party retry action or losing built-in provenance.
