### PR TITLE
fix(portal-shell): import Components.Web so @onclick compiles as a directive

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor
@@ -67,7 +67,7 @@
         <button class="portal-search portal-search--placeholder"
                 type="button"
                 aria-haspopup="dialog"
-                aria-expanded="@_searchOpen.ToString().ToLowerInvariant()"
+                aria-expanded="@(_searchOpen ? "true" : "false")"
                 @onclick="ToggleSearchPlaceholder">
             <span class="portal-search__icon" aria-hidden="true"></span>
             <span class="portal-search__placeholder">@SearchPlaceholder</span>

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
@@ -1,4 +1,16 @@
 @using System.Security.Claims
 @using Microsoft.AspNetCore.Components
 @using Microsoft.AspNetCore.Components.Authorization
+@*
+   CRITICAL: Microsoft.AspNetCore.Components.Web hosts the EventHandlers
+   table that registers @onclick / @onchange / @onsubmit / etc. as Razor
+   directive attributes. Without this @using, the Razor compiler does NOT
+   recognise them as directives and silently emits them to the browser as
+   literal HTML attributes (e.g. <button @onclick="..."> in raw HTML),
+   which the DOM rejects with InvalidCharacterError on the very first
+   Blazor diff batch — terminating the SignalR circuit and breaking every
+   consumer module that renders this shell.
+   See hotfix/portal-shell-onclick-render.
+*@
+@using Microsoft.AspNetCore.Components.Web
 @using Microsoft.Extensions.Configuration


### PR DESCRIPTION
## Summary

Hotfix for the production circuit-kill regression introduced by #113. The new `PortalModuleShell.razor` shipped its first event-binding (`@onclick` on the universal-search placeholder), and `BuildingBlocks.WebUI/_Imports.razor` was missing `@using Microsoft.AspNetCore.Components.Web`. That namespace hosts the `EventHandlers` table that registers `@onclick` / `@onchange` / `@onsubmit` etc. as Razor directive attributes — without it, the compiler silently emitted `@onclick` to the browser as a literal HTML attribute name. The DOM rejected it on the very first Blazor diff batch with `InvalidCharacterError: Invalid qualified name: '@onclick'`, terminating the SignalR circuit and breaking every consumer module (Frontline `/fabric`, Sales) that renders this shell in production.

### Root cause (post-mortem)

| | |
|---|---|
| Symptom in test | `Unhandled exception rendering component: InvalidCharacterError: Failed to execute 'setAttribute' on 'Element': '@onclick' is not a valid attribute name.` → `Unhandled exception in circuit … this circuit will be terminated.` |
| Symptom in browser | `Error applying batch 3` immediately after WebSocket connect, page goes "modules broken". |
| Reproducer | `http://localhost:5097/fabric` (Frontline) on `main` post-#113. |
| Why it slipped past CI / build | Razor compiles cleanly without the import; the missing directive is just rendered as text. No build error, no warning. The bug only fires at runtime when Blazor diffs the rendered tree against the real DOM. |
| Why prior PRs were fine | `PortalModuleShell.razor` had no event-handlers before #113. The missing `@using` was latent. |

### Fix

* `src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor`
  * Add `@using Microsoft.AspNetCore.Components.Web` (mirrors what `Sales.WebUI` and `Frontline.WebUI` already import in their own `_Imports.razor`).
  * Add a guard comment explaining the failure mode so a future reader does not delete the import while "tidying up".
* `src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalModuleShell.razor`
  * Cosmetic only: `aria-expanded="@_searchOpen.ToString().ToLowerInvariant()"` → `aria-expanded="@(_searchOpen ? "true" : "false")"`. Same output, reads cleaner inside an attribute expression.

### Test plan

- [x] Verified raw HTML on `http://localhost:5097/fabric` no longer contains a literal `@onclick` attribute (count: 0; was 1 on `main`).
- [x] Verified Blazor circuit stays alive across navigation between `/fabric` and `/fabric/low-stock` — no `Error applying batch 3`, no circuit disconnect, no `InvalidCharacterError` in browser console or server log.
- [x] Verified the universal-search placeholder opens the inline "coming soon" popover (`ToggleSearchPlaceholder`) and the popover Dismiss closes it (`CloseSearchPlaceholder`) — both `@onclick` handlers wire end-to-end.
- [x] Verified Sales WebUI still bootstraps a clean circuit on the auth-gated home page.
- [x] `dotnet build` clean for `BuildingBlocks.WebUI`, `Frontline.WebUI`, `Sales.WebUI`, `Portal.WebUI`.

### Follow-ups (out of scope for this hotfix)

* `Portal.WebUI/index.html` is static HTML and does not consume `PortalModuleShell.razor`, so it was unaffected by this regression.
* Long-term: consider adding an architecture test that asserts every Razor library which references `Microsoft.AspNetCore.App` and ships `.razor` components also imports `Microsoft.AspNetCore.Components.Web` in `_Imports.razor` — would have caught this at PR time.

Refs #92.
