### PR TITLE
ci(deploy-test): force-remove docker compose recreate orphans before up

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -221,8 +221,44 @@ jobs:
               exit 1
             '
 
+      # Defensive cleanup against half-finished `docker compose recreate`s.
+      #
+      # When `docker rm` of an old container fails mid-way through `up -d`
+      # (we have hit overlayfs `unlinkat ... directory not empty` twice on
+      # the test host), Docker leaves the OLD container alive but renamed
+      # to `<12-hex>_<original-name>` so the canonical name "frees up" for
+      # the new container. The new container then fails to come up because
+      # the published port is still held by the renamed orphan, and the
+      # next health-check (`docker exec lkvitai-mes-warehouse-api ...`)
+      # targets a name that does not exist any more — silent fail.
+      #
+      # This step finds those stale renamed orphans by their hash-prefix
+      # pattern and force-removes them BEFORE we recreate the stack.
+      # Pattern is intentionally narrow: matches only `<12-hex>_lkvitai-mes-…`
+      # so canonical containers (warehouse-api / portal-webui / db-test /
+      # redis / etc.) are never touched. Idempotent — when there is no
+      # orphan the command is a no-op.
+      - name: Remove docker compose recreate orphans
+        run: |
+          set -euo pipefail
+          orphans=$(docker ps -a --format '{{.Names}}' \
+            | grep -E '^[0-9a-f]{12}_lkvitai-mes-' || true)
+          if [ -n "$orphans" ]; then
+            echo "::warning::Found docker compose recreate orphans, removing:"
+            echo "$orphans"
+            echo "$orphans" | xargs -r docker rm -f
+          else
+            echo "No docker compose recreate orphans found."
+          fi
+
       - name: Deploy containers
-        run: IMAGE_TAG=${{ env.IMAGE_TAG }} docker compose -f docker-compose.test.yml up -d
+        # `--remove-orphans` clears any service that disappeared from the
+        # compose file (belt-and-braces against the chore/deploy-test-orphan-cleanup
+        # case above). Note: this does NOT clean up the renamed orphans
+        # the previous step targets — `--remove-orphans` only removes
+        # services unknown to the current compose, while renamed orphans
+        # share the project label and look "known" to compose.
+        run: IMAGE_TAG=${{ env.IMAGE_TAG }} docker compose -f docker-compose.test.yml up -d --remove-orphans
 
       - name: Wait for API health
         run: |


### PR DESCRIPTION
## Summary

Defensive cleanup against half-finished \docker compose recreate\s on the test host.

When \docker rm\ of an old container fails mid-\up -d\ (overlayfs \unlinkat ... directory not empty\ \u2014 hit twice on the test host today, once on PR #117 deploy), Docker leaves the OLD container alive but renamed to \<12-hex>_<original-name>\ so the canonical name 'frees up' for the new container. Because the published port is still held by the renamed orphan, the new container fails to come up; the next health-check (\docker exec lkvitai-mes-warehouse-api ...\) targets a canonical name that does not exist any more \u2014 silent fail, deploy job times out at 'Wait for API health' even though the renamed orphan is happily logging \/health\ 200s.

## Change

- New step \Remove docker compose recreate orphans\ before \Deploy containers\. Finds containers matching \^[0-9a-f]{12}_lkvitai-mes-\ and \docker rm -f\s them. Idempotent. Pattern is intentionally narrow so canonical containers (warehouse-api / portal-webui / db-test / redis / vector / cadvisor / portainer-agent / manuals) are never touched.
- \docker compose up -d\ now also passes \--remove-orphans\ as belt-and-braces against services that disappear from the compose file.

## Test plan

- Manual chase: PR #117 deploy needed two manual reruns + Portainer-side orphan deletion before it went green. With this step, a single rerun would have been enough.
- Idempotency: \grep -E '^[0-9a-f]{12}_lkvitai-mes-'\ returns empty on a clean host \u2192 \xargs -r\ is a no-op.