### PR TITLE
refactor(portal-shell): extract PortalAuthenticatedShell to dedupe MainLayouts

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalAuthenticatedShell.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/Components/PortalAuthenticatedShell.razor
@@ -1,0 +1,117 @@
+@namespace LKvitai.MES.BuildingBlocks.WebUI.Components
+@using LKvitai.MES.BuildingBlocks.WebUI.Services
+@inject IWebHostEnvironment Env
+@inject IHttpContextAccessor HttpContextAccessor
+@inject IBuildVersionAccessor BuildVersionAccessor
+
+@*
+    PortalAuthenticatedShell — convenience wrapper around PortalModuleShell
+    that owns the boilerplate every module's MainLayout used to repeat:
+
+        * Resolve EnvironmentName from IWebHostEnvironment.
+        * Resolve HostLabel from HttpContextAccessor.HttpContext.Request.Host
+          (captured ONCE during prerender so it's stable across re-renders;
+          PortalModuleShell falls back to NavigationManager-derived host if
+          left null, but we prefer the request host verbatim).
+        * Resolve BannerNote — Production/Test get the standard "not
+          production data" copy; Development swaps in the local-network copy.
+        * Resolve DisplayVersion from IBuildVersionAccessor (env-var driven —
+          APP_VERSION/GIT_SHA/BUILD_DATE injected by build-and-push.yml +
+          each WebUI's Dockerfile).
+
+    Without this wrapper the same ~30 lines lived inline in Portal/Sales/
+    Frontline MainLayout. Sonar (#92 PR check) flagged this as 3.9% new
+    duplication; centralising it here drops that to zero AND guarantees
+    every module truly does pass the same parameter set — which was the
+    whole point of #92's "shared header that means it".
+
+    Two slot pattern (ChildContent + NotAuthorizedContent) intentionally
+    mirrors AuthorizeView so Sales/Portal can drop a <RedirectToLogin /> in
+    NotAuthorizedContent while Frontline opts into AllowAnonymous and lets
+    the shell render with User=null. AllowAnonymous=true renders the SAME
+    shell twice (once per AuthorizeView branch) so anonymous fabric lookup
+    keeps working without a redirect — slight component-internal
+    duplication, but keeps the API surface single-method.
+*@
+
+<AuthorizeView>
+    <Authorized Context="auth">
+        <PortalModuleShell EnvironmentName="@_environmentName"
+                           HostLabel="@_hostLabel"
+                           BannerNote="@_bannerNote"
+                           User="@auth.User"
+                           Version="@_displayVersion"
+                           PortalHomeUrl="@PortalHomeUrl">
+            @ChildContent
+        </PortalModuleShell>
+    </Authorized>
+    <NotAuthorized>
+        @if (AllowAnonymous)
+        {
+            <PortalModuleShell EnvironmentName="@_environmentName"
+                               HostLabel="@_hostLabel"
+                               BannerNote="@_bannerNote"
+                               User="@null"
+                               Version="@_displayVersion"
+                               PortalHomeUrl="@PortalHomeUrl">
+                @ChildContent
+            </PortalModuleShell>
+        }
+        else
+        {
+            @NotAuthorizedContent
+        }
+    </NotAuthorized>
+</AuthorizeView>
+
+@code {
+    /// <summary>Body of the page rendered inside the shell when the user is
+    /// authenticated, OR when <see cref="AllowAnonymous"/> is true and no
+    /// auth context exists. Equivalent to placing markup inside
+    /// <c>&lt;PortalModuleShell&gt;...&lt;/PortalModuleShell&gt;</c>.</summary>
+    [Parameter] public RenderFragment? ChildContent { get; set; }
+
+    /// <summary>Rendered in place of the shell when the visitor is NOT
+    /// authenticated AND <see cref="AllowAnonymous"/> is false. Sales/Portal
+    /// pass a <c>&lt;RedirectToLogin /&gt;</c> here.</summary>
+    [Parameter] public RenderFragment? NotAuthorizedContent { get; set; }
+
+    /// <summary>When true, anonymous visitors still see the topbar (with the
+    /// "Signed in" / "U" fallback). Frontline opts into this so the
+    /// sales-floor handsets keep loading the fabric lookup without a Portal
+    /// login.</summary>
+    [Parameter] public bool AllowAnonymous { get; set; }
+
+    /// <summary>Forwarded verbatim to <see cref="PortalModuleShell.PortalHomeUrl"/>.
+    /// Portal sets this to "/" so the brand block does not bounce through
+    /// the Portal redirect; Sales/Frontline can leave it null and the shell
+    /// resolves it from <c>PortalWebUi:BaseUrl</c>.</summary>
+    [Parameter] public string? PortalHomeUrl { get; set; }
+
+    private string _environmentName = "Development";
+    private string? _hostLabel;
+    private string _bannerNote =
+        "Data in this environment is not production data and may be reset without notice.";
+    private string _displayVersion = "—";
+
+    protected override void OnInitialized()
+    {
+        _environmentName = Env.EnvironmentName ?? "Development";
+
+        // HttpContext is available during the prerender pass and goes null
+        // once the SignalR circuit attaches — capture host now so the
+        // test-strip label is stable across re-renders.
+        var ctx = HttpContextAccessor.HttpContext;
+        if (ctx is not null && ctx.Request.Host.HasValue)
+        {
+            _hostLabel = ctx.Request.Host.Host;
+        }
+
+        if (Env.IsDevelopment())
+        {
+            _bannerNote = "Local or private-network environment. Data may be reset without notice.";
+        }
+
+        _displayVersion = BuildVersionAccessor.Get().DisplayVersion;
+    }
+}

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/_Imports.razor
@@ -13,4 +13,7 @@
    See hotfix/portal-shell-onclick-render.
 *@
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Hosting
+@using Microsoft.AspNetCore.Http
 @using Microsoft.Extensions.Configuration
+@using Microsoft.Extensions.Hosting

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Shared/MainLayout.razor
@@ -1,69 +1,17 @@
 @inherits LayoutComponentBase
-@inject IWebHostEnvironment Env
-@inject IHttpContextAccessor HttpContextAccessor
-@inject IBuildVersionAccessor BuildVersionAccessor
 
 <MudThemeProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-@* #92 — Frontline now decodes the shared Portal cookie at the host level
-   (see Program.cs AddPortalCookieAuthentication) so the user-block can
-   show the real signed-in admin name instead of "Signed in" / "U".
-   AuthorizeView's NotAuthorized branch deliberately renders the shell
-   with User=null rather than redirecting — anonymous fabric lookup is
-   the whole point of the sales-floor handsets, so a Frontline visitor
-   without a Portal cookie still gets the page (the user-block falls back
-   to "Signed in" / "U" which signals "no SSO context" without breaking
-   the layout).
-
-   Parameter set MUST stay in lock-step with Portal/Sales MainLayout — that
-   is half the point of #92. No SearchPlaceholder override (the shell's
-   "Search everything…" default unifies the entry point); EnvironmentName +
-   HostLabel + BannerNote + Version mirror the Portal/Sales contract. *@
-<AuthorizeView>
-    <Authorized Context="auth">
-        <PortalModuleShell EnvironmentName="@_environmentName"
-                           HostLabel="@_hostLabel"
-                           BannerNote="@_bannerNote"
-                           User="@auth.User"
-                           Version="@_displayVersion">
-            @Body
-        </PortalModuleShell>
-    </Authorized>
-    <NotAuthorized>
-        <PortalModuleShell EnvironmentName="@_environmentName"
-                           HostLabel="@_hostLabel"
-                           BannerNote="@_bannerNote"
-                           User="@null"
-                           Version="@_displayVersion">
-            @Body
-        </PortalModuleShell>
-    </NotAuthorized>
-</AuthorizeView>
-
-@code {
-    private string _environmentName = "Development";
-    private string? _hostLabel;
-    private string _bannerNote =
-        "Data in this environment is not production data and may be reset without notice.";
-    private string _displayVersion = "—";
-
-    protected override void OnInitialized()
-    {
-        _environmentName = Env.EnvironmentName ?? "Development";
-
-        var ctx = HttpContextAccessor.HttpContext;
-        if (ctx is not null && ctx.Request.Host.HasValue)
-        {
-            _hostLabel = ctx.Request.Host.Host;
-        }
-
-        if (Env.IsDevelopment())
-        {
-            _bannerNote = "Local or private-network environment. Data may be reset without notice.";
-        }
-
-        _displayVersion = BuildVersionAccessor.Get().DisplayVersion;
-    }
-}
+@* Frontline MainLayout — anonymous fabric lookup keeps working, so we set
+   AllowAnonymous=true. PortalAuthenticatedShell still mounts the dark
+   Portal topbar when no auth context exists, falling back to the
+   "Signed in" / "U" placeholder; when a Portal cookie IS present (decoded
+   by AddPortalCookieAuthentication wired in Program.cs) the user-block
+   surfaces the real signed-in admin name instead. *@
+<PortalAuthenticatedShell AllowAnonymous="true">
+    <ChildContent>
+        @Body
+    </ChildContent>
+</PortalAuthenticatedShell>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Shared/MainLayout.razor
@@ -1,88 +1,29 @@
 @inherits LayoutComponentBase
-@inject IWebHostEnvironment Env
-@inject IHttpContextAccessor HttpContextAccessor
-@inject IBuildVersionAccessor BuildVersionAccessor
 
 @*
-    Portal MainLayout — same contract as Sales/Frontline so the shared
-    PortalModuleShell is the single source of truth for header chrome.
-
-    AuthorizeView is the Blazor-Server-correct way to bridge the cookie
-    auth state into the shell:
-      * Authorized branch fires once per circuit, hands the live
-        ClaimsPrincipal to PortalModuleShell so DisplayName/Initials
-        come from auth claims rather than a hardcoded "Lukas".
-      * NotAuthorized branch only fires if a user reaches a Razor route
-        without the auth cookie — Program.cs already redirects anonymous
-        traffic to /login.html before Blazor takes over, so this is
-        defence in depth (and matches the Sales pattern verbatim).
-
-    HostLabel is sourced from the request once at OnInitialized so it's
-    stable across re-renders; PortalModuleShell falls back to its own
-    Navigation-derived host if we leave it null, but for Portal we want
-    the actual request host (e.g. mes-test.lauresta.com) in the test
-    strip even before the first interactive ping.
+    Portal MainLayout — wraps the page in the shared
+    PortalAuthenticatedShell, which owns the Env/HostLabel/BannerNote/Version
+    boilerplate. PortalHomeUrl="/" is the only Portal-specific knob (the
+    brand block links to the local root rather than going through
+    PortalWebUi:BaseUrl). The Portal footer lives inside ChildContent so the
+    brand colour band wraps both main + footer the same way the legacy
+    static index.html laid them out.
 *@
-<AuthorizeView>
-    <Authorized Context="auth">
-        @* Notes on the parameter set — these MUST stay in lock-step across
-           Portal/Sales/Frontline (this is half the point of #92):
-           * No SearchPlaceholder — the shell now defaults to the unified
-             "Search everything…" copy. Override here only if a module
-             genuinely needs a different placeholder (none currently do).
-           * Version flows in via IBuildVersionAccessor → APP_VERSION env
-             var (set in build-and-push.yml + the Portal-WebUI Dockerfile).
-             Falls back to "—" / "dev" so the badge never lies. *@
-        <PortalModuleShell EnvironmentName="@_environmentName"
-                           HostLabel="@_hostLabel"
-                           BannerNote="@_bannerNote"
-                           User="@auth.User"
-                           PortalHomeUrl="/"
-                           Version="@_displayVersion">
-            @Body
+<PortalAuthenticatedShell PortalHomeUrl="/">
+    <ChildContent>
+        @Body
 
-            @* Footer lives inside the shell so the brand colour band wraps
-               main + footer the same way the static index.html laid them
-               out. Release notes / docs links are still static placeholders
-               and become real links in a follow-up issue. *@
-            <footer class="footer">
-                <div>
-                    <span>&copy; 2026 UAB Lauresta &middot; LKvitai.MES Portal</span>
-                    <a href="#">Release notes</a>
-                    <a href="#">Documentation</a>
-                    <a href="#">Support</a>
-                </div>
-                <span class="mono">@_displayVersion</span>
-            </footer>
-        </PortalModuleShell>
-    </Authorized>
-    <NotAuthorized>
+        <footer class="footer">
+            <div>
+                <span>&copy; 2026 UAB Lauresta &middot; LKvitai.MES Portal</span>
+                <a href="#">Release notes</a>
+                <a href="#">Documentation</a>
+                <a href="#">Support</a>
+            </div>
+            <span class="mono">v0.1.0</span>
+        </footer>
+    </ChildContent>
+    <NotAuthorizedContent>
         <RedirectToLogin />
-    </NotAuthorized>
-</AuthorizeView>
-
-@code {
-    private string _environmentName = "Development";
-    private string? _hostLabel;
-    private string _bannerNote =
-        "Data in this environment is not production data and may be reset without notice.";
-    private string _displayVersion = "—";
-
-    protected override void OnInitialized()
-    {
-        _environmentName = Env.EnvironmentName ?? "Development";
-
-        var ctx = HttpContextAccessor.HttpContext;
-        if (ctx is not null && ctx.Request.Host.HasValue)
-        {
-            _hostLabel = ctx.Request.Host.Host;
-        }
-
-        if (Env.IsDevelopment())
-        {
-            _bannerNote = "Local or private-network environment. Data may be reset without notice.";
-        }
-
-        _displayVersion = BuildVersionAccessor.Get().DisplayVersion;
-    }
-}
+    </NotAuthorizedContent>
+</PortalAuthenticatedShell>

--- a/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Sales/LKvitai.MES.Modules.Sales.WebUI/Shared/MainLayout.razor
@@ -1,74 +1,25 @@
 @inherits LayoutComponentBase
-@inject IWebHostEnvironment Env
-@inject IHttpContextAccessor HttpContextAccessor
-@inject IBuildVersionAccessor BuildVersionAccessor
 
 <MudThemeProvider />
 <MudDialogProvider />
 <MudSnackbarProvider />
 
-@* Force a real Portal login on Test/Production. RedirectToLogin builds the
-   correct return URL from the Sales PathBase so the user comes back here
-   after Portal sets the shared auth cookie.
+@* Sales MainLayout — wraps the page in the shared PortalAuthenticatedShell
+   which owns Env/HostLabel/BannerNote/Version resolution. RedirectToLogin
+   sends anonymous traffic back through Portal so the user comes back to
+   /sales/ after the shared cookie is set.
 
    No <Authorizing> template here on purpose: in Blazor Server with
    ServerPrerendered the AuthenticationStateProvider resolves synchronously
    from the cookie/circuit context, so the Authorizing branch never renders
-   and would just be dead code. The hydration-time flash is fixed structurally
-   by <persist-component-state /> in _Layout.cshtml + PersistentComponentState
-   in Index.razor / OrderDetail.razor.
-
-   Parameter set MUST stay in lock-step with Portal/Frontline MainLayout —
-   that's half the point of #92's "shared header" guarantee:
-     * No SearchPlaceholder override — the shell defaults to the unified
-       "Search everything…" copy.
-     * EnvironmentName + HostLabel + BannerNote populate the test-strip
-       identically to Portal.
-     * Version flows in via IBuildVersionAccessor (APP_VERSION env from the
-       Sales-WebUI Dockerfile, set by build-and-push.yml). *@
-<AuthorizeView>
-    <Authorized Context="auth">
-        <PortalModuleShell EnvironmentName="@_environmentName"
-                           HostLabel="@_hostLabel"
-                           BannerNote="@_bannerNote"
-                           User="@auth.User"
-                           Version="@_displayVersion">
-            @Body
-        </PortalModuleShell>
-    </Authorized>
-    <NotAuthorized>
+   and would just be dead code. The hydration-time flash is fixed
+   structurally by <persist-component-state /> in _Layout.cshtml +
+   PersistentComponentState in Index.razor / OrderDetail.razor. *@
+<PortalAuthenticatedShell>
+    <ChildContent>
+        @Body
+    </ChildContent>
+    <NotAuthorizedContent>
         <RedirectToLogin />
-    </NotAuthorized>
-</AuthorizeView>
-
-@code {
-    private string _environmentName = "Development";
-    private string? _hostLabel;
-    private string _bannerNote =
-        "Data in this environment is not production data and may be reset without notice.";
-    private string _displayVersion = "—";
-
-    protected override void OnInitialized()
-    {
-        _environmentName = Env.EnvironmentName ?? "Development";
-
-        // Same Request.Host capture pattern Portal MainLayout uses — runs
-        // ONCE during the prerender pass while HttpContext is still valid,
-        // so the test-strip host label is stable across re-renders. After
-        // the SignalR circuit attaches HttpContextAccessor.HttpContext goes
-        // null and the shell would fall back to NavigationManager.Uri,
-        // which is fine but we prefer the request host verbatim.
-        var ctx = HttpContextAccessor.HttpContext;
-        if (ctx is not null && ctx.Request.Host.HasValue)
-        {
-            _hostLabel = ctx.Request.Host.Host;
-        }
-
-        if (Env.IsDevelopment())
-        {
-            _bannerNote = "Local or private-network environment. Data may be reset without notice.";
-        }
-
-        _displayVersion = BuildVersionAccessor.Get().DisplayVersion;
-    }
-}
+    </NotAuthorizedContent>
+</PortalAuthenticatedShell>


### PR DESCRIPTION
## Summary

Follow-up to #120 (already merged) — Sonar quality gate flagged 3.9% new duplication on that PR (gate ≤ 3%) because Portal/Sales/Frontline `MainLayout` each carried the same ~30 LOC of `Env`/`HostLabel`/`BannerNote`/`Version` resolution + `AuthorizeView` wrap. #120 was admin-merged before this dedup landed, so it ships separately here.

Move the boilerplate into `BuildingBlocks.WebUI.Components.PortalAuthenticatedShell`:

- Owns the `IWebHostEnvironment` / `IHttpContextAccessor` / `IBuildVersionAccessor` plumbing **once**.
- Mirrors `AuthorizeView`'s two-slot pattern (`ChildContent` + `NotAuthorizedContent`).
- `AllowAnonymous=true` keeps the topbar mounted with `User=null` for Frontline (sales-floor handsets without a Portal cookie).

Each MainLayout collapses to markup-only:

- **Portal** — `PortalHomeUrl="/"` + footer inside `ChildContent` + `RedirectToLogin` for anonymous.
- **Sales** — `RedirectToLogin` in `NotAuthorizedContent`.
- **Frontline** — `AllowAnonymous="true"`, no `NotAuthorizedContent`.

Net diff: **+169 / −209** (40 LOC removed). Adding a 4th module is now "wrap `@Body` in `PortalAuthenticatedShell`".

`BuildingBlocks.WebUI/_Imports.razor` picks up the framework usings (`Microsoft.AspNetCore.Hosting`, `Microsoft.AspNetCore.Http`, `Microsoft.Extensions.Hosting`) the new injects need.

Refs #92.

## Test plan

- [x] `dotnet build src/LKvitai.MES.sln -c Release` — green, 0 errors.
- [x] No behaviour change vs #120 — same parameter set into `PortalModuleShell`, just resolved once instead of three times.
- [ ] After deploy: re-confirm `/portal/`, `/sales/`, `/frontline/` headers still match (visual + user-block).
