### PR TITLE
fix(frontline/api): apply Sales OpenSSL/TLS hack so Frontline.Api can talk to legacy LKvitaiDb

### DIFF
--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Dockerfile
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Dockerfile
@@ -32,9 +32,23 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false --no-restore
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS runtime
 WORKDIR /app
 
+# curl is needed for the docker-compose healthcheck.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Legacy LKvitaiDb (SQL Server 2008/2012) compatibility — same hack as
+# Sales.Api/Dockerfile. The .NET 8 base image (Debian 12) ships OpenSSL 3
+# with SECLEVEL=2 and MinProtocol=TLSv1.2. The legacy SQL Server only offers
+# TLS 1.0 with SHA1-signed self-signed certs during the TDS pre-login
+# handshake (which is mandatory regardless of Encrypt=False), so the
+# connection dies with "SSL Provider, error: 31 - Encryption(ssl/tls)
+# handshake failed" before any SQL is sent. Lower SECLEVEL and MinProtocol
+# so the handshake can complete; the actual data exchange is still
+# unencrypted because the connection string sets
+# Encrypt=False;TrustServerCertificate=True.
+RUN sed -i 's|^\[openssl_init\]|[openssl_init]\nssl_conf = ssl_sect|' /etc/ssl/openssl.cnf \
+    && printf '\n[ssl_sect]\nsystem_default = system_default_sect\n\n[system_default_sect]\nMinProtocol = TLSv1\nCipherString = DEFAULT:@SECLEVEL=0\n' >> /etc/ssl/openssl.cnf
 
 COPY --from=build /app/publish .
 USER app


### PR DESCRIPTION
## Summary

Hotfix on top of merged PR #108. Frontline.Api in the test deploy was 500-ing every `/api/frontline/fabric/*` call with:

```
Microsoft.Data.SqlClient.SqlException (0x80131904):
A connection was successfully established with the server, but then an error occurred during the pre-login handshake.
(provider: SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed)
 ---> System.IO.IOException: Received an unexpected EOF or 0 bytes from the transport stream.
```

Root cause: Frontline.Api's Dockerfile was missing the OpenSSL config tweak Sales.Api carries (added in the S-2 work). The .NET 8 runtime image (Debian 12) ships OpenSSL 3 with `SECLEVEL=2` and `MinProtocol=TLSv1.2`, but the legacy `LKVITAIDBV1SQL` server only offers TLS 1.0 with a SHA1-signed self-signed cert during the TDS pre-login handshake. The handshake is mandatory regardless of `Encrypt=False`, so it has to negotiate something both sides accept — without the tweak it dies before any TDS bytes go over the wire.

Fix: copy the exact `sed` + `printf` block from `src/Modules/Sales/LKvitai.MES.Modules.Sales.Api/Dockerfile` into `src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Dockerfile`. Same comment block for the next person who has to debug this.

Actual data exchange stays unencrypted (the secret connection string sets `Encrypt=False;TrustServerCertificate=True`); only the pre-login handshake is allowed to negotiate TLS 1.0.

No code changes — Dockerfile only.

## Test plan

- [ ] CI green (`frontline-build`, `architecture`, `e2e-tests`, `GitGuardian`)
- [ ] After deploy-test runs, `https://mes-test.lauresta.com/frontline/fabric/low-stock` shows real prod fabrics (Bamar Pol / DOMICET / ALMEDAHL suppliers, hundreds of rows) instead of the "Frontline API unreachable" banner
- [ ] After deploy-test, `https://mes-test.lauresta.com/api/frontline/fabric/R104` returns the prod card (200) and writes a `dbo.mes_FabricAvailabilityCheckLog` row
