### PR TITLE
feat(frontline): real QR in lookup sidebar (deep-links to fabric on phone)

### DIFF
--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/LKvitai.MES.Modules.Frontline.WebUI.csproj
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/LKvitai.MES.Modules.Frontline.WebUI.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MudBlazor" />
+    <PackageReference Include="QRCoder" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
@@ -14,6 +14,8 @@
 @page "/fabric"
 @page "/fabric/lookup"
 @inject FrontlineApiClient Api
+@inject FabricLookupQrCodeBuilder Qr
+@inject NavigationManager Nav
 
 <PageTitle>Frontline · Fabric availability</PageTitle>
 
@@ -250,11 +252,22 @@
             <section class="panel">
                 <div class="panel__head">
                     <h3>Open on phone</h3>
-                    <p>Scan to continue this lookup on the sales-floor handset.</p>
+                    <p>
+                        @if (_result is null)
+                        {
+                            <text>Scan to open this lookup on the sales-floor handset.</text>
+                        }
+                        else
+                        {
+                            <text>Scan to open <span class="mono">@_result.Code</span> on the sales-floor handset.</text>
+                        }
+                    </p>
                 </div>
                 <div class="qr-block">
-                    <div class="qr-placeholder" aria-hidden="true"></div>
-                    <p class="qr-block__caption">QR will deep-link to this fabric on the mobile lookup once F-2 ships.</p>
+                    <div class="qr-svg" aria-label="@QrAriaLabel()">
+                        @((MarkupString)Qr.BuildSvg(BuildPhoneDeepLink()))
+                    </div>
+                    <p class="qr-block__caption mono">@FormatDeepLinkForCaption(BuildPhoneDeepLink())</p>
                 </div>
             </section>
 
@@ -442,6 +455,53 @@
             _ => "alt-img--red",
         };
     }
+
+    /// <summary>
+    /// Builds the absolute URL the sidebar QR points at. With no result on
+    /// screen it returns the bare lookup page; once the operator has loaded
+    /// a fabric we deep-link to that code (and the selected width, if one
+    /// has been picked) so scanning the QR on a phone lands on the same
+    /// fabric the desktop user is looking at.
+    /// </summary>
+    /// <remarks>
+    /// We always emit an absolute URL: a phone camera scanner needs the
+    /// scheme + host to open the link in a browser. <see cref="NavigationManager.BaseUri"/>
+    /// already includes the trailing slash + the WebUI's base path
+    /// (e.g. <c>https://mes-test.lauresta.com/frontline/</c>) so we just
+    /// append the relative route + query.
+    /// </remarks>
+    private string BuildPhoneDeepLink()
+    {
+        var basePath = "fabric"; // canonical mobile lookup route
+        if (_result is null || string.IsNullOrWhiteSpace(_result.Code))
+        {
+            return new Uri(new Uri(Nav.BaseUri), basePath).AbsoluteUri;
+        }
+
+        var code = Uri.EscapeDataString(_result.Code);
+        var query = $"?code={code}";
+        if (_selectedWidth > 0)
+        {
+            query += $"&width={_selectedWidth}";
+        }
+        return new Uri(new Uri(Nav.BaseUri), $"{basePath}{query}").AbsoluteUri;
+    }
+
+    /// <summary>
+    /// Compact one-line caption shown under the QR: scheme + host + path
+    /// only. Operators don't need the query string in plain text — the QR
+    /// itself carries that — and the truncation keeps the sidebar tight on
+    /// the laptop screens that live behind the cutting tables.
+    /// </summary>
+    private static string FormatDeepLinkForCaption(string url)
+    {
+        if (!Uri.TryCreate(url, UriKind.Absolute, out var u)) return url;
+        return $"{u.Host}{u.AbsolutePath}";
+    }
+
+    private string QrAriaLabel() => _result is null
+        ? "QR code linking to the Frontline fabric lookup page"
+        : $"QR code linking to fabric {_result.Code} on the Frontline mobile lookup";
 
     private RenderFragment StatusIcon(FabricAvailabilityStatus s) => @<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
         @if (s == FabricAvailabilityStatus.Enough)

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Program.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Program.cs
@@ -14,6 +14,12 @@ builder.Services.AddScaffoldWebUiCore("FrontlineApi", "FrontlineApi:BaseUrl", "h
 // here and FrontlineApiClient itself will not need to change.
 builder.Services.AddScoped<FrontlineApiClient>();
 
+// Server-rendered QR code generator for the FabricLookup "Open on phone"
+// sidebar (and, ahead of #96, the wall-printable per-fabric QR). Singleton
+// because QRCoder's QRCodeGenerator wraps a thread-safe internal cache
+// and a fresh instance per circuit would just thrash the GC for no win.
+builder.Services.AddSingleton<FabricLookupQrCodeBuilder>();
+
 var app = builder.Build();
 
 app.UseScaffoldWebUiPipeline();

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Services/FabricLookupQrCodeBuilder.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Services/FabricLookupQrCodeBuilder.cs
@@ -1,0 +1,61 @@
+using QRCoder;
+
+namespace LKvitai.MES.Modules.Frontline.WebUI.Services;
+
+/// <summary>
+/// Builds the inline-SVG QR code that the desktop FabricLookup sidebar
+/// uses for the "Open on phone" panel and the (planned) wall-printable
+/// per-fabric deep link.
+///
+/// Implementation choice: <see cref="SvgQRCode"/> renders a self-contained
+/// vector image with no external assets, no JS, no client-side library and
+/// no extra HTTP round-trip. The SVG is interpolated straight into the
+/// markup via <c>MarkupString</c>, which keeps the QR crisp at any zoom
+/// level and survives Blazor's prerender → interactive boundary intact.
+///
+/// Registered as a singleton in <c>Program.cs</c> — the underlying
+/// <see cref="QRCodeGenerator"/> is documented as thread-safe so reusing
+/// one instance across circuits is cheaper than per-request creation.
+/// </summary>
+public sealed class FabricLookupQrCodeBuilder : IDisposable
+{
+    private readonly QRCodeGenerator _generator = new();
+
+    /// <summary>
+    /// Renders <paramref name="payload"/> (typically an absolute URL such
+    /// as <c>https://mes.lauresta.com/frontline/fabric?code=R104</c>) into
+    /// a square SVG string sized to <paramref name="sizePx"/> CSS pixels.
+    /// Falls back to a tiny placeholder SVG if the payload is empty so the
+    /// caller never has to branch on null in the markup.
+    /// </summary>
+    /// <remarks>
+    /// <para>ECC level <c>Q</c> (≈25% recovery) is the sweet spot for screen
+    /// QRs that may be scanned through phone cameras at an angle: it tolerates
+    /// glare and mild occlusion without bloating the matrix density past
+    /// what looks comfortable in a 180 px sidebar tile.</para>
+    /// <para>The SVG is emitted with a 2-module quiet zone, no logo and no
+    /// background fill so the surrounding panel colour shows through —
+    /// keeps the visual consistent with the Frontline neutral surface.</para>
+    /// </remarks>
+    public string BuildSvg(string payload, int sizePx = 180)
+    {
+        if (string.IsNullOrWhiteSpace(payload))
+        {
+            // Same shape as a real QR but explicitly blank — easier to spot
+            // an empty payload bug than rendering nothing at all.
+            return $"<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 1 1\" width=\"{sizePx}\" height=\"{sizePx}\" />";
+        }
+
+        using var data = _generator.CreateQrCode(payload, QRCodeGenerator.ECCLevel.Q);
+        var svgQr = new SvgQRCode(data);
+
+        // pixelsPerModule: 4 keeps the matrix sharp at the 180 px sidebar
+        // size and still scans cleanly when scaled down to the inline
+        // 28 px hint that lives inside the result card. QRCoder emits the
+        // SVG at modules * pixelsPerModule, then we let CSS resize it via
+        // the wrapping element so it stays crisp in either spot.
+        return svgQr.GetGraphic(pixelsPerModule: 4);
+    }
+
+    public void Dispose() => _generator.Dispose();
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
@@ -422,21 +422,24 @@ button, input, select { font: inherit; }
   padding: 16px;
   text-align: center;
 }
-.qr-placeholder {
-  width: 120px; height: 120px;
-  background:
-    linear-gradient(45deg, var(--n-200) 25%, transparent 25%),
-    linear-gradient(-45deg, var(--n-200) 25%, transparent 25%),
-    linear-gradient(45deg, transparent 75%, var(--n-200) 75%),
-    linear-gradient(-45deg, transparent 75%, var(--n-200) 75%);
-  background-size: 12px 12px;
-  background-position: 0 0, 0 6px, 6px -6px, -6px 0;
-  border: 2px solid var(--n-300);
-  border-radius: var(--r-sm);
-}
 .qr-block__caption {
-  color: var(--n-500); font-size: 11.5px; max-width: 200px; margin: 0;
+  color: var(--n-500); font-size: 11.5px; max-width: 220px; margin: 0;
+  word-break: break-all;
 }
+/* Live QR (server-rendered SVG via QRCoder). Box the SVG so its native
+   pixel size doesn't bleed past the sidebar, and force the inner <svg>
+   to fill the box — QRCoder emits width/height attributes that we want
+   CSS to override. White inner background + 6px padding give the camera
+   a clean quiet zone even when the surrounding panel is tinted. */
+.qr-svg {
+  width: 180px; height: 180px;
+  display: grid; place-items: center;
+  padding: 6px;
+  background: #fff;
+  border: 1px solid var(--n-200);
+  border-radius: 6px;
+}
+.qr-svg svg { width: 100%; height: 100%; display: block; }
 .last-checked-list { display: flex; flex-direction: column; gap: 10px; }
 .last-checked-item {
   display: flex; flex-direction: column; gap: 2px;


### PR DESCRIPTION
## Summary

> "a gde v lookup qr???"

The desktop FabricLookup sidebar shipped with a placeholder QR tile and the caption "QR will deep-link to this fabric on the mobile lookup once F-2 ships." F-2 has shipped, the placeholder did not. Replace it with a server-rendered SVG QR via QRCoder so the operator can scan the desktop sidebar with a sales-floor handset and land on the same fabric they're looking at.

## Changes

- `LKvitai.MES.Modules.Frontline.WebUI.csproj`: add `<PackageReference Include="QRCoder" />`. Version is centralised in `Directory.Packages.props` (1.6.0) — Warehouse already uses the same package for MFA, so no new dependency lands in the solution.
- `Services/FabricLookupQrCodeBuilder.cs` (new):
  - `BuildSvg(payload, sizePx)` — emits a self-contained SVG QR with no external assets, no JS and no extra HTTP round-trip.
  - ECC level Q (~25% recovery) is the sweet spot for screen QRs scanned through phone cameras at angles.
  - Singleton in `Program.cs` — `QRCodeGenerator` is thread-safe and per-circuit instances would just thrash the GC.
- `Pages/FabricLookup.razor`:
  - Inject `FabricLookupQrCodeBuilder` and `NavigationManager`.
  - `BuildPhoneDeepLink()` returns the bare lookup URL when no fabric is loaded and `…/fabric?code={code}&width={n}` once a result is on screen — scanning the QR after a lookup lands on the **same fabric** the desktop user is looking at.
  - Render the QR inside a new `.qr-svg` wrapper via `MarkupString`.
  - Caption now shows the host + path of the live deep-link in mono so the operator can read it back to a colleague over the radio.
  - Sidebar header copy adapts: "Scan to open this lookup on the sales-floor handset" → "Scan to open `<code>` on the sales-floor handset" once a result lands.
- `wwwroot/css/fabric.css`:
  - Add `.qr-svg` (180×180 white tile with border + 6 px quiet zone) so the SVG always sizes to the sidebar regardless of QRCoder's emitted dimensions.
  - Drop the now-dead `.qr-placeholder` checker-pattern style (only referenced by the markup we just removed).

## Verified locally

`GET /fabric` returns the new `qr-svg` wrapper, contains a real `<svg viewBox=…>` matrix, and no longer carries the "once F-2 ships" placeholder string.

## Out of scope (separate issues)

- #96 — wall-printable per-fabric QR for the warehouse roll labels.
- DelegatingHandler-driven base URL when the WebUI runs behind a path prefix that differs from the page's own base href.

## Test plan

- [ ] CI green
- [ ] After deploy-test runs, `https://mes-test.lauresta.com/frontline/fabric` shows a real QR in the right-hand sidebar (not a checker pattern) — desktop only (≥ 980 px viewport).
- [ ] Caption under the QR reads `mes-test.lauresta.com/frontline/fabric`.
- [ ] After running a lookup (e.g. `R104`), the QR matrix changes and the caption updates to include the code in the path; scanning it on a phone opens `https://mes-test.lauresta.com/frontline/fabric?code=R104&width=…`.
- [ ] On the mobile breakpoint (< 980 px) the sidebar (and therefore the QR) is correctly hidden.
