### PR TITLE
fix(frontline): low-stock view loads the full filtered set in one fetch (no fake paging)

### DIFF
--- a/docs/sql/frontline-f2-3.sql
+++ b/docs/sql/frontline-f2-3.sql
@@ -63,7 +63,13 @@ BEGIN
 
     IF @Page     IS NULL OR @Page     < 1   SET @Page     = 1;
     IF @PageSize IS NULL OR @PageSize < 1   SET @PageSize = 50;
-    IF @PageSize > 500                      SET @PageSize = 500;
+    -- Cap at 1000 so a single fetch can carry the whole low-stock view
+    -- (prod catalogue is ~757 fabrics; threshold=25 returns ~560 rows).
+    -- WebUI defaults to PageSize=1000 so every low-stock row is visible
+    -- without paginating through partial pages — until #100 ships
+    -- proper MudDataGrid windowed paging, this keeps KPI tiles accurate
+    -- and removes the confusing "Showing 1–200 of 557" footer.
+    IF @PageSize > 1000                     SET @PageSize = 1000;
     IF @ThresholdMeters IS NULL OR @ThresholdMeters < 0 SET @ThresholdMeters = 25;
     IF @LowThreshold    IS NULL OR @LowThreshold    < 0 SET @LowThreshold    = 10;
 

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
@@ -52,8 +52,11 @@ public sealed class SqlFabricQueryService : IFabricQueryService
     private const string PlaceholderPhotoUrl    = "/img/fabric_pl.png";
 
     /// <summary>Soft cap on per-page rows; mirrors the SP's own clamp so
-    /// the wire never sees a request the SP would silently shrink.</summary>
-    private const int MaxPageSize = 500;
+    /// the wire never sees a request the SP would silently shrink. The SP
+    /// caps at 1000 because the prod catalogue is ~757 fabrics, so the
+    /// WebUI low-stock view can fetch the entire filtered result set in a
+    /// single round-trip until #100 wires real MudDataGrid windowed paging.</summary>
+    private const int MaxPageSize = 1000;
 
     /// <summary>Deduplication-friendly empty list, returned for fabrics
     /// whose <c>fa_Alternatives</c> column is NULL or whitespace.</summary>

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
@@ -112,12 +112,6 @@
             <button class="btn-xs" type="button" title="Refresh data" @onclick="ReloadAsync" disabled="@_busy">
                 @(_busy ? "…" : "↻ Refresh")
             </button>
-
-            <nav class="pagination" aria-label="Pagination">
-                <button type="button" disabled>‹</button>
-                <button type="button" class="is-active">1</button>
-                <button type="button" disabled>›</button>
-            </nav>
         </div>
 
         <div class="fa-table-wrap">
@@ -216,7 +210,23 @@
         </div>
 
         <div class="fa-table-foot">
-            <span>Showing <strong>@(_rows.Count == 0 ? 0 : 1)–@_rows.Count</strong> of <strong>@_totalRows</strong> rows</span>
+            <span>
+                @if (_rows.Count == 0)
+                {
+                    <text>No fabrics match the current filters.</text>
+                }
+                else if (_rows.Count == _totalRows)
+                {
+                    <text>Showing all <strong>@_totalRows</strong> matching fabrics.</text>
+                }
+                else
+                {
+                    <text>
+                        Showing first <strong>@_rows.Count</strong> of <strong>@_totalRows</strong> matching fabrics.
+                        Narrow the filters to bring the rest into view (full grid paging tracked in #100).
+                    </text>
+                }
+            </span>
             <span class="mono" style="opacity:.7">Server-side filter via dbo.mes_Fabric_GetLowStockList</span>
         </div>
     </section>
@@ -224,16 +234,14 @@
 </main>
 
 @code {
-    // Default page size for the desktop grid. Mirrors the SP's clamp (500)
-    // far enough to avoid a refetch when the operator scrolls past 100 rows
-    // without having to ship the full 800-row catalogue every time.
-    private const int DefaultPageSize = 200;
-
-    // KPI tiles aggregate across the rows currently on screen — accurate
-    // because the toolbar pushes the same filters into the SP, so the
-    // returned page IS the filtered universe up to DefaultPageSize. When
-    // the result set genuinely exceeds DefaultPageSize the metrics will
-    // undercount; #100 introduces server-side aggregates to fix that.
+    // Default page size for the desktop grid. The SP caps at 1000; the prod
+    // catalogue is ~757 fabrics, so a single fetch carries every row that
+    // matches the filters — KPI tiles stay accurate without a server-side
+    // aggregate proc, and the operator can scan, sort and search the whole
+    // low-stock universe from one screen. #100 will introduce real
+    // MudDataGrid windowed paging if the catalogue ever outgrows 1000 rows
+    // for a single filter combination.
+    private const int DefaultPageSize = 1000;
     private static readonly IReadOnlyList<SelectOption> ThresholdOptions =
     [
         new("",    "Any (all)"),


### PR DESCRIPTION
## Summary

UX hotfix on top of merged PRs #108 + #109. Operators reported the desktop low-stock list footer showed `Showing 1–200 of 557 rows` with no way to reach the other 357 — the static `<nav class="pagination">` in the toolbar was a placeholder for #100 (MudDataGrid windowed paging), not real pagination. KPI tiles were also undercounting because they aggregated only across the loaded 200 rows.

Until #100 lands, this PR sizes a single fetch to fit the entire filtered set, so the operator can scan / sort / search the whole low-stock universe from one screen and the KPI tiles stay accurate.

### Changes

- **`dbo.mes_Fabric_GetLowStockList`**: bump `@PageSize` cap from 500 → 1000 (re-applied to prod). Prod catalogue is ~757 fabrics; threshold=25 returns ~560 rows; threshold=100 returns ~700 — well within 1000.
- **`SqlFabricQueryService.MaxPageSize`**: 500 → 1000, mirrors the SP cap.
- **`FabricLowStock.razor`** (`DefaultPageSize` 200 → 1000):
  - Drops the static fake `<nav class="pagination">` from the toolbar (better no pagination than a button that does nothing).
  - Footer wording is now one of three honest variants:
    - `No fabrics match the current filters.` (empty)
    - `Showing all <N> matching fabrics.` (N == totalRows — the prod case)
    - `Showing first <N> of <M> matching fabrics. Narrow the filters to bring the rest into view (full grid paging tracked in #100).` (the rare edge case where the filtered set actually exceeds 1000 — physically unreachable today)

### Why not real pagination right now

Issue #100 stays open and now genuinely tracks "MudDataGrid `ServerData` with windowed paging". Its only valid scenario after this PR is a filter combination that returns >1000 rows — which the prod catalogue size (~757 fabrics) cannot produce today. When the catalogue grows past 1000 fabrics, #100 becomes unblocked.

## Test plan

- [ ] CI green
- [ ] After deploy-test runs, `https://mes-test.lauresta.com/frontline/fabric/low-stock` renders the entire filtered set in one page (e.g. ~557 rows at threshold=25), and the footer says `Showing all 557 matching fabrics.`
- [ ] KPI tiles in the strip match the totals shown by changing filters (Below threshold = grid total)
- [ ] No fake `‹ 1 ›` pagination strip in the toolbar anymore
