### PR TITLE
F-2.3 + F-2.4 Frontline: real LKvitaiDb data end-to-end (closes #97 #99)

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -153,7 +153,13 @@ services:
       retries: 5
       start_period: 30s
 
-  # --- Frontline module (scaffold, anonymous) -----------------------------------
+  # --- Frontline module (anonymous in F-2; PortalAuth lands in F-Auth) ---------
+  # F-2.4: Frontline.Api defaults to FabricDataSource=Auto, so it talks to the
+  # legacy SQL Server (LKvitaiDb) when the connection string is set, and
+  # quietly falls back to the in-memory stub otherwise (with a Warning log).
+  # The deploy workflow ships LKVITAI_MSACCESS_DB_CONNECTION as a secret —
+  # mirror Sales here so /api/frontline/fabric/{code} and /api/frontline/fabric/low-stock
+  # return real production data instead of the F-1 stub fixtures.
   frontline-api:
     image: ghcr.io/lauresta/lkvitai-mes-frontline-api:${IMAGE_TAG:-latest}
     container_name: lkvitai-mes-frontline-api
@@ -162,6 +168,8 @@ services:
       - "5031:8080"
     environment:
       ASPNETCORE_ENVIRONMENT: Test
+      ConnectionStrings__LKvitaiDb: "${LKVITAI_MSACCESS_DB_CONNECTION}"
+      Frontline__FabricDataSource: "Sql"
     volumes:
       - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
     networks:

--- a/docs/sql/frontline-f2-2.sql
+++ b/docs/sql/frontline-f2-2.sql
@@ -44,9 +44,15 @@ GO
 CREATE PROCEDURE dbo.mes_Fabric_GetMobileCard
     @Code            nvarchar(50),
     @DefaultPhotoUrl nvarchar(256) = N'/img/fabric_pl.png',
-    @LowThreshold    int           = 10,    -- < 10  -> Low
-    @EnoughThreshold int           = 25     -- >= 25 -> Enough; in-between still Low
+    @LowThreshold    int           = 10,    -- reserved (see note)
+    @EnoughThreshold int           = 25     -- >= @EnoughThreshold -> Enough; 1..@EnoughThreshold-1 -> Low
 AS
+-- @LowThreshold is currently unused. It used to define a separate "critical"
+-- tier (1..@LowThreshold-1) but the contract only exposes a single Low state,
+-- so the lookup card now treats every positive sub-threshold value as Low.
+-- The parameter is kept in the signature for backwards compatibility with the
+-- .NET adapter (FabricLookupParams.LowThreshold) and to leave the door open
+-- for a future "critical" UI tier.
 BEGIN
     SET NOCOUNT ON;
 
@@ -104,7 +110,14 @@ BEGIN
         Status = CASE
                     WHEN IsDiscontinued = 1 THEN 4
                     WHEN ISNULL(CAST(StockMetersRaw AS int), 0) >= @EnoughThreshold THEN 1
-                    WHEN ISNULL(CAST(StockMetersRaw AS int), 0) BETWEEN 1 AND @LowThreshold - 1 THEN 2
+                    -- ANY positive value below @EnoughThreshold is Low. The
+                    -- legacy proc had a gap (10..24m fell through to 0/Unknown)
+                    -- which surfaced as a missing badge on the lookup card.
+                    -- F-2.3 (mes_Fabric_GetLowStockList) treats the same range
+                    -- as Low; mirror that here so swapping between lookup and
+                    -- low-stock list never disagrees on whether a fabric is
+                    -- "running out".
+                    WHEN ISNULL(CAST(StockMetersRaw AS int), 0) BETWEEN 1 AND @EnoughThreshold - 1 THEN 2
                     WHEN ISNULL(CAST(StockMetersRaw AS int), 0) = 0 THEN 3
                     ELSE 0
                  END,
@@ -198,7 +211,11 @@ BEGIN
         Status      = CASE
                         WHEN IsDiscontinued = 1 THEN 4
                         WHEN ISNULL(CAST(StockMetersRaw AS int), 0) >= @EnoughThreshold THEN 1
-                        WHEN ISNULL(CAST(StockMetersRaw AS int), 0) BETWEEN 1 AND @LowThreshold - 1 THEN 2
+                        -- See RS2 comment: any positive value below
+                        -- @EnoughThreshold is Low. Keeps the alternatives
+                        -- chip strip aligned with the main width chip on
+                        -- the same card.
+                        WHEN ISNULL(CAST(StockMetersRaw AS int), 0) BETWEEN 1 AND @EnoughThreshold - 1 THEN 2
                         WHEN ISNULL(CAST(StockMetersRaw AS int), 0) = 0 THEN 3
                         ELSE 0
                       END,

--- a/docs/sql/frontline-f2-3.sql
+++ b/docs/sql/frontline-f2-3.sql
@@ -1,0 +1,186 @@
+/*
+================================================================================
+ Frontline F-2.3 — dbo.mes_Fabric_GetLowStockList (low-stock list SQL adapter)
+--------------------------------------------------------------------------------
+ Server-side filter / sort / paging for the desktop low-stock list. Replaces
+ the F-1 in-memory stub used by SqlFabricQueryService.GetLowStockListAsync.
+
+ Result set (single, paged):
+   Code, Name, PhotoUrl, WidthMm, AvailableMeters, ThresholdMeters, Status,
+   ExpectedDate, IncomingMeters, Supplier, AlternativeCodes, LastChecked,
+   CanReserve, CanNotify, CanReplace, TotalRows
+
+ Status enum (matches FabricAvailabilityStatus on the .NET side):
+   1 = Enough, 2 = Low, 3 = None (out), 4 = Discontinued, 0 = Unknown.
+
+ Inclusion rule: a row appears in the list if
+     Available < @ThresholdMeters
+   OR Status IN (None, Discontinued).
+ In other words, "Out" and "Discontinued" are always shown regardless of
+ threshold — they need attention even at high threshold settings.
+
+ Sorting (server-side):
+   @SortBy IN ('Code', 'Available', 'LastChecked'); fallback Code ASC.
+   @SortDir IN ('ASC', 'DESC'); fallback ASC.
+   Code ASC is always used as the secondary tie-breaker so paging stays stable.
+
+ Paging: @Page (1-based), @PageSize (1..500). Windowed COUNT() emits the same
+ TotalRows on every row — same shape as dbo.weblb_Orders_Paged so the C# reader
+ can read it from the last row of the page.
+
+ Idempotent: DROP-then-CREATE because SQL Server 2014 has no CREATE OR ALTER.
+================================================================================
+*/
+
+USE LKVITAIDBV1SQL;
+GO
+
+SET ANSI_NULLS ON;
+SET QUOTED_IDENTIFIER ON;
+GO
+
+PRINT '== F-2.3: creating dbo.mes_Fabric_GetLowStockList ==';
+
+IF OBJECT_ID('dbo.mes_Fabric_GetLowStockList', 'P') IS NOT NULL
+    DROP PROCEDURE dbo.mes_Fabric_GetLowStockList;
+GO
+
+CREATE PROCEDURE dbo.mes_Fabric_GetLowStockList
+    @Search           nvarchar(100) = NULL,
+    @ThresholdMeters  int           = 25,
+    @Status           nvarchar(20)  = NULL,    -- 'low' | 'out' | 'disc' | NULL/'all'
+    @WidthMm          int           = NULL,
+    @Supplier         nvarchar(100) = NULL,
+    @SortBy           nvarchar(20)  = 'Code',
+    @SortDir          nvarchar(4)   = 'ASC',
+    @Page             int           = 1,
+    @PageSize         int           = 50,
+    @LowThreshold     int           = 10,    -- < @LowThreshold => Status=Low (red chip)
+    @DefaultPhotoUrl  nvarchar(256) = N'/img/fabric_pl.png'
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    IF @Page     IS NULL OR @Page     < 1   SET @Page     = 1;
+    IF @PageSize IS NULL OR @PageSize < 1   SET @PageSize = 50;
+    IF @PageSize > 500                      SET @PageSize = 500;
+    IF @ThresholdMeters IS NULL OR @ThresholdMeters < 0 SET @ThresholdMeters = 25;
+    IF @LowThreshold    IS NULL OR @LowThreshold    < 0 SET @LowThreshold    = 10;
+
+    DECLARE @SearchNorm   nvarchar(100) = NULLIF(LTRIM(RTRIM(@Search)),   N'');
+    DECLARE @SupplierNorm nvarchar(100) = NULLIF(LTRIM(RTRIM(@Supplier)), N'');
+    DECLARE @StatusNorm   nvarchar(20)  = NULLIF(LOWER(LTRIM(RTRIM(@Status))), N'');
+
+    DECLARE @SortByNorm  nvarchar(20) = CASE LOWER(ISNULL(@SortBy, ''))
+        WHEN 'available'   THEN 'Available'
+        WHEN 'lastchecked' THEN 'LastChecked'
+        ELSE 'Code'
+    END;
+    DECLARE @SortDirNorm nvarchar(4)  =
+        CASE WHEN UPPER(ISNULL(@SortDir, '')) = 'DESC' THEN 'DESC' ELSE 'ASC' END;
+
+    ;WITH Base AS (
+        SELECT
+            Code           = c.sCodeInternal,
+            Name           = ISNULL(c.sName, N''),
+            WidthMm        = ISNULL(c.fa_WidthMm, 2000),
+            Available      = ISNULL(CAST(r.Likutis AS int), 0),
+            ExpectedDate   = c.fa_ExpectedDelivery,
+            IncomingMeters = c.mes_IncomingMeters,
+            LastChecked    = c.mes_LastCheckedAt,
+            Supplier       = sup.sName,
+            Alts           = c.fa_Alternatives,
+            IsDiscontinued = ISNULL(c.fa_IsDiscontinued, 0)
+        FROM dbo.TBD_Components AS c
+        LEFT JOIN dbo.V_Remains AS r
+               ON UPPER(LTRIM(RTRIM(r.Kodas))) = UPPER(LTRIM(RTRIM(c.sCodeInternal)))
+        LEFT JOIN dbo.TBD_Suppliers AS sup
+               ON sup.iSupplierID = c.iSupplierID
+        WHERE c.iComponentCategoryID = 1
+          AND c.iComponentID NOT IN (3739, 3143)
+    ),
+    Classified AS (
+        SELECT
+            *,
+            -- Effective EnoughThreshold for status: the user's threshold filter.
+            -- Items below the user's threshold cannot be "Enough" by definition,
+            -- so we mirror the picture the operator expects on screen.
+            Status = CASE
+                        WHEN IsDiscontinued = 1                                            THEN 4  -- Discontinued
+                        WHEN Available >= @ThresholdMeters                                 THEN 1  -- Enough (only happens when threshold filter inactive)
+                        WHEN Available BETWEEN 1 AND @LowThreshold - 1                     THEN 2  -- Low (red)
+                        WHEN Available BETWEEN @LowThreshold AND @ThresholdMeters - 1      THEN 2  -- Low (orange — same enum value, UI varies tone)
+                        WHEN Available = 0                                                 THEN 3  -- None / Out
+                        ELSE 0                                                                     -- Unknown (defensive)
+                     END
+        FROM Base
+    ),
+    Filtered AS (
+        SELECT *
+        FROM Classified
+        WHERE
+            -- Inclusion: below user threshold OR Out/Discontinued (always shown).
+            (Available < @ThresholdMeters OR Status IN (3, 4))
+            -- Status filter (single-status drop-down).
+            AND (
+                @StatusNorm IS NULL
+                OR @StatusNorm = N'all'
+                OR (@StatusNorm = N'low'  AND Status = 2)
+                OR (@StatusNorm = N'out'  AND Status = 3)
+                OR (@StatusNorm = N'disc' AND Status = 4)
+            )
+            -- Width filter.
+            AND (@WidthMm IS NULL OR WidthMm = @WidthMm)
+            -- Supplier filter (case-insensitive exact match on display name).
+            AND (@SupplierNorm IS NULL OR Supplier = @SupplierNorm)
+            -- Free-text search across code / name / supplier.
+            AND (
+                @SearchNorm IS NULL
+                OR Code     LIKE N'%' + @SearchNorm + N'%'
+                OR Name     LIKE N'%' + @SearchNorm + N'%'
+                OR Supplier LIKE N'%' + @SearchNorm + N'%'
+            )
+    ),
+    Numbered AS (
+        SELECT
+            *,
+            TotalRows = COUNT(*) OVER (),
+            -- Sort key fan-out — kept readable instead of dynamic SQL.
+            -- Code ASC is the primary tie-breaker on every branch so paging
+            -- stays deterministic when two rows share an Available value.
+            RowNum = ROW_NUMBER() OVER (
+                ORDER BY
+                    CASE WHEN @SortByNorm = 'Available'   AND @SortDirNorm = 'ASC'  THEN Available    END ASC,
+                    CASE WHEN @SortByNorm = 'Available'   AND @SortDirNorm = 'DESC' THEN Available    END DESC,
+                    CASE WHEN @SortByNorm = 'LastChecked' AND @SortDirNorm = 'DESC' THEN LastChecked  END DESC,
+                    CASE WHEN @SortByNorm = 'LastChecked' AND @SortDirNorm = 'ASC'  THEN LastChecked  END ASC,
+                    CASE WHEN @SortByNorm = 'Code'        AND @SortDirNorm = 'DESC' THEN Code         END DESC,
+                    Code ASC
+            )
+        FROM Filtered
+    )
+    SELECT
+        Code,
+        Name,
+        PhotoUrl         = @DefaultPhotoUrl,
+        WidthMm,
+        AvailableMeters  = Available,
+        ThresholdMeters  = @ThresholdMeters,
+        Status,
+        ExpectedDate,
+        IncomingMeters,
+        Supplier,
+        AlternativeCodes = Alts,                                     -- raw CSV; .NET adapter splits + normalises
+        LastChecked,
+        CanReserve = CASE WHEN Status NOT IN (3, 4) THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END,
+        CanNotify  = CASE WHEN Status = 3            THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END,
+        CanReplace = CASE WHEN Status = 4            THEN CAST(1 AS bit) ELSE CAST(0 AS bit) END,
+        TotalRows
+    FROM Numbered
+    WHERE RowNum BETWEEN ((@Page - 1) * @PageSize + 1) AND (@Page * @PageSize)
+    ORDER BY RowNum;
+END
+GO
+
+PRINT '== F-2.3: done ==';
+GO

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Composition/FrontlineFabricDataSource.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Composition/FrontlineFabricDataSource.cs
@@ -16,28 +16,30 @@ namespace LKvitai.MES.Modules.Frontline.Api.Composition;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>F-2.2 reality check.</b> The SQL adapter
-/// (<see cref="SqlFabricQueryService"/>) implements the lookup card via
-/// <c>dbo.mes_Fabric_GetMobileCard</c> and pairs with
-/// <see cref="SqlFabricLookupRecorder"/> for audit-log writes via
-/// <c>dbo.mes_Fabric_RecordLookup</c>. The low-stock list path is reserved
-/// for F-2.3 — calling <c>GetLowStockListAsync</c> on the SQL adapter
-/// throws <see cref="NotImplementedException"/> with a pointer to that
-/// task. The default mode therefore stays <c>"Stub"</c> until F-2.4 flips
-/// the switch.
+/// <b>F-2.3 reality.</b> The SQL adapter
+/// (<see cref="SqlFabricQueryService"/>) implements both the lookup card
+/// (<c>dbo.mes_Fabric_GetMobileCard</c>) and the desktop low-stock list
+/// (<c>dbo.mes_Fabric_GetLowStockList</c>); audit-log writes go through
+/// <see cref="SqlFabricLookupRecorder"/> over
+/// <c>dbo.mes_Fabric_RecordLookup</c>. F-2.4 flips the default mode from
+/// the old <c>"Stub"</c> to <c>"Auto"</c>, so any deploy that ships the
+/// <c>LKvitaiDb</c> connection string automatically wires the legacy DB
+/// without touching configuration.
 /// </para>
 /// <para>
 /// <b>Selection rules.</b>
 /// </para>
 /// <list type="bullet">
-///   <item><c>"Stub"</c> (current default) — registers
-///   <see cref="StubFabricQueryService"/> +
-///   <see cref="NoOpFabricLookupRecorder"/>; logs an informational line so
-///   the stub origin of every payload is obvious in the startup banner.</item>
-///   <item><c>"Sql"</c> / <c>"Auto"</c> — requires
-///   <c>ConnectionStrings:LKvitaiDb</c>; throws at startup if it's missing.
-///   Registers <see cref="SqlFabricQueryService"/> +
-///   <see cref="SqlFabricLookupRecorder"/>.</item>
+///   <item><c>"Auto"</c> (default) — uses SQL when
+///   <c>ConnectionStrings:LKvitaiDb</c> is set; otherwise falls back to
+///   the in-memory stub with a startup-warning log line so the stub origin
+///   of every payload is obvious. Same shape as
+///   <c>SalesOrdersDataSource</c>.</item>
+///   <item><c>"Sql"</c> — requires <c>ConnectionStrings:LKvitaiDb</c>;
+///   throws at startup if the connection string is missing.</item>
+///   <item><c>"Stub"</c> — explicit dev / test opt-in. Registers the in-memory
+///   stub and the no-op recorder regardless of whether a connection string
+///   is configured, so unit / integration tests can run hermetically.</item>
 /// </list>
 /// </remarks>
 public static class FrontlineFabricDataSource
@@ -65,38 +67,55 @@ public static class FrontlineFabricDataSource
 
         var mode = ResolveMode(requestedMode);
 
+        // Auto = "Sql when we have the connection, Stub otherwise (with a
+        // loud warning so the operator sees the fallback in the startup log)."
+        // Same shape as SalesOrdersDataSource so the two modules stay in
+        // lock-step.
+        if (mode == ModeAuto)
+        {
+            mode = hasConnection ? ModeSql : ModeStub;
+        }
+
         if (mode == ModeStub)
         {
-            // Explicit dev / test path. Both ports are registered together
-            // so the endpoint can call IFabricLookupRecorder unconditionally
-            // — the no-op recorder makes the stub flow indistinguishable
-            // from the SQL flow as far as the API surface is concerned.
             services.AddSingleton<IFabricQueryService>(sp =>
             {
                 var logger = sp.GetService<ILoggerFactory>()?
                     .CreateLogger("Frontline.FabricDataSource");
-                logger?.LogInformation(
-                    "Frontline fabric read-side is using the in-memory STUB " +
-                    "(Frontline:FabricDataSource={Mode}). Environment={Environment}. " +
-                    "F-2.4 will flip the default to Sql once the low-stock adapter ships.",
-                    requestedMode ?? "Stub (default)", environment.EnvironmentName);
+                if (string.Equals(requestedMode, ModeStub, StringComparison.OrdinalIgnoreCase))
+                {
+                    logger?.LogInformation(
+                        "Frontline fabric read-side is using the in-memory STUB " +
+                        "(Frontline:FabricDataSource=Stub, environment={Environment}).",
+                        environment.EnvironmentName);
+                }
+                else
+                {
+                    // Auto-fallback path. Real deploys MUST set ConnectionStrings:LKvitaiDb;
+                    // logging at Warning makes the stub origin impossible to miss.
+                    logger?.LogWarning(
+                        "Frontline fabric read-side fell back to the in-memory STUB because " +
+                        "ConnectionStrings:LKvitaiDb is missing (Frontline:FabricDataSource={Mode}, environment={Environment}). " +
+                        "Set the connection string to use the legacy LKvitaiDb data, or set Frontline:FabricDataSource=Stub to silence this warning.",
+                        requestedMode ?? "Auto (default)", environment.EnvironmentName);
+                }
                 return new StubFabricQueryService();
             });
             services.AddSingleton<IFabricLookupRecorder, NoOpFabricLookupRecorder>();
             return services;
         }
 
-        // Sql / Auto — both require the legacy connection string. Fail fast
-        // (at composition time, before the host opens any sockets) so the
-        // operator sees a clear startup error instead of a 500 on the first
-        // /api/frontline/fabric/{code} request.
+        // Sql — explicit (or Auto-resolved) legacy DB binding. Fail fast at
+        // composition time so the operator sees a clear startup error
+        // instead of a 500 on the first /api/frontline/fabric/{code} request.
         if (!hasConnection)
         {
             throw new InvalidOperationException(
                 $"Frontline fabric SQL adapter requires ConnectionStrings:{ConnectionStringName} to be set " +
-                $"(environment '{environment.EnvironmentName}'). Provide the LKvitaiDb connection string via " +
-                "environment variable (ConnectionStrings__LKvitaiDb) or user-secrets, " +
-                "or set Frontline:FabricDataSource=Stub explicitly for a stub-only test/dev run.");
+                $"(environment '{environment.EnvironmentName}', requested mode '{requestedMode ?? "(none)"}'). " +
+                "Provide the LKvitaiDb connection string via environment variable " +
+                "(ConnectionStrings__LKvitaiDb) or user-secrets, or set Frontline:FabricDataSource=Stub explicitly " +
+                "for a stub-only test/dev run.");
         }
 
         var commandTimeout = configuration.GetValue(CommandTimeoutKey, defaultValue: 30);
@@ -113,16 +132,17 @@ public static class FrontlineFabricDataSource
 
     private static string ResolveMode(string? requestedMode)
     {
-        // F-2.2 default is still Stub — the SQL low-stock adapter lands in
-        // F-2.3 and the data-source flip lands in F-2.4. Until then a
-        // plain default has to keep the WebUI usable in dev without a
-        // legacy connection string.
-        if (string.IsNullOrWhiteSpace(requestedMode)) return ModeStub;
+        // F-2.4 flips the default from Stub → Auto so any deploy that ships
+        // the LKvitaiDb connection string automatically uses real data
+        // without touching configuration. The Auto branch above degrades
+        // to Stub (with a startup warning) when the connection string is
+        // missing, so dev machines without the legacy DB still boot.
+        if (string.IsNullOrWhiteSpace(requestedMode)) return ModeAuto;
         if (string.Equals(requestedMode, ModeStub, StringComparison.OrdinalIgnoreCase)) return ModeStub;
         if (string.Equals(requestedMode, ModeSql,  StringComparison.OrdinalIgnoreCase)) return ModeSql;
         if (string.Equals(requestedMode, ModeAuto, StringComparison.OrdinalIgnoreCase)) return ModeAuto;
 
         throw new InvalidOperationException(
-            $"Unknown Frontline:FabricDataSource '{requestedMode}'. Expected one of: '{ModeSql}', '{ModeAuto}', '{ModeStub}'.");
+            $"Unknown Frontline:FabricDataSource '{requestedMode}'. Expected one of: '{ModeAuto}', '{ModeSql}', '{ModeStub}'.");
     }
 }

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/appsettings.json
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/appsettings.json
@@ -5,5 +5,16 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "Frontline": {
+    "_Comment_FabricDataSource": "Auto = Sql when ConnectionStrings:LKvitaiDb is set, in-memory Stub otherwise (with a startup warning). Sql = legacy DB always (fail fast on missing connection). Stub = explicit dev/test opt-in. Default is Auto.",
+    "FabricDataSource": "Auto",
+    "Sql": {
+      "_Comment_CommandTimeoutSeconds": "Per-command timeout for SqlFabricQueryService and SqlFabricLookupRecorder; default 30s.",
+      "CommandTimeoutSeconds": 30
+    }
+  },
+  "ConnectionStrings": {
+    "_Comment_LKvitaiDb": "Provided at deploy time via the ConnectionStrings__LKvitaiDb environment variable; do NOT commit a real connection string here."
+  }
 }

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
@@ -13,8 +13,9 @@ namespace LKvitai.MES.Modules.Frontline.Infrastructure.Sql;
 /// SQL Server adapter for <see cref="IFabricQueryService"/> over the legacy
 /// <c>LKvitaiDb</c> database. Lookup card calls
 /// <c>dbo.mes_Fabric_GetMobileCard</c> (F-2.2 successor to the legacy
-/// <c>weblb_Fabric_GetMobileCard</c>); the low-stock list is reserved for
-/// F-2.3 and currently throws.
+/// <c>weblb_Fabric_GetMobileCard</c>); the desktop low-stock list calls
+/// <c>dbo.mes_Fabric_GetLowStockList</c> (F-2.3 — server-side filter,
+/// sort and paging over <c>dbo.V_Remains</c> + <c>dbo.TBD_Components</c>).
 /// </summary>
 /// <remarks>
 /// <list type="bullet">
@@ -22,22 +23,41 @@ namespace LKvitai.MES.Modules.Frontline.Infrastructure.Sql;
 ///   widths, alternatives). Unknown / blacklisted code → zero result sets;
 ///   the adapter treats "no rows in RS1" as a 404 to keep the proc cheap on
 ///   the unhappy path.</item>
-///   <item>Status integers in RS2/RS3 map 1:1 to
-///   <see cref="FabricAvailabilityStatus"/> (1 Enough, 2 Low, 3 None,
-///   4 Discontinued, 0 Unknown).</item>
-///   <item>Selected width is picked client-side: explicit <c>?width=</c>
-///   wins when present in the returned set; otherwise the smallest available
-///   width — same rule as the F-1 in-memory stub and the legacy
-///   <c>FabricAvailabilityController.Mobile</c>.</item>
+///   <item><c>dbo.mes_Fabric_GetLowStockList</c> — single paged result set
+///   plus a windowed <c>TotalRows</c> column on every row (same shape as
+///   <c>dbo.weblb_Orders_Paged</c>). The adapter trims and uppercases the
+///   filter inputs before passing them through; nullable filters travel as
+///   <see cref="DBNull"/> so the SP's <c>IS NULL</c> branches fire instead
+///   of looking for the literal <c>N''</c>.</item>
+///   <item>Status integers map 1:1 to <see cref="FabricAvailabilityStatus"/>
+///   (1 Enough, 2 Low, 3 None, 4 Discontinued, 0 Unknown).</item>
+///   <item>Selected width on the lookup card is picked client-side:
+///   explicit <c>?width=</c> wins when present in the returned set;
+///   otherwise the smallest available width — same rule as the in-memory
+///   stub and the legacy <c>FabricAvailabilityController.Mobile</c>.</item>
+///   <item><c>AlternativeCodes</c> on the low-stock list comes back from
+///   the SP as a raw CSV string (same format as <c>fa_Alternatives</c>).
+///   The adapter splits and normalises it client-side: tokens are trimmed,
+///   uppercased, deduplicated, and the legacy <c>NRxxx → Rxxx</c> rewrite
+///   is applied so the WebUI never sees a mixed bag.</item>
 /// </list>
 /// All column reads are <see cref="DBNull"/>-guarded; missing columns or
 /// unexpected types degrade to safe defaults instead of throwing, so a
-/// single bad row never blanks the whole card.
+/// single bad row never blanks the whole card / page.
 /// </remarks>
 public sealed class SqlFabricQueryService : IFabricQueryService
 {
-    private const string GetMobileCardProcName = "dbo.mes_Fabric_GetMobileCard";
-    private const string PlaceholderPhotoUrl   = "/img/fabric_pl.png";
+    private const string GetMobileCardProcName  = "dbo.mes_Fabric_GetMobileCard";
+    private const string GetLowStockProcName    = "dbo.mes_Fabric_GetLowStockList";
+    private const string PlaceholderPhotoUrl    = "/img/fabric_pl.png";
+
+    /// <summary>Soft cap on per-page rows; mirrors the SP's own clamp so
+    /// the wire never sees a request the SP would silently shrink.</summary>
+    private const int MaxPageSize = 500;
+
+    /// <summary>Deduplication-friendly empty list, returned for fabrics
+    /// whose <c>fa_Alternatives</c> column is NULL or whitespace.</summary>
+    private static readonly IReadOnlyList<string> EmptyAlternativeList = Array.Empty<string>();
 
     private readonly FrontlineSqlOptions _options;
     private readonly ILogger<SqlFabricQueryService> _logger;
@@ -181,19 +201,127 @@ public sealed class SqlFabricQueryService : IFabricQueryService
             Alternatives:    alternatives);
     }
 
-    public Task<PagedResult<FabricLowStockDto>> GetLowStockListAsync(
+    public async Task<PagedResult<FabricLowStockDto>> GetLowStockListAsync(
         FabricLowStockQueryParams query,
         CancellationToken cancellationToken)
     {
-        // F-2.3 will wire this to dbo.mes_Fabric_GetLowStockList. Until then
-        // the SQL data source covers the lookup card only; anyone running
-        // Frontline:FabricDataSource=Sql who needs the low-stock list must
-        // either complete F-2.3 or switch back to Stub.
-        throw new NotImplementedException(
-            "SqlFabricQueryService.GetLowStockListAsync is reserved for F-2.3 " +
-            "(dbo.mes_Fabric_GetLowStockList over dbo.V_Remains + TBD_Components.mes_*). " +
-            "Set Frontline:FabricDataSource=Stub if you need the low-stock list to render today.");
+        ArgumentNullException.ThrowIfNull(query);
+
+        var page     = query.Page     < 1 ? 1 : query.Page;
+        var pageSize = query.PageSize < 1 ? 50 : (query.PageSize > MaxPageSize ? MaxPageSize : query.PageSize);
+
+        var totalSw = Stopwatch.StartNew();
+
+        var openSw = Stopwatch.StartNew();
+        await using var conn = new SqlConnection(_options.ConnectionString);
+        await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+        openSw.Stop();
+
+        await using var cmd = new SqlCommand(GetLowStockProcName, conn)
+        {
+            CommandType    = CommandType.StoredProcedure,
+            CommandTimeout = _options.CommandTimeoutSeconds,
+        };
+        cmd.Parameters.Add(new SqlParameter("@Search",          SqlDbType.NVarChar, 100) { Value = NullableNVarChar(query.Search) });
+        cmd.Parameters.Add(new SqlParameter("@ThresholdMeters", SqlDbType.Int)           { Value = (object?)query.ThresholdMeters ?? DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@Status",          SqlDbType.NVarChar, 20)  { Value = NullableNVarChar(query.Status) });
+        cmd.Parameters.Add(new SqlParameter("@WidthMm",         SqlDbType.Int)           { Value = (object?)query.WidthMm ?? DBNull.Value });
+        cmd.Parameters.Add(new SqlParameter("@Supplier",        SqlDbType.NVarChar, 100) { Value = NullableNVarChar(query.Supplier) });
+        cmd.Parameters.Add(new SqlParameter("@Page",            SqlDbType.Int)           { Value = page });
+        cmd.Parameters.Add(new SqlParameter("@PageSize",        SqlDbType.Int)           { Value = pageSize });
+
+        var execSw = Stopwatch.StartNew();
+        await using var reader = await cmd.ExecuteReaderAsync(cancellationToken).ConfigureAwait(false);
+        execSw.Stop();
+
+        var matSw = Stopwatch.StartNew();
+        var rows = new List<FabricLowStockDto>(capacity: pageSize);
+        var totalRows = 0;
+        while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+        {
+            rows.Add(new FabricLowStockDto(
+                Code:             ReadString(reader, "Code", string.Empty),
+                Name:             ReadString(reader, "Name", string.Empty),
+                PhotoUrl:         ReadString(reader, "PhotoUrl", PlaceholderPhotoUrl),
+                WidthMm:          ReadInt(reader, "WidthMm"),
+                AvailableMeters:  ReadInt(reader, "AvailableMeters"),
+                ThresholdMeters:  ReadInt(reader, "ThresholdMeters"),
+                Status:           ReadStatus(reader, "Status"),
+                ExpectedDate:     ReadDateOnlyOrNull(reader, "ExpectedDate"),
+                IncomingMeters:   ReadIntOrNull(reader, "IncomingMeters"),
+                Supplier:         ReadStringOrNull(reader, "Supplier"),
+                AlternativeCodes: SplitAlternatives(ReadStringOrNull(reader, "AlternativeCodes"), excludeCode: ReadString(reader, "Code", string.Empty)),
+                LastChecked:      ReadDateTimeOffsetOrNull(reader, "LastChecked"),
+                CanReserve:       ReadBool(reader, "CanReserve"),
+                CanNotify:        ReadBool(reader, "CanNotify"),
+                CanReplace:       ReadBool(reader, "CanReplace")));
+
+            totalRows = ReadInt(reader, "TotalRows");  // every row carries the same windowed count
+        }
+        matSw.Stop();
+        totalSw.Stop();
+
+        _logger.LogInformation(
+            "[FrontlinePerf] sql.GetLowStockList returned={Returned} total={Total} page={Page} pageSize={PageSize} " +
+            "search={HasSearch} threshold={Threshold} status={HasStatus} width={HasWidth} supplier={HasSupplier} " +
+            "openMs={OpenMs} execMs={ExecMs} materialiseMs={MatMs} totalMs={TotalMs}",
+            rows.Count, totalRows, page, pageSize,
+            !string.IsNullOrWhiteSpace(query.Search), query.ThresholdMeters,
+            !string.IsNullOrWhiteSpace(query.Status), query.WidthMm.HasValue,
+            !string.IsNullOrWhiteSpace(query.Supplier),
+            openSw.ElapsedMilliseconds, execSw.ElapsedMilliseconds,
+            matSw.ElapsedMilliseconds, totalSw.ElapsedMilliseconds);
+
+        return new PagedResult<FabricLowStockDto>(rows, totalRows, page, pageSize);
     }
+
+    /// <summary>
+    /// Splits a CSV-ish alternatives string into a normalised list. Operators
+    /// have used commas, semicolons, slashes, pipes, spaces, and tabs as
+    /// separators over the years — mirror the legacy proc's tolerance so
+    /// the same input that worked on <c>weblb_Fabric_GetMobileCard</c>
+    /// keeps working here. Tokens are trimmed, uppercased, and the legacy
+    /// <c>NRxxx → Rxxx</c> rewrite is applied. The fabric's own code is
+    /// removed from the result so a self-reference never appears as an
+    /// alternative chip.
+    /// </summary>
+    private static IReadOnlyList<string> SplitAlternatives(string? raw, string excludeCode)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return EmptyAlternativeList;
+
+        var seen   = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var result = new List<string>(capacity: 4);
+        var exclude = (excludeCode ?? string.Empty).Trim().ToUpperInvariant();
+
+        foreach (var token in raw.Split(_alternativeSeparators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            var t = token.Trim().ToUpperInvariant();
+            if (t.Length == 0) continue;
+
+            // Strip residual punctuation that has shown up in operator entries.
+            t = t.Replace(".", string.Empty, StringComparison.Ordinal)
+                 .Replace(":", string.Empty, StringComparison.Ordinal)
+                 .Replace("\\", string.Empty, StringComparison.Ordinal);
+            if (t.Length == 0) continue;
+
+            // Legacy "NRxxx" prefix → "Rxxx".
+            if (t.Length > 2 && t[0] == 'N' && t[1] == 'R')
+            {
+                t = "R" + t.Substring(2);
+            }
+
+            if (string.Equals(t, exclude, StringComparison.Ordinal)) continue;
+            if (seen.Add(t)) result.Add(t);
+        }
+
+        return result.Count == 0 ? EmptyAlternativeList : result;
+    }
+
+    private static readonly char[] _alternativeSeparators =
+        new[] { ',', ';', ' ', '\t', '\n', '\r', '|', '/' };
+
+    private static object NullableNVarChar(string? value)
+        => string.IsNullOrWhiteSpace(value) ? DBNull.Value : value.Trim();
 
     // ---------------------------------------------------------------------
     // Defensive readers — same pattern as SqlOrdersQueryService. Tolerate
@@ -255,6 +383,40 @@ public sealed class SqlFabricQueryService : IFabricQueryService
         var ordinal = TryGetOrdinal(reader, columnName);
         if (ordinal < 0 || reader.IsDBNull(ordinal)) return null;
         return Convert.ToDateTime(reader.GetValue(ordinal), CultureInfo.InvariantCulture);
+    }
+
+    /// <summary>
+    /// Reads a SQL <c>datetime2</c> column as a UTC <see cref="DateTimeOffset"/>.
+    /// The proc stamps <c>mes_LastCheckedAt</c> via <c>sysutcdatetime()</c>,
+    /// so the value is already in UTC — we just attach the offset so callers
+    /// can display "checked 5 min ago" without re-deriving the timezone.
+    /// </summary>
+    private static DateTimeOffset? ReadDateTimeOffsetOrNull(SqlDataReader reader, string columnName)
+    {
+        var dt = ReadDateTimeOrNull(reader, columnName);
+        if (dt is null) return null;
+        return new DateTimeOffset(DateTime.SpecifyKind(dt.Value, DateTimeKind.Utc));
+    }
+
+    /// <summary>
+    /// Reads a SQL <c>bit</c> column as <see cref="bool"/>. Tolerates wider
+    /// numeric representations (some legacy procs project <c>tinyint</c>);
+    /// non-zero ⇒ <c>true</c>.
+    /// </summary>
+    private static bool ReadBool(SqlDataReader reader, string columnName)
+    {
+        var ordinal = TryGetOrdinal(reader, columnName);
+        if (ordinal < 0 || reader.IsDBNull(ordinal)) return false;
+        var raw = reader.GetValue(ordinal);
+        return raw switch
+        {
+            bool b   => b,
+            byte by  => by != 0,
+            short s  => s != 0,
+            int i    => i != 0,
+            long l   => l != 0,
+            _        => bool.TryParse(Convert.ToString(raw, CultureInfo.InvariantCulture), out var parsed) && parsed,
+        };
     }
 
     private static int TryGetOrdinal(SqlDataReader reader, string columnName)

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
@@ -1,11 +1,16 @@
 @* FabricLowStock — desktop low-stock list for purchasing/ops.
 
    UX baseline: docs/ux/fabric-availability-static-preview.html (.desktop-panel).
-   F-1: rows come from FrontlineApiClient.GetLowStockAsync over
-   /api/frontline/fabric/low-stock. The toolbar still drives client-side
-   filtering only (server-side filter / sort / paging arrives in F-3 with
-   MudDataGrid ServerData and a real low-stock proc derived from the legacy
-   web_RemainsAll view).
+   F-2.3 / F-2.4: rows come from FrontlineApiClient.GetLowStockAsync over
+   /api/frontline/fabric/low-stock, which executes
+   dbo.mes_Fabric_GetLowStockList against the legacy LKvitaiDb. The toolbar
+   pushes search / threshold / status / width / supplier filters into the
+   FabricLowStockQueryParams payload so the SP does the heavy lifting and
+   the client only renders the returned page. KPI tiles aggregate across
+   the rows currently loaded; a server-side aggregate proc + windowed grid
+   are tracked in #100 and #101 — when the result set grows past one page
+   this view still works, but the metrics will need that follow-up to stay
+   accurate at scale.
 
    Columns (per fabric-availability-codex-rules.md §5):
      Photo · Code · Name · Width · Available (+progress) · Status · ETA
@@ -35,12 +40,12 @@
         <div class="fa-panel__head">
             <div>
                 <h2 id="ls-title">Low-stock materials</h2>
-                <p>Server-side filter, sort and paging once F-3 lands. F-1 uses the stub data source.</p>
+                <p>Server-side filter and sort over <span class="mono">dbo.mes_Fabric_GetLowStockList</span>; full grid paging arrives with #100.</p>
             </div>
             <span class="mono" style="color:var(--n-500); font-size:11.5px">
                 @(_apiError
                     ? "Frontline API unreachable"
-                    : $"F-1 · {_rows.Count} rows from /api/frontline/fabric/low-stock")
+                    : $"{_rows.Count} of {_totalRows} rows · /api/frontline/fabric/low-stock")
             </span>
         </div>
 
@@ -76,7 +81,8 @@
                 <input type="search"
                        value="@_search"
                        placeholder="Search code, name, supplier…"
-                       @oninput="@(e => _search = e.Value?.ToString() ?? "")" />
+                       @oninput="@OnSearchInput"
+                       @onkeyup="@OnSearchKeyUp" />
                 <span class="kbd">/</span>
             </label>
 
@@ -84,22 +90,22 @@
                       ExtraClass="threshold-field"
                       Value="@_threshold"
                       Options="@ThresholdOptions"
-                      ValueChanged="@(v => _threshold = v)" />
+                      ValueChanged="@OnThresholdChanged" />
 
             <LkSelect Label="Status"
                       Value="@_statusFilter"
                       Options="@StatusOptions"
-                      ValueChanged="@(v => _statusFilter = v)" />
+                      ValueChanged="@OnStatusChanged" />
 
             <LkSelect Label="Width"
                       Value="@_widthFilter"
-                      Options="@WidthOptions"
-                      ValueChanged="@(v => _widthFilter = v)" />
+                      Options="@_widthOptions"
+                      ValueChanged="@OnWidthChanged" />
 
             <LkSelect Label="Supplier"
                       Value="@_supplierFilter"
-                      Options="@SupplierOptions"
-                      ValueChanged="@(v => _supplierFilter = v)" />
+                      Options="@_supplierOptions"
+                      ValueChanged="@OnSupplierChanged" />
 
             <div style="flex:1"></div>
 
@@ -132,7 +138,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    @foreach (var r in FilteredRows())
+                    @foreach (var r in _rows)
                     {
                         <tr>
                             <td><span class="row-thumb @ThumbClass(r.Code)"></span></td>
@@ -197,7 +203,7 @@
                             </td>
                         </tr>
                     }
-                    else if (_initialised && !FilteredRows().Any())
+                    else if (_initialised && _rows.Count == 0)
                     {
                         <tr>
                             <td colspan="11" style="text-align:center; color:var(--n-500); padding:24px 12px">
@@ -210,14 +216,24 @@
         </div>
 
         <div class="fa-table-foot">
-            <span>Showing <strong>1–@FilteredRows().Count()</strong> of <strong>@_rows.Count</strong> rows</span>
-            <span class="mono" style="opacity:.7">F-1 stub · server paging arrives in F-3</span>
+            <span>Showing <strong>@(_rows.Count == 0 ? 0 : 1)–@_rows.Count</strong> of <strong>@_totalRows</strong> rows</span>
+            <span class="mono" style="opacity:.7">Server-side filter via dbo.mes_Fabric_GetLowStockList</span>
         </div>
     </section>
 
 </main>
 
 @code {
+    // Default page size for the desktop grid. Mirrors the SP's clamp (500)
+    // far enough to avoid a refetch when the operator scrolls past 100 rows
+    // without having to ship the full 800-row catalogue every time.
+    private const int DefaultPageSize = 200;
+
+    // KPI tiles aggregate across the rows currently on screen — accurate
+    // because the toolbar pushes the same filters into the SP, so the
+    // returned page IS the filtered universe up to DefaultPageSize. When
+    // the result set genuinely exceeds DefaultPageSize the metrics will
+    // undercount; #100 introduces server-side aggregates to fix that.
     private static readonly IReadOnlyList<SelectOption> ThresholdOptions =
     [
         new("",    "Any (all)"),
@@ -235,33 +251,36 @@
         new("disc", "Discontinued"),
     ];
 
-    private static readonly IReadOnlyList<SelectOption> WidthOptions =
-    [
-        new("",     "All widths"),
-        new("1600", "1600 mm"),
-        new("1800", "1800 mm"),
-        new("2000", "2000 mm"),
-        new("2500", "2500 mm"),
-    ];
-
-    private static readonly IReadOnlyList<SelectOption> SupplierOptions =
-    [
-        new("",       "All suppliers"),
-        new("Decora", "Decora"),
-        new("Vali",   "Vali"),
-        new("Marla",  "Marla"),
-    ];
+    // Width and supplier dropdowns are derived from the loaded rows so the
+    // operator only ever sees values that exist in the data — the legacy
+    // SQL Server has long-tail width / supplier values we don't want to
+    // hard-code. The rebuild runs on every reload; an empty list always
+    // includes the "All …" sentinel so the dropdown stays usable.
+    private IReadOnlyList<SelectOption> _widthOptions    = new[] { new SelectOption("", "All widths") };
+    private IReadOnlyList<SelectOption> _supplierOptions = new[] { new SelectOption("", "All suppliers") };
 
     private string _search          = "";
-    private string _threshold       = "";
+    private string _threshold       = "25";   // matches the SP default; "" = Any (all)
     private string _statusFilter    = "";
     private string _widthFilter     = "";
     private string _supplierFilter  = "";
 
     private List<FabricLowStockDto> _rows = new();
+    private int _totalRows;
     private bool _busy;
     private bool _apiError;
     private bool _initialised;
+
+    // Coalesces overlapping reloads when the operator types fast in the
+    // search box. The latest filter snapshot always wins; the previous
+    // request's CancellationToken is cancelled so its result never
+    // overwrites a newer one.
+    private CancellationTokenSource? _reloadCts;
+
+    // Free-text search debounce. 250 ms feels responsive without spamming
+    // the SP on every keystroke.
+    private CancellationTokenSource? _searchDebounceCts;
+    private const int SearchDebounceMs = 250;
 
     private int _metricBelow;
     private int _metricOut;
@@ -275,44 +294,109 @@
         await ReloadAsync().ConfigureAwait(true);
     }
 
+    private FabricLowStockQueryParams BuildQuery() => new()
+    {
+        Page             = 1,
+        PageSize         = DefaultPageSize,
+        Search           = string.IsNullOrWhiteSpace(_search) ? null : _search.Trim(),
+        ThresholdMeters  = int.TryParse(_threshold, out var t) ? t : (int?)null,
+        Status           = string.IsNullOrWhiteSpace(_statusFilter) ? null : _statusFilter,
+        WidthMm          = int.TryParse(_widthFilter, out var w) ? w : (int?)null,
+        Supplier         = string.IsNullOrWhiteSpace(_supplierFilter) ? null : _supplierFilter,
+    };
+
     private async Task ReloadAsync()
     {
+        // Cancel any in-flight request — keystroke storms shouldn't pile
+        // up requests that all eventually overwrite the UI in arrival
+        // order rather than relevance order.
+        _reloadCts?.Cancel();
+        _reloadCts?.Dispose();
+        _reloadCts = new CancellationTokenSource();
+        var ct = _reloadCts.Token;
+
         _busy = true;
         _apiError = false;
         StateHasChanged();
 
         try
         {
-            // F-1: fetch a single page of every row (stub returns ≤ 6 today).
-            // F-3 will switch to MudDataGrid ServerData and push these
-            // filters into FabricLowStockQueryParams instead of filtering in-memory.
-            var page = await Api
-                .GetLowStockAsync(new FabricLowStockQueryParams { Page = 1, PageSize = 200 }, CancellationToken.None)
-                .ConfigureAwait(true);
+            var page = await Api.GetLowStockAsync(BuildQuery(), ct).ConfigureAwait(true);
+
+            if (ct.IsCancellationRequested) return;
 
             if (page is null)
             {
                 _apiError = true;
                 _rows = new();
+                _totalRows = 0;
             }
             else
             {
                 _rows = page.Items.ToList();
+                _totalRows = page.Total;
+                RebuildDropdowns();
                 RecomputeMetrics();
             }
 
             _initialised = true;
         }
+        catch (OperationCanceledException)
+        {
+            // Superseded by a newer reload; nothing to do.
+        }
         finally
         {
-            _busy = false;
+            // Only clear busy if this is still the current reload —
+            // otherwise the newer reload will manage the flag itself.
+            if (!ct.IsCancellationRequested) _busy = false;
+        }
+    }
+
+    private void RebuildDropdowns()
+    {
+        // Widths: distinct, sorted ascending. The "All widths" sentinel is
+        // always first so the operator can clear the filter without typing.
+        var widths = new List<SelectOption> { new("", "All widths") };
+        widths.AddRange(_rows
+            .Select(r => r.WidthMm)
+            .Where(w => w > 0)
+            .Distinct()
+            .OrderBy(w => w)
+            .Select(w => new SelectOption(w.ToString(), $"{w} mm")));
+        _widthOptions = widths;
+
+        // Suppliers: distinct (case-insensitive), sorted alphabetically.
+        var suppliers = new List<SelectOption> { new("", "All suppliers") };
+        suppliers.AddRange(_rows
+            .Select(r => r.Supplier)
+            .Where(s => !string.IsNullOrWhiteSpace(s))
+            .Select(s => s!.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(s => s, StringComparer.OrdinalIgnoreCase)
+            .Select(s => new SelectOption(s, s)));
+        _supplierOptions = suppliers;
+
+        // If the operator's current filter value vanished from the data
+        // (e.g. supplier filter set to "Bamar Pol" but the threshold
+        // change dropped them), clear it silently — keeping a stale value
+        // would result in an empty grid the operator can't explain.
+        if (!string.IsNullOrEmpty(_widthFilter) &&
+            !_widthOptions.Any(o => o.Value == _widthFilter))
+        {
+            _widthFilter = "";
+        }
+        if (!string.IsNullOrEmpty(_supplierFilter) &&
+            !_supplierOptions.Any(o => string.Equals(o.Value, _supplierFilter, StringComparison.OrdinalIgnoreCase)))
+        {
+            _supplierFilter = "";
         }
     }
 
     private void RecomputeMetrics()
     {
         var weekFromNow = DateOnly.FromDateTime(DateTime.UtcNow.Date.AddDays(7));
-        _metricBelow = _rows.Count;
+        _metricBelow = _totalRows;
         _metricOut = _rows.Count(r => r.Status == FabricAvailabilityStatus.None);
         _metricOutNoEta = _rows.Count(r => r.Status == FabricAvailabilityStatus.None && r.ExpectedDate is null);
         _metricExpected = _rows.Count(r => r.ExpectedDate is { } d && d <= weekFromNow);
@@ -320,51 +404,66 @@
         _metricDisc = _rows.Count(r => r.Status == FabricAvailabilityStatus.Discontinued);
     }
 
-    private IEnumerable<FabricLowStockDto> FilteredRows()
+    private void OnSearchInput(ChangeEventArgs e)
     {
-        IEnumerable<FabricLowStockDto> q = _rows;
+        _search = e.Value?.ToString() ?? "";
+        DebouncedReload();
+    }
 
-        if (!string.IsNullOrWhiteSpace(_search))
+    private async Task OnSearchKeyUp(KeyboardEventArgs e)
+    {
+        // Enter triggers an immediate fetch — operator is signalling intent.
+        if (string.Equals(e.Key, "Enter", StringComparison.OrdinalIgnoreCase))
         {
-            var needle = _search.Trim();
-            q = q.Where(r =>
-                r.Code.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
-                r.Name.Contains(needle, StringComparison.OrdinalIgnoreCase) ||
-                (r.Supplier?.Contains(needle, StringComparison.OrdinalIgnoreCase) ?? false) ||
-                r.AlternativeCodes.Any(a => a.Contains(needle, StringComparison.OrdinalIgnoreCase)));
+            _searchDebounceCts?.Cancel();
+            await ReloadAsync().ConfigureAwait(true);
         }
+    }
 
-        q = _statusFilter switch
-        {
-            "low"  => q.Where(r => r.Status == FabricAvailabilityStatus.Low),
-            "out"  => q.Where(r => r.Status == FabricAvailabilityStatus.None),
-            "disc" => q.Where(r => r.Status == FabricAvailabilityStatus.Discontinued),
-            _      => q,
-        };
+    private void DebouncedReload()
+    {
+        _searchDebounceCts?.Cancel();
+        _searchDebounceCts?.Dispose();
+        _searchDebounceCts = new CancellationTokenSource();
+        var ct = _searchDebounceCts.Token;
 
-        if (_threshold == "0")
+        // Fire-and-forget: the await happens inside Task.Run so the input
+        // handler returns immediately and Blazor batches the StateHasChanged
+        // for the new search value.
+        _ = Task.Run(async () =>
         {
-            q = q.Where(r => r.Status == FabricAvailabilityStatus.None);
-        }
-        else if (int.TryParse(_threshold, out var t))
-        {
-            q = q.Where(r =>
-                r.AvailableMeters <= t ||
-                r.Status is FabricAvailabilityStatus.Discontinued or FabricAvailabilityStatus.None);
-        }
+            try
+            {
+                await Task.Delay(SearchDebounceMs, ct).ConfigureAwait(false);
+                if (ct.IsCancellationRequested) return;
+                await InvokeAsync(ReloadAsync).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { /* superseded */ }
+        });
+    }
 
-        if (!string.IsNullOrEmpty(_widthFilter) && int.TryParse(_widthFilter, out var w))
-        {
-            q = q.Where(r => r.WidthMm == w);
-        }
+    private Task OnThresholdChanged(string v)
+    {
+        _threshold = v;
+        return ReloadAsync();
+    }
 
-        if (!string.IsNullOrEmpty(_supplierFilter))
-        {
-            q = q.Where(r =>
-                string.Equals(r.Supplier, _supplierFilter, StringComparison.OrdinalIgnoreCase));
-        }
+    private Task OnStatusChanged(string v)
+    {
+        _statusFilter = v;
+        return ReloadAsync();
+    }
 
-        return q;
+    private Task OnWidthChanged(string v)
+    {
+        _widthFilter = v;
+        return ReloadAsync();
+    }
+
+    private Task OnSupplierChanged(string v)
+    {
+        _supplierFilter = v;
+        return ReloadAsync();
     }
 
     private static int MetersBarPct(FabricLowStockDto r)


### PR DESCRIPTION
## Summary

Frontline fabric availability — F-2.3 + F-2.4 (and a small F-2.2 status bugfix). Closes the loop so the test deploy stops showing F-1 stub fixtures and starts serving real data from the legacy `LKVITAIDBV1SQL`.

PR #90 (F-2.1 + F-2.2) shipped the lookup-card adapter and the audit log, but left the low-stock list throwing `NotImplementedException` and `FrontlineFabricDataSource` defaulting to `Stub`. Test deploy was therefore still rendering the in-memory fixtures even though the API container had been built. This PR finishes the SQL adapter side, flips the data-source default to `Auto` and wires the test compose so any deploy that ships the `LKvitaiDb` connection string automatically uses real data — same shape as Sales.

Closes #97 (F-2.3 low-stock SQL adapter) and #99 (F-2.4 data-source flip). #98 / #100 / #101 are partially addressed and tracked for the next pass.

### F-2.3 — Low-stock list SQL adapter (`docs/sql/frontline-f2-3.sql`)

- New proc `dbo.mes_Fabric_GetLowStockList` — server-side filter (search/threshold/status/width/supplier), sort (Code | Available | LastChecked, ASC | DESC), 1-based paging up to 500/page, windowed `TotalRows` on every row (mirrors `weblb_Orders_Paged` shape)
- Joins `TBD_Components → V_Remains → TBD_Suppliers`; inclusion rule keeps **Out** and **Discontinued** visible regardless of threshold so they're never hidden by a high slider value
- `SqlFabricQueryService.GetLowStockListAsync` replaces the previous `NotImplementedException` with a real adapter; defensive readers tolerate `DBNull` / missing columns; `AlternativeCodes` CSV is split + normalised client-side (handles `;,/|` separators, `NRxxx → Rxxx` legacy rewrite, dedup, self-reference removal). Per-call structured perf log `[FrontlinePerf] sql.GetLowStockList`

### F-2.4 — Data-source flip

- `FrontlineFabricDataSource` default mode flips Stub → Auto:
  - `Auto` + `ConnectionStrings:LKvitaiDb` set → SQL adapter
  - `Auto` + no connection → Stub fallback with a `Warning` startup log
  - `Sql` → SQL adapter, fail-fast on missing connection
  - `Stub` → explicit dev/test opt-in (clean `Info` log)

  Mirrors `SalesOrdersDataSource` so the two modules behave identically.
- `appsettings.json` (Frontline.Api): adds `Frontline:FabricDataSource = "Auto"`, `Frontline:Sql:CommandTimeoutSeconds = 30`, and a connection-string placeholder hint. Real connection string still comes from the `ConnectionStrings__LKvitaiDb` env var at deploy time.
- `docker-compose.test.yml`: `frontline-api` now receives `ConnectionStrings__LKvitaiDb` (from the `LKVITAI_MSACCESS_DB_CONNECTION` secret) and `Frontline__FabricDataSource=Sql`, mirroring `sales-api`. **Removes the silent stub fallback in the test environment.**

### F-2.2 — Status bugfix (`docs/sql/frontline-f2-2.sql`)

- `dbo.mes_Fabric_GetMobileCard`: values BETWEEN `@LowThreshold` and `@EnoughThreshold-1` (e.g. 15m at the 25m enough-threshold) used to fall through the CASE to status=0 (Unknown) and showed no badge on the lookup card. Now mapped to status=2 (Low) so the lookup card and the low-stock list always agree on whether a fabric is "running out". `@LowThreshold` parameter is kept in the signature for backwards compatibility but documented as reserved.

### WebUI (`FabricLowStock.razor`)

- Toolbar pushes search / threshold / status / width / supplier filters into `FabricLowStockQueryParams` instead of filtering in-memory, so the SP does the heavy lifting on prod's 757-fabric catalogue
- Width and supplier dropdowns now derive from the loaded rows (the F-1 hardcoded `Decora / Vali / Marla` list never matched prod's `Bamar Pol / DOMICET / ALMEDAHL`)
- In-flight reload requests are coalesced via `CancellationToken`; free-text search is debounced 250 ms; `Enter` triggers an immediate fetch
- KPI tiles still aggregate client-side; #100 + #101 will move them to a server aggregate when the page-1 buffer is no longer enough

## Test plan

Smoke-tested end-to-end against the prod `LKVITAIDBV1SQL`:

**Lookup card:**

| Case | Expected | Observed |
|---|---|---|
| `/fabric/R104` | name "Tkanina impr. gr. III", supplier "Bamar Pol", widths[0] = 2000mm/15m/Low | matches |
| `/fabric/R104` (status fix) | widths[0].status = 2 (Low) after F-2.2 bugfix | matches (was 0/Unknown before) |
| `/fabric/NOPE_DOESNT_EXIST` | 404 + audit row | matches |

**Low-stock list:**

| Filter | Expected total | Observed |
|---|---|---|
| defaults (threshold=25) | 589 | 589 |
| status=disc | 342 | 342 |
| supplier="Bamar Pol" | 56 | 56 |
| threshold=0 (Out + Disc) | 344 | 344 |
| width=2500 | 2 | 2 |

**Audit log:**

```
sCodeInternal       CheckedAt              CheckedBy
NOPE_DOESNT_EXIST   2026-05-03 07:28:33    (anon)
R104                2026-05-03 07:28:33    (anon)
```

`R104.mes_LastCheckedAt = 2026-05-03 07:28:33` → recorder is updating the matched fabric row AND inserting a log entry.

**Composition modes:**

| Config | Expected | Observed |
|---|---|---|
| `Sql` + connection set | SQL adapter, no warning | matches |
| `Auto` + connection set | SQL adapter, no warning | matches |
| `Auto` + no connection | Stub + WARN startup log | matches |
| `Stub` + no connection | Stub + INFO startup log (explicit opt-in) | matches |
| `Sql` + no connection | startup `InvalidOperationException` (fail fast) | matches |

- [ ] CI green (`frontline-build`, `architecture`, `e2e-tests`, `GitGuardian`)
- [ ] SonarCloud quality gate (any new issues triaged or accepted)
- [ ] Manual QA in test deploy: WebUI low-stock shows real `Bamar Pol / DOMICET / ALMEDAHL` suppliers (not stub `Decora / Vali / Marla`)
- [ ] Manual QA in test deploy: lookup card for a known fabric (e.g. R104) returns prod data and writes an audit row

## Out of scope (tracked separately)

- **#98** — `dbo.mes_Fabric_GetLowStockMetrics` for the 4-tile KPI strip (current page-1 client-side aggregate is correct up to ~200 rows; needs server aggregate when #100 lands)
- **#100** — MudDataGrid `ServerData` with windowed paging (this PR pushes filters server-side and dropdowns are derived; full grid paging is the remaining piece)
- **#101** — wire KPI tiles to the new server endpoint (depends on #98)
- **#102** — Frontline Portal cookie auth + WebUI `DelegatingHandler` (`CheckedBy` is null until then)
