### PR TITLE
fix(frontline): pageSize regression + loading affordance for low-stock list

### DIFF
--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Endpoints/FabricAvailabilityEndpoints.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Endpoints/FabricAvailabilityEndpoints.cs
@@ -135,10 +135,26 @@ public static class FabricAvailabilityEndpoints
         int?    Page,
         int?    PageSize)
     {
+        // PageSize semantics: missing or non-positive → server default (50);
+        // anything above the SP cap is clamped DOWN to the cap rather than
+        // silently reset to 50 (the previous behaviour, which made the
+        // WebUI's pageSize=1000 request collapse to 50 rows and made the
+        // toolbar filters look broken because the first 50 Code-ASC rows
+        // rarely change between threshold values).
+        // Cap is kept in sync with SqlFabricQueryService.MaxPageSize and
+        // dbo.mes_Fabric_GetLowStockList's @PageSize clamp (both 1000).
+        private const int MaxPageSize = 1000;
+
         public FabricLowStockQueryParams ToQueryParams()
         {
             var page = Page is null or < 1 ? 1 : Page.Value;
-            var size = PageSize is null or < 1 or > 500 ? 50 : PageSize.Value;
+            var size = PageSize switch
+            {
+                null               => 50,
+                < 1                => 50,
+                > MaxPageSize      => MaxPageSize,
+                _                  => PageSize.Value,
+            };
             return new FabricLowStockQueryParams
             {
                 Search          = Search,

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
@@ -43,9 +43,18 @@
                 <p>Server-side filter and sort over <span class="mono">dbo.mes_Fabric_GetLowStockList</span>; full grid paging arrives with #100.</p>
             </div>
             <span class="mono" style="color:var(--n-500); font-size:11.5px">
-                @(_apiError
-                    ? "Frontline API unreachable"
-                    : $"{_rows.Count} of {_totalRows} rows · /api/frontline/fabric/low-stock")
+                @if (_apiError)
+                {
+                    <text>Frontline API unreachable</text>
+                }
+                else if (!_initialised)
+                {
+                    <text>Loading… · /api/frontline/fabric/low-stock</text>
+                }
+                else
+                {
+                    @($"{_rows.Count} of {_totalRows} rows · /api/frontline/fabric/low-stock")
+                }
             </span>
         </div>
 
@@ -109,12 +118,18 @@
 
             <div style="flex:1"></div>
 
-            <button class="btn-xs" type="button" title="Refresh data" @onclick="ReloadAsync" disabled="@_busy">
-                @(_busy ? "…" : "↻ Refresh")
+            <button class="btn-xs" type="button" title="Refresh data" @onclick="ReloadAsync" disabled="@_isRefreshing">
+                @(_isRefreshing ? "…" : "↻ Refresh")
             </button>
         </div>
 
-        <div class="fa-table-wrap">
+        @* Non-blocking loading affordance. Stays invisible for fast (cache-hit)
+           reloads — only paints if the API takes longer than LoadingShowAfterMs.
+           Toolbar above stays interactive; table body below dims to 60% via the
+           is-refreshing modifier on .fa-table-wrap. Same UX as Sales orders. *@
+        <div class="fa-loading-bar @(_isRefreshing ? "is-active" : "")" aria-hidden="true"></div>
+
+        <div class="fa-table-wrap @(_isRefreshing ? "is-refreshing" : "")">
             <table class="lk-table">
                 <thead>
                     <tr>
@@ -132,6 +147,29 @@
                     </tr>
                 </thead>
                 <tbody>
+                    @* First-load skeleton: render placeholder rows until the
+                       very first response lands. Without it the operator sees
+                       an empty <tbody> + a 2px loading bar, which reads as
+                       "no data" rather than "loading" on a slow cold start. *@
+                    @if (!_initialised && !_apiError)
+                    {
+                        @for (var i = 0; i < SkeletonRowCount; i++)
+                        {
+                            <tr class="fa-skel-row" aria-hidden="true">
+                                <td><span class="fa-skel fa-skel--thumb"></span></td>
+                                <td><span class="fa-skel fa-skel--w60"></span></td>
+                                <td><span class="fa-skel fa-skel--w160"></span></td>
+                                <td><span class="fa-skel fa-skel--w40"></span></td>
+                                <td><span class="fa-skel fa-skel--w120"></span></td>
+                                <td><span class="fa-skel fa-skel--w60"></span></td>
+                                <td><span class="fa-skel fa-skel--w80"></span></td>
+                                <td><span class="fa-skel fa-skel--w40"></span></td>
+                                <td><span class="fa-skel fa-skel--w120"></span></td>
+                                <td><span class="fa-skel fa-skel--w60"></span></td>
+                                <td><span class="fa-skel fa-skel--w60"></span></td>
+                            </tr>
+                        }
+                    }
                     @foreach (var r in _rows)
                     {
                         <tr>
@@ -211,7 +249,11 @@
 
         <div class="fa-table-foot">
             <span>
-                @if (_rows.Count == 0)
+                @if (!_initialised)
+                {
+                    <text>Loading…</text>
+                }
+                else if (_rows.Count == 0)
                 {
                     <text>No fabrics match the current filters.</text>
                 }
@@ -275,7 +317,26 @@
 
     private List<FabricLowStockDto> _rows = new();
     private int _totalRows;
-    private bool _busy;
+
+    // Loading-bar UX (mirrors Sales orders Index.razor):
+    //   * `_isRefreshing` is the *visible* state — it is only flipped on
+    //     after LoadingShowAfterMs so a fast (cache-hit) reload never
+    //     paints a bar at all.
+    //   * Once shown, the bar stays on screen for at least
+    //     LoadingMinVisibleMs total so it does not flash on/off in a
+    //     single frame on borderline-slow responses.
+    //   * The Refresh button and pagination buttons share `_isRefreshing`
+    //     so they only disable when the bar is actually visible —
+    //     instant reloads keep the toolbar fully responsive.
+    private bool _isRefreshing;
+    private const int LoadingShowAfterMs  = 150;
+    private const int LoadingMinVisibleMs = 350;
+
+    // Number of placeholder rows rendered before the first response lands.
+    // 8 fills a typical 1080p viewport without dwarfing the panel — enough
+    // structure to read as "loading" rather than "no data".
+    private const int SkeletonRowCount = 8;
+
     private bool _apiError;
     private bool _initialised;
 
@@ -323,13 +384,14 @@
         _reloadCts = new CancellationTokenSource();
         var ct = _reloadCts.Token;
 
-        _busy = true;
         _apiError = false;
-        StateHasChanged();
+        // NOTE: do NOT flip _isRefreshing here. We schedule it after
+        // LoadingShowAfterMs so a fast (cache-hit) response never paints
+        // a loading bar at all — filter changes feel instant.
 
         try
         {
-            var page = await Api.GetLowStockAsync(BuildQuery(), ct).ConfigureAwait(true);
+            var page = await FetchWithDeferredLoadingBarAsync(ct).ConfigureAwait(true);
 
             if (ct.IsCancellationRequested) return;
 
@@ -355,10 +417,55 @@
         }
         finally
         {
-            // Only clear busy if this is still the current reload —
-            // otherwise the newer reload will manage the flag itself.
-            if (!ct.IsCancellationRequested) _busy = false;
+            // Only clear the visible refresh state if this is still the
+            // current reload — otherwise the newer reload will manage it.
+            if (!ct.IsCancellationRequested)
+            {
+                _isRefreshing = false;
+                StateHasChanged();
+            }
         }
+    }
+
+    /// <summary>
+    /// Races the low-stock API call against a "show loading bar" delay so a
+    /// fast (cache-hit) response never paints a loading affordance, while a
+    /// slow one still gets a stable bar that stays visible for at least
+    /// <see cref="LoadingMinVisibleMs"/>. Mirrors the Sales orders helper of
+    /// the same shape — keep both in sync if the UX lever ever moves.
+    /// </summary>
+    private async Task<PagedResult<FabricLowStockDto>?> FetchWithDeferredLoadingBarAsync(CancellationToken ct)
+    {
+        var totalSw  = System.Diagnostics.Stopwatch.StartNew();
+        var apiTask  = Api.GetLowStockAsync(BuildQuery(), ct);
+        var showTask = Task.Delay(LoadingShowAfterMs, ct);
+
+        long? barShownAtMs = null;
+        if (await Task.WhenAny(apiTask, showTask).ConfigureAwait(true) == showTask
+            && !showTask.IsCanceled)
+        {
+            _isRefreshing = true;
+            barShownAtMs  = totalSw.ElapsedMilliseconds;
+            StateHasChanged();
+        }
+
+        var result = await apiTask.ConfigureAwait(true);
+
+        if (barShownAtMs is { } shownAt)
+        {
+            // Once the bar is up, keep it visible long enough to register —
+            // otherwise it flashes off the moment the API completes, which
+            // feels glitchy. Cancellation here just means we were superseded;
+            // the caller handles the stale-response case.
+            var remaining = LoadingMinVisibleMs - (int)(totalSw.ElapsedMilliseconds - shownAt);
+            if (remaining > 0)
+            {
+                try { await Task.Delay(remaining, ct).ConfigureAwait(true); }
+                catch (OperationCanceledException) { /* superseded; fall through */ }
+            }
+        }
+
+        return result;
     }
 
     private void RebuildDropdowns()

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Services/FrontlineApiClient.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Services/FrontlineApiClient.cs
@@ -184,7 +184,11 @@ public sealed class FrontlineApiClient
         {
             parts.Add($"page={query.Page}");
         }
-        if (query.PageSize is > 0 and not 50)
+        // Always forward pageSize when explicitly set on the client query —
+        // omitting it lets the server fall back to its own default (50),
+        // which silently throws away the WebUI's "show me everything"
+        // intent. The API endpoint clamps to its own MaxPageSize cap.
+        if (query.PageSize > 0)
         {
             parts.Add($"pageSize={query.PageSize}");
         }

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
@@ -528,6 +528,44 @@ button, input, select { font: inherit; }
 .threshold-field .toolbar__label { color: var(--accent-700); }
 .threshold-field select { color: var(--accent-700); font-weight: 600; }
 
+/* ── Loading affordance ────────────────────────────────────────
+   Mirrors the Sales orders-list loading bar (orders.css §list-loading-bar)
+   so the Frontline low-stock screen feels identical when filters reload.
+   The bar sits between the toolbar and the table; the table body fades to
+   60% opacity and ignores pointer events while a refresh is in flight. */
+.fa-loading-bar { position: relative; height: 2px; overflow: hidden;
+  background: transparent; transition: background .12s ease-in-out; }
+.fa-loading-bar.is-active { background: var(--accent-50); }
+.fa-loading-bar.is-active::before {
+  content: "";
+  position: absolute; left: 0; top: 0; bottom: 0; width: 35%;
+  background: linear-gradient(90deg, transparent 0%,
+    var(--accent-500) 30%, var(--accent-500) 70%, transparent 100%);
+  animation: fa-loading-slide 1.05s ease-in-out infinite;
+}
+@keyframes fa-loading-slide {
+  0%   { transform: translateX(-100%); }
+  100% { transform: translateX(286%); }
+}
+.fa-table-wrap.is-refreshing tbody { opacity: .6; pointer-events: none;
+  transition: opacity .12s ease-in-out; }
+
+/* First-load skeleton rows — gentle pulse so an operator opening the
+   page on a cold deploy sees structured placeholder content instead of
+   a blank panel + a loading bar. The placeholder bar inside each cell
+   varies in width so it doesn't read as a uniform striped pattern. */
+.fa-skel { display: inline-block; height: 10px; border-radius: 3px;
+  background: var(--n-100); animation: fa-skel-pulse 1.4s ease-in-out infinite; }
+.fa-skel--w20  { width:  20px; } .fa-skel--w40  { width:  40px; }
+.fa-skel--w60  { width:  60px; } .fa-skel--w80  { width:  80px; }
+.fa-skel--w120 { width: 120px; } .fa-skel--w160 { width: 160px; }
+.fa-skel--thumb { width: 36px; height: 28px; border-radius: 4px;
+  vertical-align: middle; }
+@keyframes fa-skel-pulse {
+  0%, 100% { opacity: .55; }
+  50%      { opacity: .9; }
+}
+
 /* ── Low-stock table (also used inside fabric.css; lk-table is local copy
       to keep Frontline.WebUI self-contained until shared assembly extraction) */
 .fa-table-wrap { overflow-x: auto; }


### PR DESCRIPTION
## Summary

Two fixes on top of merged PR #110, both prompted by operator feedback on the test deploy. Stacked into one PR because they share the same feature branch and would otherwise force-push to split.

### 1. API silently clamped `pageSize > 500` to 50

> "Footer always shows `Showing first 50 of 659 matching fabrics. Narrow the filters to bring the rest into view (full grid paging tracked in #100).`, and changing the toolbar filters does nothing."

PR #110 bumped the SP cap and the WebUI default to 1000 but missed the API-side guard inside `LowStockListRequest.ToQueryParams()`:

```csharp
var size = PageSize is null or < 1 or > 500 ? 50 : PageSize.Value;
```

Anything above 500 (the old cap) was reset to 50 instead of being clamped down to the cap. So the WebUI's `pageSize=1000` request collapsed to 50 rows, the footer always showed `Showing first 50 of <N>`, and the toolbar filters "did nothing" because the first 50 rows by Code-ASC are dominated by the R1xx range and rarely change between threshold values (only the `totalRows` count shifted, which the operator could not see in a single 50-row window).

`FrontlineApiClient.BuildLowStockUrl` was also skipping `pageSize=50`. The "skip pageSize when it equals 50" optimisation made the WebUI silently rely on the server default — exactly what bit us when the server default and the client default drifted apart.

**Changes:**
- `LowStockListRequest.ToQueryParams`: bump cap from 500 → 1000 (matches `SqlFabricQueryService.MaxPageSize` and `dbo.mes_Fabric_GetLowStockList @PageSize` clamp); when above the cap, clamp **down to the cap** rather than reset to 50; switch expression with explicit `MaxPageSize` constant.
- `FrontlineApiClient.BuildLowStockUrl`: always forward `pageSize` when set on the client query.

### 2. Loading affordance — first-load skeleton + deferred reload bar

> "Also need loading [indicator] until data arrives, like in Sales Orders."

Mirrors the Sales orders list UX (`orders.css §list-loading-bar` + `Index.razor.FetchWithDeferredLoadingBarAsync`).

**Changes:**
- `wwwroot/css/fabric.css`:
  * `.fa-loading-bar` (+`.is-active`) — same gradient sweep + keyframe timing as Sales' `.list-loading-bar`, namespaced to Frontline.
  * `.fa-table-wrap.is-refreshing tbody` — fades rows to 60% and suppresses pointer events during reload.
  * `.fa-skel` family for first-load skeleton rows (thumb + 6 width sizes + gentle pulse).
- `Pages/FabricLowStock.razor`:
  * Replace synchronous `_busy` with `_isRefreshing`, driven by a new `FetchWithDeferredLoadingBarAsync` helper that races the API call against `Task.Delay(LoadingShowAfterMs)` and only flips the visible refresh state after the delay wins. Once shown, holds for `LoadingMinVisibleMs` total.
  * Render the loading bar between the toolbar and the table; thread `is-refreshing` modifier onto `.fa-table-wrap`.
  * Inject 8 skeleton `<tr>` rows when `!_initialised` so a cold first load reads as "loading", not "no data".
  * Suppress header summary, empty-state, and footer copy until `_initialised` — all three now show "Loading…" before the first response.
  * Refresh button disable now follows `_isRefreshing`, so cache-hit reloads keep the toolbar fully responsive.

UX numbers (LoadingShowAfterMs=150, LoadingMinVisibleMs=350) match the Sales constants verbatim — change in lock-step if the lever ever moves.

## Test plan

- [ ] CI green
- [ ] After deploy-test runs, `/frontline/fabric/low-stock` shows the full filtered set; footer reads `Showing all <N> matching fabrics.`
- [ ] Toolbar threshold change visibly changes which rows appear; KPI tiles update
- [ ] On cold first load, table shows 8 skeleton rows + loading bar instead of empty panel
- [ ] On filter change with a slow SP, 2px teal bar appears between toolbar and table; table dims to 60%
- [ ] On filter change with a fast SP (<150 ms), bar never paints — instant transition
