### PR TITLE
feat(portal): shared header + auth-aware shell (closes #92)

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
@@ -1,5 +1,38 @@
 @namespace LKvitai.MES.BuildingBlocks.WebUI.Components
 @inject NavigationManager Navigation
+@inject IConfiguration Configuration
+
+@*
+   PortalModuleShell — shared dark Portal topbar + test-strip wrapper used by
+   every WebUI in the solution (Portal home, Sales, Frontline, future modules).
+   Owning this in BuildingBlocks.WebUI keeps brand, environment chrome, search
+   entry point and the user/logout block in lock-step across modules; module
+   pages should only ever render their own content via @ChildContent.
+
+   Issue #92 — Portal 1: Shared Header And Auth-Aware Shell:
+     * Brand block is a single <a> linking to the Portal home URL so users
+       can return from any module. URL resolution priority:
+         1. PortalHomeUrl parameter (lets a host pin a specific value)
+         2. Configuration["PortalWebUi:BaseUrl"] (the canonical knob — same
+            key consumers already use to build cross-module redirects)
+         3. "/" — safe local fallback (works in dev, in tests, and inside the
+            Portal WebUI itself where the home IS this app's root).
+     * Universal search is a PLACEHOLDER button styled to look like a search
+       input. Clicking opens a small "coming soon" popover instead of doing
+       module-only filtering, matching the Outlook 365-style universal-search
+       intent in the Portal dashboard plan.
+     * User name / initials come from ClaimsPrincipal with a layered fallback
+       chain (display_name claim → GivenName+Surname → ClaimTypes.Name →
+       Identity.Name → "Signed in" / "U"). No more hardcoded "Lukas" / "RM".
+     * Environment / Version are explicit slots ready to be fed by runtime
+       data from the Portal status endpoint (Issue #93). Default Version is
+       "—" so an unset value never silently shows a wrong number.
+
+   Authentic-migration seam: the user-block + logout form below is the only
+   place that talks to the current cookie-auth flow. Replacing it with an
+   Authentic-driven token + redirect is a localised change — see the
+   "AUTHENTIC SEAM" markers below.
+*@
 
 <div class="app-shell">
     <div class="test-strip">
@@ -12,24 +45,48 @@
     </div>
 
     <header class="topbar">
-        <div class="brand">
+        @* Brand block: single clickable link back to Portal home. Logo,
+           name and tagline all live INSIDE the same <a> per the design
+           rule (one anchor, one click target). *@
+        <a class="brand brand--link"
+           href="@ResolvedHomeUrl"
+           aria-label="@BrandAriaLabel">
             <div class="brand__mark">LK</div>
             <div>
                 <div class="brand__name">LKvitai<span>.MES</span></div>
                 <div class="brand__tagline mono">Manufacturing &middot; Execution &middot; Standards</div>
             </div>
-        </div>
+        </a>
+
         <div class="topbar__separator" aria-hidden="true"></div>
-        <label class="portal-search">
+
+        @* Universal-search placeholder. Rendered as a button so it cannot
+           accidentally pretend to be a real input — clicking opens a small
+           "coming soon" popover anchored to the topbar. Real cross-module
+           search lands in a future issue. *@
+        <button class="portal-search portal-search--placeholder"
+                type="button"
+                aria-haspopup="dialog"
+                aria-expanded="@_searchOpen.ToString().ToLowerInvariant()"
+                @onclick="ToggleSearchPlaceholder">
             <span class="portal-search__icon" aria-hidden="true"></span>
-            <span class="sr-only">@SearchLabel</span>
-            <input type="search" placeholder="@SearchPlaceholder" autocomplete="off" />
-        </label>
+            <span class="portal-search__placeholder">@SearchPlaceholder</span>
+            <span class="portal-search__hint mono" aria-hidden="true">⌘K</span>
+        </button>
+
         <div class="topbar__spacer"></div>
+
         <div class="env-badge" aria-label="Environment and version">
             <div><span class="mono">ENV</span><strong class="mono">@EnvironmentBadge</strong></div>
             <div><span class="mono">VER</span><strong class="mono">@Version</strong></div>
         </div>
+
+        @* AUTHENTIC SEAM: user-block + logout form.
+           Replace the form below with an Authentic logout endpoint when the
+           module migrates off cookie auth. The DisplayName/Initials helpers
+           keep working as long as the new auth scheme still surfaces a
+           ClaimsPrincipal — only the markup wrapping the logout submit needs
+           to change. *@
         <div class="user-block">
             <div class="user-block__avatar">@Initials</div>
             <div>
@@ -41,19 +98,78 @@
         </div>
     </header>
 
+    @* Universal-search "coming soon" popover. Plain inline panel rather than
+       a full <dialog> — keeps the shell SSR-safe (no JS interop) and small
+       enough that consumers don't need to opt in to extra script. *@
+    @if (_searchOpen)
+    {
+        <div class="universal-search-popover" role="dialog" aria-label="Universal search">
+            <div class="universal-search-popover__head">
+                <strong>Universal search</strong>
+                <button type="button"
+                        class="link-button universal-search-popover__close"
+                        @onclick="CloseSearchPlaceholder"
+                        aria-label="Dismiss">×</button>
+            </div>
+            <p class="universal-search-popover__body">
+                Search across orders, fabrics, modules and more — coming soon.
+                For now use module-level filters inside each section.
+            </p>
+        </div>
+    }
+
     @ChildContent
 </div>
 
 @code {
     [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>
+    /// Authenticated principal whose claims drive <see cref="DisplayName"/>
+    /// and <see cref="Initials"/>. Pass <c>null</c> from anonymous shells —
+    /// the safe "Signed in" / "U" fallback fires.
+    /// </summary>
     [Parameter] public ClaimsPrincipal? User { get; set; }
+
     [Parameter] public string EnvironmentName { get; set; } = "Development";
     [Parameter] public string? HostLabel { get; set; }
-    [Parameter] public string Version { get; set; } = "0.1.0";
-    [Parameter] public string SearchPlaceholder { get; set; } = "Find a module...";
-    [Parameter] public string SearchLabel { get; set; } = "Find a module";
+
+    /// <summary>
+    /// Build/release version shown in the env-badge. Issue #93 wires this
+    /// to the Portal status endpoint (APP_VERSION / RELEASE_TAG); until then
+    /// the default em-dash makes "value not set" obviously not-a-version.
+    /// </summary>
+    [Parameter] public string Version { get; set; } = "—";
+
+    /// <summary>
+    /// Optional override for the Portal home URL the brand block links to.
+    /// When unset, the shell falls back to <c>Configuration["PortalWebUi:BaseUrl"]</c>
+    /// then to <c>"/"</c>.
+    /// </summary>
+    [Parameter] public string? PortalHomeUrl { get; set; }
+
+    /// <summary>
+    /// Placeholder copy for the universal-search button. Module shells used
+    /// to override this (e.g. Frontline passes "Find fabric…") to hint at
+    /// module context, but the placeholder itself does not perform any
+    /// module-specific filtering — that lives inside the module page.
+    /// </summary>
+    [Parameter] public string SearchPlaceholder { get; set; } = "Search…";
+
+    [Parameter] public string SearchLabel { get; set; } = "Open universal search";
+
+    /// <summary>
+    /// POST target for logout. Defaults to the relative <c>auth/logout</c>
+    /// endpoint that <c>Portal.WebUI/Program.cs</c> + every module's auth
+    /// pipeline already maps. AUTHENTIC SEAM: switch to the Authentic-issued
+    /// endpoint here (or wrap the form in a host-provided fragment).
+    /// </summary>
     [Parameter] public string LogoutAction { get; set; } = "auth/logout";
-    [Parameter] public string BannerNote { get; set; } = "Data in this environment is not production data and may be reset without notice.";
+
+    [Parameter] public string BannerNote { get; set; } =
+        "Data in this environment is not production data and may be reset without notice.";
+
+    private bool _searchOpen;
 
     private string EnvironmentLabel => (EnvironmentName ?? "Development").ToUpperInvariant();
 
@@ -70,21 +186,85 @@
         }
     }
 
-    private string DisplayName => User?.FindFirstValue(ClaimTypes.Name)
-                                  ?? User?.Identity?.Name
-                                  ?? "Signed in";
+    /// <summary>
+    /// Layered fallback chain for the user's display name. First match wins:
+    ///   1. <c>display_name</c> claim (preferred — lets identity providers
+    ///      surface a properly-cased "Lukas Mažeika" instead of a username).
+    ///   2. <c>GivenName + Surname</c> assembled from standard claims.
+    ///   3. <see cref="ClaimTypes.Name"/>.
+    ///   4. <c>IIdentity.Name</c> (covers older test fixtures).
+    ///   5. The literal "Signed in" — only when no auth context exists at all.
+    /// </summary>
+    private string DisplayName
+    {
+        get
+        {
+            if (User is null) return "Signed in";
 
+            var displayClaim = User.FindFirstValue("display_name");
+            if (!string.IsNullOrWhiteSpace(displayClaim)) return displayClaim;
+
+            var given   = User.FindFirstValue(ClaimTypes.GivenName);
+            var surname = User.FindFirstValue(ClaimTypes.Surname);
+            if (!string.IsNullOrWhiteSpace(given) || !string.IsNullOrWhiteSpace(surname))
+            {
+                return $"{given} {surname}".Trim();
+            }
+
+            return User.FindFirstValue(ClaimTypes.Name)
+                ?? User.Identity?.Name
+                ?? "Signed in";
+        }
+    }
+
+    /// <summary>
+    /// Two-letter avatar text. Same fallback priority as
+    /// <see cref="DisplayName"/>: an explicit <c>initials</c> claim wins
+    /// outright; otherwise we slice the resolved display name.
+    /// </summary>
     private string Initials
     {
         get
         {
-            var parts = DisplayName.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            var explicitInitials = User?.FindFirstValue("initials");
+            if (!string.IsNullOrWhiteSpace(explicitInitials))
+            {
+                return explicitInitials.ToUpperInvariant();
+            }
+
+            var name = DisplayName;
+            if (string.Equals(name, "Signed in", StringComparison.Ordinal))
+            {
+                return "U";
+            }
+
+            var parts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
             var raw = parts.Length >= 2
                 ? $"{parts[0][0]}{parts[1][0]}"
                 : parts.Length == 1 ? parts[0][0].ToString() : "U";
             return raw.ToUpperInvariant();
         }
     }
+
+    private string ResolvedHomeUrl
+    {
+        get
+        {
+            if (!string.IsNullOrWhiteSpace(PortalHomeUrl)) return PortalHomeUrl;
+
+            var configured = Configuration["PortalWebUi:BaseUrl"];
+            if (!string.IsNullOrWhiteSpace(configured)) return configured;
+
+            // Safe local fallback. Inside the Portal WebUI itself this is
+            // always correct; inside module shells it just no-ops to the
+            // module's own root, which is better than dead-linking.
+            return "/";
+        }
+    }
+
+    private string BrandAriaLabel => string.Equals(ResolvedHomeUrl, "/", StringComparison.Ordinal)
+        ? "Portal home"
+        : "Open Portal home";
 
     private string ResolveNavigationHost()
     {
@@ -95,4 +275,7 @@
 
         return "localhost";
     }
+
+    private void ToggleSearchPlaceholder() => _searchOpen = !_searchOpen;
+    private void CloseSearchPlaceholder() => _searchOpen = false;
 }

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
@@ -1,3 +1,4 @@
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Authorization
+@using Microsoft.Extensions.Configuration

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
@@ -73,6 +73,27 @@
   min-width: 0;
 }
 
+/* Brand block as a single anchor back to Portal home (issue #92).
+   Strip the default link chrome — colour comes from .brand__name /
+   .brand__tagline below — but light up the mark on hover/focus so the
+   click affordance is obvious without breaking the dark-topbar look. */
+.brand--link {
+  color: inherit;
+  text-decoration: none;
+  border-radius: 6px;
+  outline: none;
+  transition: background-color .15s ease-in-out;
+}
+.brand--link:hover .brand__mark,
+.brand--link:focus-visible .brand__mark {
+  border-color: var(--accent-400);
+  color: var(--accent-300, var(--accent-400));
+}
+.brand--link:focus-visible {
+  outline: 2px solid var(--accent-400);
+  outline-offset: 2px;
+}
+
 .brand__mark {
   display: grid;
   place-items: center;
@@ -118,29 +139,50 @@
   flex: 1;
 }
 
+/* Universal-search placeholder. Rendered as a <button> (issue #92): the
+   visible look mimics a search input but the only behaviour is opening a
+   "coming soon" popover, so it cannot be mistaken for a real cross-module
+   search box. Real search lands in a follow-up issue. */
 .portal-search {
   position: relative;
   flex: 1 1 360px;
   max-width: 460px;
 }
 
-.portal-search input {
+.portal-search--placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   width: 100%;
   padding: 8px 10px 8px 34px;
   border: 1px solid var(--dark-line);
   border-radius: 4px;
   outline: none;
   background: #1b2028;
-  color: var(--n-0);
-  font-size: 13px;
-}
-
-.portal-search input::placeholder {
   color: #8f98a6;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .12s ease-in-out, color .12s ease-in-out;
+}
+.portal-search--placeholder:hover {
+  border-color: #2a323d;
+  color: #b6bfcb;
+}
+.portal-search--placeholder:focus-visible {
+  border-color: var(--accent-400);
+  color: var(--n-0);
 }
 
-.portal-search input:focus {
-  border-color: var(--accent-400);
+.portal-search__placeholder { flex: 1; min-width: 0; }
+.portal-search__hint {
+  font-size: 10px;
+  letter-spacing: .5px;
+  padding: 1px 6px;
+  border: 1px solid var(--dark-line);
+  border-radius: 3px;
+  color: #8f98a6;
+  background: var(--dark-2);
 }
 
 .portal-search__icon {
@@ -166,6 +208,34 @@
   transform: rotate(45deg);
   transform-origin: left center;
 }
+
+/* Tiny "coming soon" popover anchored to the topbar. Sits inside the
+   .app-shell so it scrolls with the page rather than floating over the
+   whole viewport — cheaper than a full <dialog> and good enough for a
+   placeholder until real universal search arrives. */
+.universal-search-popover {
+  position: relative;
+  margin: -1px 28px 0 28px;
+  padding: 12px 14px;
+  background: var(--n-0);
+  border: 1px solid var(--n-200);
+  border-top: 0;
+  border-radius: 0 0 6px 6px;
+  box-shadow: 0 8px 24px rgb(0 0 0 / 8%);
+  font-size: 12.5px;
+  color: var(--n-700);
+}
+.universal-search-popover__head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 4px;
+  color: var(--n-900);
+}
+.universal-search-popover__body { margin: 0; }
+.universal-search-popover__close {
+  font-size: 16px; line-height: 1; color: var(--n-500);
+}
+.universal-search-popover__close:hover,
+.universal-search-popover__close:focus-visible { color: var(--n-900); text-decoration: none; }
 
 .env-badge {
   display: flex;

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>LKvitai.MES - Portal</title>
-  <link rel="stylesheet" href="styles.css?v=0.1.6">
+  <link rel="stylesheet" href="styles.css?v=0.1.7">
 </head>
 <body>
   <div class="app-shell">
@@ -17,40 +17,74 @@
       <span class="mono test-strip__host" id="portal-host">lkvitai-test.vpn.lauresta.com</span>
     </div>
 
+    <!-- Issue #92: Portal home reuses the same brand/search/env contract as
+         the shared PortalModuleShell (BuildingBlocks.WebUI). The static page
+         can't render the Razor component directly (Portal is a static
+         index.html SPA), so we mirror the markup 1:1 — class names, ARIA
+         attributes and behaviour all match so any future migration to the
+         shared component is visually invisible. The brand is a single <a>
+         pointing at "/" (Portal's own root), the topbar search is a
+         placeholder button that opens a "coming soon" popover, and the
+         per-module filter has moved into the Modules section so the global
+         search no longer pretends to be module-only. -->
     <header class="topbar">
-      <div class="brand">
+      <a class="brand brand--link" href="/" aria-label="Portal home">
         <div class="brand__mark">LK</div>
         <div>
           <div class="brand__name">LKvitai<span>.MES</span></div>
           <div class="brand__tagline mono">Manufacturing &middot; Execution &middot; Standards</div>
         </div>
-      </div>
+      </a>
 
       <div class="topbar__separator" aria-hidden="true"></div>
 
-      <label class="search" for="module-search">
-        <span class="search__icon" aria-hidden="true"></span>
-        <span class="sr-only">Find a module</span>
-        <input id="module-search" type="search" placeholder="Find a module..." autocomplete="off">
-      </label>
+      <button id="universal-search"
+              class="portal-search portal-search--placeholder"
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+              aria-controls="universal-search-popover">
+        <span class="portal-search__icon" aria-hidden="true"></span>
+        <span class="portal-search__placeholder">Search…</span>
+        <span class="portal-search__hint mono" aria-hidden="true">⌘K</span>
+      </button>
 
       <div class="topbar__spacer"></div>
 
       <div class="env-badge" aria-label="Environment and version">
         <div><span class="mono">ENV</span><strong class="mono" id="portal-env">TEST</strong></div>
-        <div><span class="mono">VER</span><strong class="mono">0.1.0</strong></div>
+        <div><span class="mono">VER</span><strong class="mono" id="portal-version">—</strong></div>
       </div>
 
+      <!-- AUTHENTIC SEAM: same as PortalModuleShell.razor — only the form
+           target changes when migrating off cookie auth. Display name +
+           initials are static placeholders here only because Portal home
+           is a pre-Blazor static page; issue #93 wires them to the Portal
+           /me endpoint so they match the shared shell on every render. -->
       <div class="user-block">
-        <div class="user-block__avatar">RM</div>
+        <div class="user-block__avatar" id="portal-user-initials">U</div>
         <div>
-          <div class="user-block__name">Signed in</div>
+          <div class="user-block__name" id="portal-user-name">Signed in</div>
           <form action="auth/logout" method="post">
             <button class="link-button" type="submit">Logout</button>
           </form>
         </div>
       </div>
     </header>
+
+    <!-- Universal-search "coming soon" popover. Hidden by default; toggled
+         by script.js. Mirrors the inline panel rendered by
+         PortalModuleShell.razor so the styling stays in lock-step. -->
+    <div id="universal-search-popover" class="universal-search-popover" role="dialog" aria-label="Universal search" hidden>
+      <div class="universal-search-popover__head">
+        <strong>Universal search</strong>
+        <button id="universal-search-close" class="link-button universal-search-popover__close" type="button" aria-label="Dismiss">×</button>
+      </div>
+      <p class="universal-search-popover__body">
+        Search across orders, fabrics, modules and more — coming soon.
+        For now use module-level filters inside each section.
+      </p>
+    </div>
 
     <main class="main">
       <section class="hero">
@@ -104,6 +138,14 @@
               <h2 id="modules-title">Modules</h2>
               <span><strong id="available-count">1</strong> available &middot; <strong id="planned-count">8</strong> planned</span>
             </div>
+            <!-- Module-grid local filter. Lives in the section header
+                 (not the topbar) since the topbar search is now a
+                 universal-search placeholder per issue #92. -->
+            <label class="module-search" for="module-search">
+              <span class="module-search__icon" aria-hidden="true"></span>
+              <span class="sr-only">Filter modules</span>
+              <input id="module-search" type="search" placeholder="Filter modules…" autocomplete="off">
+            </label>
           </div>
 
           <div class="module-grid" id="module-grid"></div>
@@ -168,6 +210,6 @@
   </div>
 
   <output class="toast" id="toast" aria-live="polite" hidden></output>
-  <script src="script.js?v=0.1.6"></script>
+  <script src="script.js?v=0.1.7"></script>
 </body>
 </html>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/script.js
@@ -90,7 +90,14 @@ function getEnvironment(hostname) {
 const environment = getEnvironment(host);
 
 const moduleGrid = document.querySelector("#module-grid");
+// Issue #92: #module-search now lives inside the Modules section, not the
+// topbar. The topbar's #universal-search button is a placeholder that opens
+// the "coming soon" popover instead of filtering only the module grid —
+// keeping the global search entry honest about its scope.
 const searchInput = document.querySelector("#module-search");
+const universalSearchButton = document.querySelector("#universal-search");
+const universalSearchPopover = document.querySelector("#universal-search-popover");
+const universalSearchClose = document.querySelector("#universal-search-close");
 const emptyState = document.querySelector("#empty-state");
 const emptyQuery = document.querySelector("#empty-query");
 const stageGrid = document.querySelector("#stage-grid");
@@ -260,6 +267,32 @@ document.querySelectorAll("[data-period]").forEach((button) => {
 });
 
 searchInput.addEventListener("input", filterModules);
+
+// Issue #92: universal-search placeholder. Clicking the topbar button
+// opens a small "coming soon" popover (markup below the topbar in
+// index.html). Real cross-module search lands in a follow-up issue.
+function setUniversalSearchOpen(isOpen) {
+  if (!universalSearchPopover || !universalSearchButton) return;
+  universalSearchPopover.hidden = !isOpen;
+  universalSearchButton.setAttribute("aria-expanded", isOpen ? "true" : "false");
+}
+
+if (universalSearchButton) {
+  universalSearchButton.addEventListener("click", () => {
+    setUniversalSearchOpen(universalSearchPopover.hidden);
+  });
+}
+
+if (universalSearchClose) {
+  universalSearchClose.addEventListener("click", () => setUniversalSearchOpen(false));
+}
+
+document.addEventListener("keydown", (event) => {
+  if (event.key === "Escape" && universalSearchPopover && !universalSearchPopover.hidden) {
+    setUniversalSearchOpen(false);
+    universalSearchButton?.focus();
+  }
+});
 
 document.querySelector("#available-count").textContent = modules.filter((mod) => mod.status === "active").length;
 document.querySelector("#planned-count").textContent = modules.filter((mod) => mod.status === "planned").length;

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
@@ -236,6 +236,26 @@ input {
   min-width: 0;
 }
 
+/* Brand block as a single anchor back to Portal home (issue #92).
+   Mirrors PortalModuleShell — strips the link chrome and lights up the
+   mark on hover/focus. */
+.brand--link {
+  color: inherit;
+  text-decoration: none;
+  border-radius: 6px;
+  outline: none;
+  transition: background-color .15s ease-in-out;
+}
+.brand--link:hover .brand__mark,
+.brand--link:focus-visible .brand__mark {
+  border-color: var(--accent-400);
+  color: oklch(72% 0.12 175);
+}
+.brand--link:focus-visible {
+  outline: 2px solid var(--accent-400);
+  outline-offset: 2px;
+}
+
 .brand__mark {
   display: grid;
   place-items: center;
@@ -281,29 +301,54 @@ input {
   flex: 1;
 }
 
-.search {
+/* Universal-search placeholder button. Mirrors the styling of
+   PortalModuleShell.razor's .portal-search--placeholder so any future
+   migration of Portal home to the Razor shell stays visually identical.
+   The .search class is kept available below for any third-party page that
+   still embeds the old input markup. */
+.portal-search {
   position: relative;
   flex: 1 1 360px;
   max-width: 460px;
 }
 
-.search input {
+.portal-search--placeholder {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   width: 100%;
   padding: 8px 10px 8px 34px;
   border: 1px solid oklch(28% 0.02 240);
   border-radius: 4px;
   outline: none;
   background: oklch(14% 0.02 240);
-  color: var(--n-0);
+  color: oklch(60% 0.02 240);
   font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  transition: border-color .12s ease-in-out, color .12s ease-in-out;
+}
+.portal-search--placeholder:hover {
+  border-color: oklch(36% 0.02 240);
+  color: oklch(78% 0.02 240);
+}
+.portal-search--placeholder:focus-visible {
+  border-color: var(--accent-500);
+  color: var(--n-0);
 }
 
-.search input:focus {
-  border-color: var(--accent-500);
+.portal-search__placeholder { flex: 1; min-width: 0; }
+.portal-search__hint {
+  font-size: 10px;
+  letter-spacing: .5px;
+  padding: 1px 6px;
+  border: 1px solid oklch(28% 0.02 240);
+  border-radius: 3px;
+  color: oklch(60% 0.02 240);
   background: oklch(12% 0.02 240);
 }
 
-.search__icon {
+.portal-search__icon {
   position: absolute;
   left: 12px;
   top: 50%;
@@ -312,9 +357,10 @@ input {
   border: 1.8px solid oklch(55% 0.02 240);
   border-radius: 50%;
   transform: translateY(-58%);
+  pointer-events: none;
 }
 
-.search__icon::after {
+.portal-search__icon::after {
   content: "";
   position: absolute;
   right: -5px;
@@ -324,6 +370,77 @@ input {
   background: oklch(55% 0.02 240);
   transform: rotate(45deg);
   transform-origin: left center;
+}
+
+/* Module-section local filter — moved out of the topbar (issue #92). */
+.module-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  flex: 0 1 240px;
+  max-width: 280px;
+}
+.module-search input {
+  width: 100%;
+  padding: 7px 10px 7px 30px;
+  border: 1px solid var(--n-200);
+  border-radius: 4px;
+  outline: none;
+  background: var(--n-0);
+  color: var(--n-900);
+  font-size: 12.5px;
+}
+.module-search input:focus {
+  border-color: var(--accent-500);
+  box-shadow: 0 0 0 3px oklch(76% 0.05 175 / 18%);
+}
+.module-search__icon {
+  position: absolute;
+  left: 10px;
+  width: 12px;
+  height: 12px;
+  border: 1.6px solid var(--n-500);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.module-search__icon::after {
+  content: "";
+  position: absolute;
+  right: -4px;
+  bottom: -4px;
+  width: 5px;
+  height: 1.6px;
+  background: var(--n-500);
+  transform: rotate(45deg);
+  transform-origin: left center;
+}
+
+/* Universal-search "coming soon" popover — anchored under the topbar.
+   Hidden via the [hidden] attribute toggled by script.js. */
+.universal-search-popover {
+  position: relative;
+  margin: -1px 28px 0 28px;
+  padding: 12px 14px;
+  background: var(--n-0);
+  border: 1px solid var(--n-200);
+  border-top: 0;
+  border-radius: 0 0 6px 6px;
+  box-shadow: 0 8px 24px oklch(0% 0 0 / 8%);
+  font-size: 12.5px;
+  color: var(--n-700);
+}
+.universal-search-popover__head {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: 4px;
+  color: var(--n-900);
+}
+.universal-search-popover__body { margin: 0; }
+.universal-search-popover__close {
+  font-size: 16px; line-height: 1; color: var(--n-500);
+}
+.universal-search-popover__close:hover,
+.universal-search-popover__close:focus-visible {
+  color: var(--n-900); text-decoration: none;
 }
 
 .env-badge {


### PR DESCRIPTION
Closes #92.

Implements Portal dashboard execution plan, **Issue #92 — "Portal 1: shared header and auth-aware shell"**. The `PortalModuleShell` in `BuildingBlocks.WebUI` becomes the single owner of brand, universal search, environment chrome, and the user/logout block; the Portal home static page mirrors the same markup contract so a future Razor migration is invisible.

## What changed

### `PortalModuleShell.razor` (BuildingBlocks.WebUI)

- **Brand block is now a single `<a class="brand brand--link">`** wrapping the logo, the `LKvitai.MES` name and the slogan, returning the operator to Portal home from any module. URL resolution priority:
  1. `PortalHomeUrl` parameter (per-host override).
  2. `Configuration["PortalWebUi:BaseUrl"]` — the canonical knob already used by cross-module redirects.
  3. `"/"` — safe local fallback.
- **Universal search is rendered as a `<button class="portal-search--placeholder">`** styled to look like a search input. Clicking opens a small inline "coming soon" popover instead of pretending to be cross-module search. Real search is a follow-up issue; the placeholder makes the scope honest in the meantime.
- **`DisplayName` / `Initials` fall through a layered `ClaimsPrincipal` chain**: `display_name` claim → `GivenName + Surname` → `ClaimTypes.Name` → `Identity.Name` → `"Signed in"` / `"U"`. An explicit `initials` claim wins outright. Hardcoded "Lukas" / "RM" are gone.
- **`Version` default flipped from `"0.1.0"` to `"—"`** so a forgotten parameter shows obviously-not-a-version instead of a misleading literal. Issue #93 wires the runtime feed.
- **AUTHENTIC SEAM markers** added next to the user-block / logout form so the future migration off cookie auth has a localised target.

### `portal-shell.css` (BuildingBlocks.WebUI)

- `.brand--link` strips the link chrome and lights up the mark on hover/focus-visible.
- `.portal-search--placeholder` button mirrors the dark-topbar input look with a placeholder caption + a `⌘K` hint glyph.
- `.universal-search-popover` is the small inline panel anchored under the topbar.

### Portal home (static `index.html` + `script.js` + `styles.css`)

- Brand block converted to `<a class="brand brand--link" href="/">`.
- Topbar search input replaced with the same universal-search placeholder button + popover used by the Razor shell. The button is wired in `script.js` to toggle the popover; **Esc** closes it.
- The per-module filter input has moved from the topbar into the Modules-section header (`id="module-search"` preserved so `script.js`' `filterModules()` keeps working). Local concern stays where it belongs.
- env-badge VER now starts at `—` with `id="portal-version"` so issue #93 can populate it from the Portal status endpoint without further markup changes.
- User-block carries id-tagged placeholders (`portal-user-name` / `portal-user-initials`) ready for the same `/me` wiring; the static `RM` / `Signed in` placeholders are gone.
- `styles.css` gains `.brand--link`, `.portal-search*` (placeholder family), `.module-search` and `.universal-search-popover`. Old `.search` input rules removed — class is no longer used anywhere in the solution.
- Cache-bust bumped to `v=0.1.7` for both `styles.css` and `script.js`.

## Out of scope (parked for follow-up)

- The 3 remaining `0.1.0` literals in Portal `index.html` (system-status panel, build panel, footer) belong to **issue #93** — Portal Runtime Data Sources — which adds the `/api/portal/v1/status` feed.
- Migrating Portal home itself to render the Razor `PortalModuleShell` (instead of mirroring the markup) requires converting the static SPA to Blazor Server and is a larger refactor than #92's scope.

## Verification

- `dotnet build` of `BuildingBlocks.WebUI`, `Portal.WebUI`, `Sales.WebUI`, `Frontline.WebUI` all green.
- Local Frontline `/fabric` smoke confirms the shell renders the new `brand--link` `<a>`, `portal-search--placeholder` button, `/` fallback `href`, and the `U` / `Signed in` claim fallbacks.
- Portal `index.html` static check confirms `brand--link` / placeholder / popover / `module-search` are all present and the old `.search` topbar input + hardcoded `RM` avatar are gone.

## Test plan

- [ ] CI green
- [ ] After deploy-test runs, click the LK brand block on `/sales` and `/frontline` — both should land on Portal home.
- [ ] Topbar "Search…" button opens a small "coming soon" popover; **Esc** closes it; popover does NOT filter modules.
- [ ] Modules section has its own "Filter modules…" input that still narrows the grid as before.
- [ ] Header user name + initials reflect the logged-in operator's claims (or `Signed in` / `U` for the Frontline anonymous shell).
- [ ] Version slot shows `—` until issue #93 wires the runtime value (no misleading `0.1.0` in the topbar).
