### PR TITLE
feat(portal): operations summary API for monthly order stages (#94)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -49,6 +49,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Production
       ConnectionStrings__PortalDb: ${PORTAL_DB_CONNECTION}
+      ConnectionStrings__LKvitaiDb: ${LKVITAI_MSACCESS_DB_CONNECTION}
     networks:
       - lkvitai-mes_prod
     healthcheck:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -67,6 +67,7 @@ services:
     environment:
       ASPNETCORE_ENVIRONMENT: Test
       ConnectionStrings__PortalDb: "Host=pg;Port=5432;Database=${TEST_DB_NAME:-lkvitai_warehouse_test};Username=${TEST_DB_USER:-postgres};Password=${TEST_DB_PASSWORD}"
+      ConnectionStrings__LKvitaiDb: "${LKVITAI_MSACCESS_DB_CONNECTION}"
     networks:
       - lkvitai-mes_default
     healthcheck:

--- a/docs/sql/mes-operations-summary.sql
+++ b/docs/sql/mes-operations-summary.sql
@@ -1,0 +1,160 @@
+-- ============================================================
+-- mes_OperationsSummary
+-- Portal operations summary: stage counts, raw status counts,
+-- created-by-day and completed-by-day for one calendar month.
+--
+-- All objects created by this file use the mes_ prefix.
+-- Safe to run multiple times (DROP + CREATE pattern for SQL 2014).
+--
+-- Parameters
+--   @Period  NVARCHAR(10)  'this' = current month (default)
+--                          'last' = previous calendar month
+--
+-- Result sets (always 5, always in this order)
+--   1. Period      (1 row)   PeriodKey, PeriodFrom, PeriodTo
+--   2. Stages      (8 rows)  StageKey, StageLabel, StageCount
+--   3. Statuses    (n rows)  StatusName, StatusCount
+--   4. CreatedByDay          Day (DATE), DayCount
+--   5. CompletedByDay        Day (DATE), DayCount
+--
+-- Business rules
+--   * Exclude test branch: FilialoID <> 7
+--   * Exclude customer-cancelled orders:
+--       Sugadintas = 1
+--       AND LTRIM(RTRIM(ISNULL(sNotes,''))) = 'Kliento prasymu anuliuotas'
+--   * Period scope : dtDateInsert in [@From, @To)  (@To = first day of next month)
+--   * completedByDay date: ISNULL(dtFinishingOrderDate, dtDateInsert)
+-- ============================================================
+
+IF OBJECT_ID(N'dbo.mes_OperationsSummary', N'P') IS NOT NULL
+    DROP PROCEDURE dbo.mes_OperationsSummary;
+GO
+
+CREATE PROCEDURE [dbo].[mes_OperationsSummary]
+    @Period NVARCHAR(10) = N'this'
+AS
+BEGIN
+    SET NOCOUNT ON;
+
+    -- -------------------------------------------------------
+    -- Resolve period date range
+    -- -------------------------------------------------------
+    DECLARE @Today  DATE = CAST(GETDATE() AS DATE);
+    DECLARE @From   DATE;
+    DECLARE @To     DATE;   -- exclusive upper bound (= first day of NEXT month)
+    DECLARE @ToIncl DATE;   -- inclusive last day (for display only)
+
+    IF ISNULL(@Period, N'') = N'last'
+    BEGIN
+        SET @From   = DATEFROMPARTS(YEAR(DATEADD(month, -1, @Today)), MONTH(DATEADD(month, -1, @Today)), 1);
+        SET @To     = DATEFROMPARTS(YEAR(@Today), MONTH(@Today), 1);
+    END
+    ELSE  -- 'this' or any other value → current month
+    BEGIN
+        SET @From   = DATEFROMPARTS(YEAR(@Today), MONTH(@Today), 1);
+        SET @To     = DATEFROMPARTS(YEAR(DATEADD(month, 1, @Today)), MONTH(DATEADD(month, 1, @Today)), 1);
+    END;
+
+    SET @ToIncl = DATEADD(day, -1, @To);
+
+    -- -------------------------------------------------------
+    -- Result set 1 — Period metadata  (1 row)
+    -- -------------------------------------------------------
+    SELECT
+        CASE WHEN ISNULL(@Period, N'') = N'last' THEN N'last' ELSE N'this' END AS PeriodKey,
+        CONVERT(NVARCHAR(10), @From,   126)                                    AS PeriodFrom,
+        CONVERT(NVARCHAR(10), @ToIncl, 126)                                    AS PeriodTo;
+
+    -- -------------------------------------------------------
+    -- Result set 2 — Stage counts  (8 rows, zero-filled)
+    -- -------------------------------------------------------
+    ;WITH Counts AS (
+        SELECT u.StateID, COUNT(*) AS Cnt
+        FROM dbo.Uzsakymai u
+        INNER JOIN dbo.Zinynas_UzsakymoSerijos us ON us.UzsakymoSerijaID = u.UzsakymoSerija
+        WHERE
+            us.FilialoID <> 7
+            AND CAST(u.dtDateInsert AS DATE) >= @From
+            AND CAST(u.dtDateInsert AS DATE) <  @To
+            AND (
+                u.Sugadintas = 0
+                OR LTRIM(RTRIM(ISNULL(u.sNotes, N''))) <> N'Kliento prasymu anuliuotas'
+            )
+        GROUP BY u.StateID
+    )
+    SELECT StageKey, StageLabel, StageCount FROM (
+        SELECT 1 AS SortKey, N'intake'      AS StageKey, N'New / Intake'          AS StageLabel, ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID IN (4, 1173102373)),    0) AS StageCount
+        UNION ALL SELECT 2, N'queued',      N'Queued',               ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID IN (8, 1173102375)),    0)
+        UNION ALL SELECT 3, N'production',  N'In production',        ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID = 1),                   0)
+        UNION ALL SELECT 4, N'mixed',       N'Mixed',                ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID = 0),                   0)
+        UNION ALL SELECT 5, N'blocked',     N'Blocked',              ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID IN (5,6,7,1173102377)), 0)
+        UNION ALL SELECT 6, N'produced',    N'Produced',             ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID = 1173102374),          0)
+        UNION ALL SELECT 7, N'branch',      N'In branch / delivery', ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID = 1173102376),          0)
+        UNION ALL SELECT 8, N'completed',   N'Completed',            ISNULL((SELECT SUM(Cnt) FROM Counts WHERE StateID = 2),                   0)
+    ) AS StageRows
+    ORDER BY SortKey;
+
+    -- -------------------------------------------------------
+    -- Result set 3 — Raw status counts
+    -- -------------------------------------------------------
+    SELECT
+        LTRIM(RTRIM(b.Busena)) AS StatusName,
+        COUNT(*)               AS StatusCount
+    FROM dbo.Uzsakymai u
+    INNER JOIN dbo.Zinynas_UzsakymoSerijos us ON us.UzsakymoSerijaID = u.UzsakymoSerija
+    INNER JOIN dbo.Zinynas_busenos         b  ON b.BusenosID         = u.StateID
+    WHERE
+        us.FilialoID <> 7
+        AND CAST(u.dtDateInsert AS DATE) >= @From
+        AND CAST(u.dtDateInsert AS DATE) <  @To
+        AND (
+            u.Sugadintas = 0
+            OR LTRIM(RTRIM(ISNULL(u.sNotes, N''))) <> N'Kliento prasymu anuliuotas'
+        )
+    GROUP BY LTRIM(RTRIM(b.Busena))
+    ORDER BY StatusCount DESC;
+
+    -- -------------------------------------------------------
+    -- Result set 4 — Created by day
+    -- -------------------------------------------------------
+    SELECT
+        CAST(u.dtDateInsert AS DATE) AS [Day],
+        COUNT(*)                     AS DayCount
+    FROM dbo.Uzsakymai u
+    INNER JOIN dbo.Zinynas_UzsakymoSerijos us ON us.UzsakymoSerijaID = u.UzsakymoSerija
+    WHERE
+        us.FilialoID <> 7
+        AND CAST(u.dtDateInsert AS DATE) >= @From
+        AND CAST(u.dtDateInsert AS DATE) <  @To
+        AND (
+            u.Sugadintas = 0
+            OR LTRIM(RTRIM(ISNULL(u.sNotes, N''))) <> N'Kliento prasymu anuliuotas'
+        )
+    GROUP BY CAST(u.dtDateInsert AS DATE)
+    ORDER BY [Day];
+
+    -- -------------------------------------------------------
+    -- Result set 5 — Completed by day
+    --    Anchored on ISNULL(dtFinishingOrderDate, dtDateInsert)
+    --    so orders without a finishing date fall back to their
+    --    creation date. Only StateID = 2 (Isduotas klientui).
+    -- -------------------------------------------------------
+    SELECT
+        CAST(ISNULL(u.dtFinishingOrderDate, u.dtDateInsert) AS DATE) AS [Day],
+        COUNT(*)                                                      AS DayCount
+    FROM dbo.Uzsakymai u
+    INNER JOIN dbo.Zinynas_UzsakymoSerijos us ON us.UzsakymoSerijaID = u.UzsakymoSerija
+    WHERE
+        us.FilialoID <> 7
+        AND u.StateID = 2
+        AND CAST(ISNULL(u.dtFinishingOrderDate, u.dtDateInsert) AS DATE) >= @From
+        AND CAST(ISNULL(u.dtFinishingOrderDate, u.dtDateInsert) AS DATE) <  @To
+        AND (
+            u.Sugadintas = 0
+            OR LTRIM(RTRIM(ISNULL(u.sNotes, N''))) <> N'Kliento prasymu anuliuotas'
+        )
+    GROUP BY CAST(ISNULL(u.dtFinishingOrderDate, u.dtDateInsert) AS DATE)
+    ORDER BY [Day];
+
+END;
+GO

--- a/sales.html
+++ b/sales.html
@@ -1,0 +1,260 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <base href="/sales/" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700;800&display=swap" rel="stylesheet" />
+    <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="css/tokens.css?v=wpUfnuRQssdwlFs3Oxnjr4-o9pez_teENQrwsepltSY" rel="stylesheet" />
+    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css?v=RGK7tHhgGFzlc8v095XLAiQPlRrXEnzlS2QKkR-ivqg" rel="stylesheet" />
+    <link href="css/orders.css?v=_Qo_77ZI2ba1vm87C2yjE9eUNIKAfByI0JMHnKyNfes" rel="stylesheet" />
+    <link rel="icon" href="data:," />
+    <title>LKvitai.MES · Sales</title>
+    <!--Blazor:{"type":"server","prerenderId":"5e14f56459794b96bb6a8b53ef9b9b42","key":{"locationHash":"77D12F14A8105320B1AAED6AE7E689DA0EC4483270A645E84079EAA0FFDF550D:0","formattedComponentKey":""},"sequence":0,"descriptor":"CfDJ8PErQz4MCv1Aov8WzxetGs5/jbQieOP1GyHU3\u002Bw/PgTciN5SbEjyO48EL39xrG4bX\u002BldmpbIHaDb3sSD5BHH5/ah4j0wG3Pi8wC7TY4T3lrR7Xa0prbVQ1srGmskYVChisKASxoFDWtkBzght0oq2lZg8bxkopmpUw/wnMg6AeJOV5pDf491iRGOgT2KPoKM\u002BcCnMX40mpHJUJyqgZ2EkSKjgCwHkEvJU0NLxSRDOr5pemAZ/Lu4u2Eocph4j5\u002BcPtWViCh5aCJiKUIcYztkL5G7HGX7Sy8xqcLkcB8XI\u002BuYdVCNx3MN2e5r0sxs1H0siQjEFxIV40EG8gsyaCNf3UWesnLYI9se1i\u002BU4YCHvAX45Mw67nBSUv2yO0Ku09bZ9/nFi/theNfOgPRJGM\u002BstXj9mLgJlPAMx2Nokz2L0Sxb9xLYijuFRU7110IBg28ImHE00d7GUgJZbCkSwUBYVZPUOMArG4U3hnzMWvSFnN1zzlbOCw8wWO7F7lEKmAKaNLbphJNrWG8F2LCrOXCdnGtQ2qadwwH23KPfZgrLmdhyWeZMbn4Hv\u002BnYGeW0uIMBAzK1414NiCv5\u002BaqB0WO2k6E="}--><!--Blazor:{"prerenderId":"5e14f56459794b96bb6a8b53ef9b9b42"}-->
+</head>
+<body>
+    
+<!--Blazor:{"type":"server","prerenderId":"b29d2ed43f444763952db0b98d9bb122","key":{"locationHash":"8BE8B724F4241EDBCE4760D9C235FA4AE9563FADCB695210DDE34963D6DDDB83:0","formattedComponentKey":""},"sequence":1,"descriptor":"CfDJ8PErQz4MCv1Aov8WzxetGs4JVXPesdHDWTO6XvXUeF9uUr1tbS1UJmbQsGYOhvAnLnCPAe6DDg0I7bWsbXE1kJo3u\u002Bku4m8QVRq0/8o435ZXIIoMCqWA2zSGcSrHzqByaY\u002BFWQntg3ieCc0J9wipsLPM\u002BNDOb1OLjCROe0pHEcniSqf0ITklKZfZcYYw7xSlFfu6IP960Q7kSZmOWfLzhDNDwEohV9\u002BbrQ9p705TVh4euoWg\u002BS\u002BYe3BwSjlZV9M7ECGK5Ozg87vWpfuLrhjY5owLleHlaj4ylmenoYCDhVDs0IQpdePbY0BqUTn6AGqG/fVh4xO5xFdqMUgKCqsTCnBvlbv9TpxtFVHj2hqS01DBkMvOt2NK1ir/7IpyL3lG7g2eQ1YzrUzealUHEqt44SE\u002BYll4Ykb47zRkvw2Jl1M2U50GN4ltTKN/64K2UDgBn1Rt7FPQzSrJwt2gwqcnLsUhID1lMNPCBWYZAL7wBkp56iSTDEDkGM8IeJoi5j\u002BlTMLPHLFoI48MqML1V5RXBerKzv5YB5BeIVuxN8A4YLrH70YQCSHPpBqYwFoi5abCzg=="}--><style>
+::-webkit-scrollbar {width: 8px;height: 8px;z-index: 1;}
+::-webkit-scrollbar-track {background: transparent;}
+::-webkit-scrollbar-thumb {background: #c4c4c4;border-radius: 1px;}
+::-webkit-scrollbar-thumb:hover {background: #a6a6a6;}
+html, body * {scrollbar-color: #c4c4c4 transparent;scrollbar-width: thin;}
+</style>
+<style>
+    .mud-chart-serie:hover {
+        filter: url(#lighten);
+    }
+</style>
+
+<style>
+:root{
+--mud-palette-black: rgba(39,44,52,1);
+--mud-palette-white: rgba(255,255,255,1);
+--mud-palette-primary: rgba(89,74,226,1);
+--mud-palette-primary-rgb: 89,74,226;
+--mud-palette-primary-text: rgba(255,255,255,1);
+--mud-palette-primary-darken: rgb(62,44,221);
+--mud-palette-primary-lighten: rgb(118,106,231);
+--mud-palette-primary-hover: rgba(89,74,226,0.058823529411764705);
+--mud-palette-secondary: rgba(255,64,129,1);
+--mud-palette-secondary-rgb: 255,64,129;
+--mud-palette-secondary-text: rgba(255,255,255,1);
+--mud-palette-secondary-darken: rgb(255,31,105);
+--mud-palette-secondary-lighten: rgb(255,102,153);
+--mud-palette-secondary-hover: rgba(255,64,129,0.058823529411764705);
+--mud-palette-tertiary: rgba(30,200,165,1);
+--mud-palette-tertiary-rgb: 30,200,165;
+--mud-palette-tertiary-text: rgba(255,255,255,1);
+--mud-palette-tertiary-darken: rgb(25,169,140);
+--mud-palette-tertiary-lighten: rgb(42,223,187);
+--mud-palette-tertiary-hover: rgba(30,200,165,0.058823529411764705);
+--mud-palette-info: rgba(33,150,243,1);
+--mud-palette-info-rgb: 33,150,243;
+--mud-palette-info-text: rgba(255,255,255,1);
+--mud-palette-info-darken: rgb(12,128,223);
+--mud-palette-info-lighten: rgb(71,167,245);
+--mud-palette-info-hover: rgba(33,150,243,0.058823529411764705);
+--mud-palette-success: rgba(0,200,83,1);
+--mud-palette-success-rgb: 0,200,83;
+--mud-palette-success-text: rgba(255,255,255,1);
+--mud-palette-success-darken: rgb(0,163,68);
+--mud-palette-success-lighten: rgb(0,235,98);
+--mud-palette-success-hover: rgba(0,200,83,0.058823529411764705);
+--mud-palette-warning: rgba(255,152,0,1);
+--mud-palette-warning-rgb: 255,152,0;
+--mud-palette-warning-text: rgba(255,255,255,1);
+--mud-palette-warning-darken: rgb(214,129,0);
+--mud-palette-warning-lighten: rgb(255,167,36);
+--mud-palette-warning-hover: rgba(255,152,0,0.058823529411764705);
+--mud-palette-error: rgba(244,67,54,1);
+--mud-palette-error-rgb: 244,67,54;
+--mud-palette-error-text: rgba(255,255,255,1);
+--mud-palette-error-darken: rgb(242,28,13);
+--mud-palette-error-lighten: rgb(246,96,85);
+--mud-palette-error-hover: rgba(244,67,54,0.058823529411764705);
+--mud-palette-dark: rgba(66,66,66,1);
+--mud-palette-dark-rgb: 66,66,66;
+--mud-palette-dark-text: rgba(255,255,255,1);
+--mud-palette-dark-darken: rgb(46,46,46);
+--mud-palette-dark-lighten: rgb(87,87,87);
+--mud-palette-dark-hover: rgba(66,66,66,0.058823529411764705);
+--mud-palette-text-primary: rgba(66,66,66,1);
+--mud-palette-text-secondary: rgba(0,0,0,0.5372549019607843);
+--mud-palette-text-disabled: rgba(0,0,0,0.3764705882352941);
+--mud-palette-action-default: rgba(0,0,0,0.5372549019607843);
+--mud-palette-action-default-hover: rgba(0,0,0,0.058823529411764705);
+--mud-palette-action-disabled: rgba(0,0,0,0.25882352941176473);
+--mud-palette-action-disabled-background: rgba(0,0,0,0.11764705882352941);
+--mud-palette-surface: rgba(255,255,255,1);
+--mud-palette-background: rgba(255,255,255,1);
+--mud-palette-background-grey: rgba(245,245,245,1);
+--mud-palette-drawer-background: rgba(255,255,255,1);
+--mud-palette-drawer-text: rgba(66,66,66,1);
+--mud-palette-drawer-icon: rgba(97,97,97,1);
+--mud-palette-appbar-background: rgba(89,74,226,1);
+--mud-palette-appbar-text: rgba(255,255,255,1);
+--mud-palette-lines-default: rgba(0,0,0,0.11764705882352941);
+--mud-palette-lines-inputs: rgba(189,189,189,1);
+--mud-palette-table-lines: rgba(224,224,224,1);
+--mud-palette-table-striped: rgba(0,0,0,0.0196078431372549);
+--mud-palette-table-hover: rgba(0,0,0,0.0392156862745098);
+--mud-palette-divider: rgba(224,224,224,1);
+--mud-palette-divider-light: rgba(0,0,0,0.8);
+--mud-palette-chip-default: rgba(0,0,0,0.0784313725490196);
+--mud-palette-chip-default-hover: rgba(0,0,0,0.11764705882352941);
+--mud-palette-grey-default: #9E9E9E;
+--mud-palette-grey-light: #BDBDBD;
+--mud-palette-grey-lighter: #E0E0E0;
+--mud-palette-grey-dark: #757575;
+--mud-palette-grey-darker: #616161;
+--mud-palette-overlay-dark: rgba(33,33,33,0.4980392156862745);
+--mud-palette-overlay-light: rgba(255,255,255,0.4980392156862745);
+--mud-elevation-0: none;
+--mud-elevation-1: 0px 2px 1px -1px rgba(0,0,0,0.2),0px 1px 1px 0px rgba(0,0,0,0.14),0px 1px 3px 0px rgba(0,0,0,0.12);
+--mud-elevation-2: 0px 3px 1px -2px rgba(0,0,0,0.2),0px 2px 2px 0px rgba(0,0,0,0.14),0px 1px 5px 0px rgba(0,0,0,0.12);
+--mud-elevation-3: 0px 3px 3px -2px rgba(0,0,0,0.2),0px 3px 4px 0px rgba(0,0,0,0.14),0px 1px 8px 0px rgba(0,0,0,0.12);
+--mud-elevation-4: 0px 2px 4px -1px rgba(0,0,0,0.2),0px 4px 5px 0px rgba(0,0,0,0.14),0px 1px 10px 0px rgba(0,0,0,0.12);
+--mud-elevation-5: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 5px 8px 0px rgba(0,0,0,0.14),0px 1px 14px 0px rgba(0,0,0,0.12);
+--mud-elevation-6: 0px 3px 5px -1px rgba(0,0,0,0.2),0px 6px 10px 0px rgba(0,0,0,0.14),0px 1px 18px 0px rgba(0,0,0,0.12);
+--mud-elevation-7: 0px 4px 5px -2px rgba(0,0,0,0.2),0px 7px 10px 1px rgba(0,0,0,0.14),0px 2px 16px 1px rgba(0,0,0,0.12);
+--mud-elevation-8: 0px 5px 5px -3px rgba(0,0,0,0.2),0px 8px 10px 1px rgba(0,0,0,0.14),0px 3px 14px 2px rgba(0,0,0,0.12);
+--mud-elevation-9: 0px 5px 6px -3px rgba(0,0,0,0.2),0px 9px 12px 1px rgba(0,0,0,0.14),0px 3px 16px 2px rgba(0,0,0,0.12);
+--mud-elevation-10: 0px 6px 6px -3px rgba(0,0,0,0.2),0px 10px 14px 1px rgba(0,0,0,0.14),0px 4px 18px 3px rgba(0,0,0,0.12);
+--mud-elevation-11: 0px 6px 7px -4px rgba(0,0,0,0.2),0px 11px 15px 1px rgba(0,0,0,0.14),0px 4px 20px 3px rgba(0,0,0,0.12);
+--mud-elevation-12: 0px 7px 8px -4px rgba(0,0,0,0.2),0px 12px 17px 2px rgba(0,0,0,0.14),0px 5px 22px 4px rgba(0,0,0,0.12);
+--mud-elevation-13: 0px 7px 8px -4px rgba(0,0,0,0.2),0px 13px 19px 2px rgba(0,0,0,0.14),0px 5px 24px 4px rgba(0,0,0,0.12);
+--mud-elevation-14: 0px 7px 9px -4px rgba(0,0,0,0.2),0px 14px 21px 2px rgba(0,0,0,0.14),0px 5px 26px 4px rgba(0,0,0,0.12);
+--mud-elevation-15: 0px 8px 9px -5px rgba(0,0,0,0.2),0px 15px 22px 2px rgba(0,0,0,0.14),0px 6px 28px 5px rgba(0,0,0,0.12);
+--mud-elevation-16: 0px 8px 10px -5px rgba(0,0,0,0.2),0px 16px 24px 2px rgba(0,0,0,0.14),0px 6px 30px 5px rgba(0,0,0,0.12);
+--mud-elevation-17: 0px 8px 11px -5px rgba(0,0,0,0.2),0px 17px 26px 2px rgba(0,0,0,0.14),0px 6px 32px 5px rgba(0,0,0,0.12);
+--mud-elevation-18: 0px 9px 11px -5px rgba(0,0,0,0.2),0px 18px 28px 2px rgba(0,0,0,0.14),0px 7px 34px 6px rgba(0,0,0,0.12);
+--mud-elevation-19: 0px 9px 12px -6px rgba(0,0,0,0.2),0px 19px 29px 2px rgba(0,0,0,0.14),0px 7px 36px 6px rgba(0,0,0,0.12);
+--mud-elevation-20: 0px 10px 13px -6px rgba(0,0,0,0.2),0px 20px 31px 3px rgba(0,0,0,0.14),0px 8px 38px 7px rgba(0,0,0,0.12);
+--mud-elevation-21: 0px 10px 13px -6px rgba(0,0,0,0.2),0px 21px 33px 3px rgba(0,0,0,0.14),0px 8px 40px 7px rgba(0,0,0,0.12);
+--mud-elevation-22: 0px 10px 14px -6px rgba(0,0,0,0.2),0px 22px 35px 3px rgba(0,0,0,0.14),0px 8px 42px 7px rgba(0,0,0,0.12);
+--mud-elevation-23: 0px 11px 14px -7px rgba(0,0,0,0.2),0px 23px 36px 3px rgba(0,0,0,0.14),0px 9px 44px 8px rgba(0,0,0,0.12);
+--mud-elevation-24: 0px 11px 15px -7px rgba(0,0,0,0.2),0px 24px 38px 3px rgba(0,0,0,0.14),0px 9px 46px 8px rgba(0,0,0,0.12);
+--mud-elevation-25: 0 5px 5px -3px rgba(0,0,0,.06), 0 8px 10px 1px rgba(0,0,0,.042), 0 3px 14px 2px rgba(0,0,0,.036);
+--mud-default-borderradius: 4px;
+--mud-drawer-width-left: 240px;
+--mud-drawer-width-right: 240px;
+--mud-drawer-width-mini-left: 56px;
+--mud-drawer-width-mini-right: 56px;
+--mud-appbar-height: 64px;
+--mud-typography-default-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-default-size: .875rem;
+--mud-typography-default-weight: 400;
+--mud-typography-default-lineheight: 1.43;
+--mud-typography-default-letterspacing: .01071em;
+--mud-typography-default-text-transform: none;
+--mud-typography-h1-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h1-size: 6rem;
+--mud-typography-h1-weight: 300;
+--mud-typography-h1-lineheight: 1.167;
+--mud-typography-h1-letterspacing: -.01562em;
+--mud-typography-h1-text-transform: none;
+--mud-typography-h2-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h2-size: 3.75rem;
+--mud-typography-h2-weight: 300;
+--mud-typography-h2-lineheight: 1.2;
+--mud-typography-h2-letterspacing: -.00833em;
+--mud-typography-h2-text-transform: none;
+--mud-typography-h3-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h3-size: 3rem;
+--mud-typography-h3-weight: 400;
+--mud-typography-h3-lineheight: 1.167;
+--mud-typography-h3-letterspacing: 0;
+--mud-typography-h3-text-transform: none;
+--mud-typography-h4-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h4-size: 2.125rem;
+--mud-typography-h4-weight: 400;
+--mud-typography-h4-lineheight: 1.235;
+--mud-typography-h4-letterspacing: .00735em;
+--mud-typography-h4-text-transform: none;
+--mud-typography-h5-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h5-size: 1.5rem;
+--mud-typography-h5-weight: 400;
+--mud-typography-h5-lineheight: 1.334;
+--mud-typography-h5-letterspacing: 0;
+--mud-typography-h5-text-transform: none;
+--mud-typography-h6-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-h6-size: 1.25rem;
+--mud-typography-h6-weight: 500;
+--mud-typography-h6-lineheight: 1.6;
+--mud-typography-h6-letterspacing: .0075em;
+--mud-typography-h6-text-transform: none;
+--mud-typography-subtitle1-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-subtitle1-size: 1rem;
+--mud-typography-subtitle1-weight: 400;
+--mud-typography-subtitle1-lineheight: 1.75;
+--mud-typography-subtitle1-letterspacing: .00938em;
+--mud-typography-subtitle1-text-transform: none;
+--mud-typography-subtitle2-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-subtitle2-size: .875rem;
+--mud-typography-subtitle2-weight: 500;
+--mud-typography-subtitle2-lineheight: 1.57;
+--mud-typography-subtitle2-letterspacing: .00714em;
+--mud-typography-subtitle2-text-transform: none;
+--mud-typography-body1-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-body1-size: 1rem;
+--mud-typography-body1-weight: 400;
+--mud-typography-body1-lineheight: 1.5;
+--mud-typography-body1-letterspacing: .00938em;
+--mud-typography-body1-text-transform: none;
+--mud-typography-body2-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-body2-size: .875rem;
+--mud-typography-body2-weight: 400;
+--mud-typography-body2-lineheight: 1.43;
+--mud-typography-body2-letterspacing: .01071em;
+--mud-typography-body2-text-transform: none;
+--mud-typography-button-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-button-size: .875rem;
+--mud-typography-button-weight: 500;
+--mud-typography-button-lineheight: 1.75;
+--mud-typography-button-letterspacing: .02857em;
+--mud-typography-button-text-transform: uppercase;
+--mud-typography-caption-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-caption-size: .75rem;
+--mud-typography-caption-weight: 400;
+--mud-typography-caption-lineheight: 1.66;
+--mud-typography-caption-letterspacing: .03333em;
+--mud-typography-caption-text-transform: none;
+--mud-typography-overline-family: 'Roboto','Helvetica','Arial','sans-serif';
+--mud-typography-overline-size: .75rem;
+--mud-typography-overline-weight: 400;
+--mud-typography-overline-lineheight: 2.66;
+--mud-typography-overline-letterspacing: .08333em;
+--mud-typography-overline-text-transform: none;
+--mud-zindex-drawer: 1100;
+--mud-zindex-appbar: 1300;
+--mud-zindex-dialog: 1400;
+--mud-zindex-popover: 1200;
+--mud-zindex-snackbar: 1500;
+--mud-zindex-tooltip: 1600;
+}
+</style>
+
+<div class="mud-popover-provider"></div>
+
+<div id="mud-snackbar-container" class="mud-snackbar-location-top-right"></div>
+
+<!--Blazor:{"prerenderId":"b29d2ed43f444763952db0b98d9bb122"}-->
+
+
+    <div id="blazor-error-ui">
+        An unhandled error has occurred.
+        <a href="" class="reload">Reload</a>
+        <a class="dismiss">🗙</a>
+    </div>
+
+    <!--Blazor-Server-Component-State:CfDJ8PErQz4MCv1Aov8WzxetGs7zxcrHcQN/fzu9P4IA/kWuYlPMeucydMfLYDZxYbFITKrBry8LjnI0Ben8TLB2/wkKqadBF+Q9RG+EUv7TuNkIYvkQSXecZhNuM8TyeYsyYHNu30fmwXxjxohqmfbAZDBKslt8vJj289dw0BjvsEquBpdB/W2rbY007kX0VYiRYG1I7wfOm6x14R+4ffPxNvc94pnw/xNUyZ1RuSDPDng16bfD5bpl3PCGyNZlKRApy9okx7R8LvJIHUPyrkuA2BEwLIV0F10xn5UHmi8sXIbHpxLVkaGa7ibOMTycL5lYw6Z2ExV0uFmDjIM4pni1DoxNZJxLGqUFGymuz9QAg38l0SbVvuw3oC/6/8ubaH/7anggAjDuJ4bOKqLqPrBl3Vecs7Bga2GCmaehx/HaDghjFylB5LfDNsabwDvWsPa4tgpS5tSTuYVqt8Hvyx0xYibAy0FpTzq4Ku0tTdUV/8k4PmOaUdYjEdxdm8x9NNkPwrYItkynggvBzqO6/eTndqzL6CnmYl4zwWSHQqwKuITs-->
+
+    <script src="_framework/blazor.server.js"></script>
+    <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'9f607f1e9a7a5864',t:'MTc3NzgyNDIxNA=='};var a=document.createElement('script');a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Configuration/SalesDbOptions.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Configuration/SalesDbOptions.cs
@@ -1,0 +1,16 @@
+namespace LKvitai.MES.Modules.Portal.Api.Configuration;
+
+/// <summary>
+/// Connection settings for the legacy SQL Server database (LKvitaiDb).
+/// Used by <c>SqlOperationsSummaryService</c> to run
+/// <c>dbo.mes_OperationsSummary</c> against the same database that
+/// Sales.Api uses. Configure via <c>ConnectionStrings:LKvitaiDb</c>
+/// (environment variable <c>ConnectionStrings__LKvitaiDb</c>).
+/// If the connection string is absent the Portal API starts normally
+/// but the operations summary endpoint returns null / empty data.
+/// </summary>
+public sealed class SalesDbOptions
+{
+    public string? ConnectionString { get; init; }
+    public int CommandTimeoutSeconds { get; init; } = 30;
+}

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Endpoints/PortalApiEndpoints.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Endpoints/PortalApiEndpoints.cs
@@ -27,6 +27,7 @@ public static class PortalApiEndpoints
         portal.MapGet("/status", BuildStatus).AllowAnonymous();
         portal.MapGet("/modules", GetModules).RequireAuthorization();
         portal.MapGet("/news", GetNews).RequireAuthorization();
+        portal.MapGet("/operations-summary", GetOperationsSummary).RequireAuthorization();
 
         var admin = portal.MapGroup("/admin")
             .RequireAuthorization(PortalPolicies.AdminOnly);
@@ -102,6 +103,19 @@ public static class PortalApiEndpoints
         CancellationToken cancellationToken)
     {
         return news.GetAsync(cancellationToken);
+    }
+
+    private static async Task<IResult> GetOperationsSummary(
+        [Microsoft.AspNetCore.Mvc.FromQuery] string? period,
+        SqlOperationsSummaryService summaryService,
+        CancellationToken cancellationToken)
+    {
+        var result = await summaryService.GetAsync(period ?? "this", cancellationToken)
+            .ConfigureAwait(false);
+
+        return result is null
+            ? Results.StatusCode(503)
+            : Results.Ok(result);
     }
 
     private static async Task<IReadOnlyList<PortalModuleResponse>> GetAdminTiles(

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/LKvitai.MES.Modules.Portal.Api.csproj
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/LKvitai.MES.Modules.Portal.Api.csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Models/PortalApiContracts.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Models/PortalApiContracts.cs
@@ -72,3 +72,40 @@ public sealed record PortalNewsItemResponse(
     string Excerpt,
     string Date,
     string? Url);
+
+// ---------------------------------------------------------------------------
+// Operations summary  (GET /api/portal/v1/operations-summary?period=this|last)
+// ---------------------------------------------------------------------------
+
+/// <summary>
+/// Full operations summary response for one calendar month.
+/// Returned by <c>GET /api/portal/v1/operations-summary?period=this|last</c>.
+/// </summary>
+public sealed record PortalOperationsSummaryResponse(
+    PortalPeriodInfo Period,
+    IReadOnlyList<PortalStageDto> Stages,
+    IReadOnlyList<PortalStatusCountDto> Statuses,
+    IReadOnlyList<PortalDayCountDto> CreatedByDay,
+    IReadOnlyList<PortalDayCountDto> CompletedByDay);
+
+/// <summary>Calendar period described by the summary.</summary>
+public sealed record PortalPeriodInfo(
+    string Key,
+    string From,
+    string To);
+
+/// <summary>One pipeline stage with its order count for the period.</summary>
+public sealed record PortalStageDto(
+    string Key,
+    string Label,
+    int Count);
+
+/// <summary>Raw localized status with its count — for debugging / drill-down.</summary>
+public sealed record PortalStatusCountDto(
+    string Status,
+    int Count);
+
+/// <summary>Per-day order count (ISO date string + integer).</summary>
+public sealed record PortalDayCountDto(
+    string Date,
+    int Count);

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Program.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
+using Microsoft.Data.SqlClient;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -47,6 +48,19 @@ builder.Services.AddDbContext<PortalDbContext>(options =>
 builder.Services
     .AddOptions<PortalDashboardOptions>()
     .Bind(builder.Configuration.GetSection(PortalDashboardOptions.SectionName));
+
+// LKvitaiDb (SQL Server) — optional; used by SqlOperationsSummaryService.
+// Portal.Api starts normally even when the connection string is absent:
+// the operations-summary endpoint returns a null/empty response instead
+// of failing with a startup exception.
+var salesConnStr = builder.Configuration.GetConnectionString("LKvitaiDb");
+builder.Services.AddSingleton(new SalesDbOptions
+{
+    ConnectionString = salesConnStr,
+    CommandTimeoutSeconds = builder.Configuration
+        .GetValue("Sales:Sql:CommandTimeoutSeconds", 30)
+});
+builder.Services.AddScoped<SqlOperationsSummaryService>();
 
 // Portal API speaks the shared PortalStructuredBearer scheme, same contract
 // Sales.Api / Warehouse.Api use. The Portal cookie path stays a Portal.WebUI

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
@@ -1,0 +1,149 @@
+using System.Data;
+using LKvitai.MES.Modules.Portal.Api.Configuration;
+using LKvitai.MES.Modules.Portal.Api.Models;
+using Microsoft.Data.SqlClient;
+
+namespace LKvitai.MES.Modules.Portal.Api.Services;
+
+/// <summary>
+/// Executes <c>dbo.mes_OperationsSummary</c> against the legacy SQL Server
+/// database (LKvitaiDb) and maps the five result sets into a
+/// <see cref="PortalOperationsSummaryResponse"/>.
+///
+/// Fails soft: if <see cref="SalesDbOptions.ConnectionString"/> is absent or
+/// the SP call throws, the method returns <c>null</c> so the Portal API can
+/// still render partial data instead of returning 500.
+/// </summary>
+public sealed class SqlOperationsSummaryService
+{
+    private const string SpName = "dbo.mes_OperationsSummary";
+
+    private readonly SalesDbOptions _options;
+    private readonly ILogger<SqlOperationsSummaryService> _logger;
+
+    public SqlOperationsSummaryService(
+        SalesDbOptions options,
+        ILogger<SqlOperationsSummaryService> logger)
+    {
+        _options = options;
+        _logger  = logger;
+    }
+
+    /// <summary>
+    /// Returns the operations summary for the requested period, or
+    /// <c>null</c> when the connection string is missing or the call fails.
+    /// </summary>
+    public async Task<PortalOperationsSummaryResponse?> GetAsync(
+        string period,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(_options.ConnectionString))
+        {
+            _logger.LogWarning(
+                "SqlOperationsSummaryService: ConnectionStrings:LKvitaiDb is not configured; " +
+                "returning null. Set the env var ConnectionStrings__LKvitaiDb to enable real data.");
+            return null;
+        }
+
+        // Normalise: only 'last' is a valid non-default value.
+        var normalised = string.Equals(period?.Trim(), "last", StringComparison.OrdinalIgnoreCase)
+            ? "last"
+            : "this";
+
+        try
+        {
+            await using var conn = new SqlConnection(_options.ConnectionString);
+            await conn.OpenAsync(cancellationToken).ConfigureAwait(false);
+
+            await using var cmd = new SqlCommand(SpName, conn)
+            {
+                CommandType    = CommandType.StoredProcedure,
+                CommandTimeout = _options.CommandTimeoutSeconds,
+            };
+            cmd.Parameters.Add(new SqlParameter("@Period", SqlDbType.NVarChar, 10)
+            {
+                Value = normalised
+            });
+
+            await using var reader = await cmd.ExecuteReaderAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            // ---------------------------------------------------------
+            // Result set 1 — Period metadata (1 row)
+            // ---------------------------------------------------------
+            PortalPeriodInfo? periodInfo = null;
+            if (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                periodInfo = new PortalPeriodInfo(
+                    Key:  reader.GetString(0),
+                    From: reader.GetString(1),
+                    To:   reader.GetString(2));
+            }
+
+            // ---------------------------------------------------------
+            // Result set 2 — Stage counts (8 rows)
+            // ---------------------------------------------------------
+            await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            var stages = new List<PortalStageDto>(8);
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                stages.Add(new PortalStageDto(
+                    Key:   reader.GetString(0),
+                    Label: reader.GetString(1),
+                    Count: reader.GetInt32(2)));
+            }
+
+            // ---------------------------------------------------------
+            // Result set 3 — Raw status counts
+            // ---------------------------------------------------------
+            await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            var statuses = new List<PortalStatusCountDto>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                statuses.Add(new PortalStatusCountDto(
+                    Status: reader.GetString(0),
+                    Count:  reader.GetInt32(1)));
+            }
+
+            // ---------------------------------------------------------
+            // Result set 4 — Created by day
+            // ---------------------------------------------------------
+            await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            var createdByDay = new List<PortalDayCountDto>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                createdByDay.Add(new PortalDayCountDto(
+                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
+                    Count: reader.GetInt32(1)));
+            }
+
+            // ---------------------------------------------------------
+            // Result set 5 — Completed by day
+            // ---------------------------------------------------------
+            await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            var completedByDay = new List<PortalDayCountDto>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                completedByDay.Add(new PortalDayCountDto(
+                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
+                    Count: reader.GetInt32(1)));
+            }
+
+            return new PortalOperationsSummaryResponse(
+                Period:         periodInfo ?? new PortalPeriodInfo(normalised, string.Empty, string.Empty),
+                Stages:         stages,
+                Statuses:       statuses,
+                CreatedByDay:   createdByDay,
+                CompletedByDay: completedByDay);
+        }
+        catch (Exception ex) when (ex is SqlException
+                                      or TaskCanceledException
+                                      or InvalidOperationException)
+        {
+            _logger.LogWarning(ex,
+                "SqlOperationsSummaryService: failed to fetch operations summary for period={Period}",
+                normalised);
+            return null;
+        }
+    }
+}

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Models/PortalDashboardData.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Models/PortalDashboardData.cs
@@ -49,6 +49,26 @@ public sealed record NewsItem(
     string Date);
 
 /// <summary>
+/// Operations summary loaded from GET /api/portal/v1/operations-summary.
+/// Mirrors the API wire shape as a WebUI-side view model so Home.razor
+/// does not reference Portal.Api types directly.
+/// </summary>
+public sealed record OperationsSummary(
+    OperationsPeriod Period,
+    IReadOnlyList<OperationsStageData> Stages,
+    IReadOnlyList<OperationsStatusCount> Statuses,
+    IReadOnlyList<OperationsDayCount> CreatedByDay,
+    IReadOnlyList<OperationsDayCount> CompletedByDay);
+
+public sealed record OperationsPeriod(string Key, string From, string To);
+
+public sealed record OperationsStageData(string Key, string Label, int Count);
+
+public sealed record OperationsStatusCount(string Status, int Count);
+
+public sealed record OperationsDayCount(string Date, int Count);
+
+/// <summary>
 /// Static seed data for the Portal dashboard sections that haven't been
 /// API-ified yet. After issue #93 (this PR) <c>Modules</c> and <c>News</c>
 /// come from the Portal API; the remaining fields are still hardcoded:

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
@@ -63,31 +63,39 @@
             <div class="operations__head">
                 <div>
                     <h2 id="operations-title" class="eyebrow mono">Operations preview</h2>
-                    <span class="operations__sample mono">Sample data</span>
+                    @if (_summaryLoading)
+                    {
+                        <span class="operations__sample mono">Loading…</span>
+                    }
+                    else if (_summary is null)
+                    {
+                        <span class="operations__sample mono">Sample data</span>
+                    }
                 </div>
                 <fieldset class="segmented" aria-label="Operations period">
                     <legend class="sr-only">Operations period</legend>
                     <button class="segmented__button @(_period == "this" ? "is-active" : null)"
                             type="button"
-                            @onclick='@(() => _period = "this")'>This month</button>
+                            @onclick='@(() => SetPeriod("this"))'>This month</button>
                     <button class="segmented__button @(_period == "last" ? "is-active" : null)"
                             type="button"
-                            @onclick='@(() => _period = "last")'>Last month</button>
+                            @onclick='@(() => SetPeriod("last"))'>Last month</button>
                 </fieldset>
             </div>
 
             <div class="stage-grid">
                 @{
-                    var stages = PortalDashboardData.Stages;
+                    var stages = _summary is not null
+                        ? _summary.Stages.Select(s => (Label: s.Label, Count: s.Count)).ToList()
+                        : PortalDashboardData.Stages.Select(s => (Label: s.Label, Count: _period == "this" ? s.ThisMonth : s.LastMonth)).ToList();
                 }
                 @for (var index = 0; index < stages.Count; index++)
                 {
                     var stage = stages[index];
                     var isFinal = index == stages.Count - 1;
-                    var value = _period == "this" ? stage.ThisMonth : stage.LastMonth;
                     <div class="stage @(isFinal ? "is-final" : null)">
                         <span>@stage.Label</span>
-                        <strong class="mono">@value</strong>
+                        <strong class="mono">@stage.Count</strong>
                     </div>
                 }
             </div>
@@ -96,7 +104,15 @@
                 <div class="daily-card__label mono">Completed / day <span>30d</span></div>
                 <div class="daily-card__bars" aria-hidden="true">
                     @{
-                        var values = PortalDashboardData.Daily[_period];
+                        IReadOnlyList<int> values;
+                        if (_summary is not null && _summary.CompletedByDay.Count > 0)
+                        {
+                            values = _summary.CompletedByDay.Select(d => d.Count).ToList();
+                        }
+                        else
+                        {
+                            values = PortalDashboardData.Daily[_period];
+                        }
                         var max = values.Max();
                     }
                     @for (var index = 0; index < values.Count; index++)
@@ -108,8 +124,12 @@
                     }
                 </div>
                 <div class="daily-card__total">
-                    <strong class="mono">@PortalDashboardData.DailyTotal[_period]</strong>
-                    <span>+5.6%</span>
+                    @{
+                        var dailyTotal = _summary is not null
+                            ? _summary.CompletedByDay.Sum(d => d.Count)
+                            : PortalDashboardData.DailyTotal[_period];
+                    }
+                    <strong class="mono">@dailyTotal</strong>
                 </div>
             </div>
 
@@ -295,6 +315,9 @@
     private IReadOnlyList<NewsItem> _news = Array.Empty<NewsItem>();
     private List<RecentShortcut> _recentShortcuts = new();
 
+    private OperationsSummary? _summary;
+    private bool _summaryLoading = true;
+
     private int _liveCount;
     private int _pilotCount;
     private int _developingCount;
@@ -310,6 +333,7 @@
         var modulesTask = PortalApi.GetModulesAsync();
         var newsTask    = PortalApi.GetNewsAsync();
         var statusTask  = PortalApi.GetStatusAsync();
+        var summaryTask = PortalApi.GetOperationsSummaryAsync(_period);
 
         _modules = await modulesTask;
         _news    = await newsTask;
@@ -320,6 +344,9 @@
             if (!string.IsNullOrWhiteSpace(status.GitSha))  _displayGitSha  = ShortSha(status.GitSha);
             _displayBuildDate = status.BuildDate;
         }
+
+        _summary        = await summaryTask;
+        _summaryLoading = false;
 
         _liveCount       = _modules.Count(m => m.Status == ModuleStatus.Live);
         _pilotCount      = _modules.Count(m => m.Status == ModuleStatus.Pilot);
@@ -461,4 +488,17 @@
         fullSha.Length <= 7 ? fullSha : fullSha[..7];
 
     private sealed record RecentShortcut(string Key, string Title, string Url, bool IsPrimary);
+
+    private async Task SetPeriod(string period)
+    {
+        if (_period == period) return;
+        _period         = period;
+        _summaryLoading = true;
+        _summary        = null;
+        StateHasChanged();
+
+        _summary        = await PortalApi.GetOperationsSummaryAsync(period);
+        _summaryLoading = false;
+        StateHasChanged();
+    }
 }

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Services/PortalApiClient.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Services/PortalApiClient.cs
@@ -218,6 +218,53 @@ public sealed class PortalApiClient
         return response.IsSuccessStatusCode;
     }
 
+    /// <summary>
+    /// Returns the operations summary for the requested period ('this' or 'last'),
+    /// or <c>null</c> when the Portal API is unreachable, the connection to
+    /// SQL Server is not configured server-side, or any other transient failure.
+    /// Callers should fall back to mock/empty data on null.
+    /// </summary>
+    public async Task<OperationsSummary?> GetOperationsSummaryAsync(
+        string period,
+        CancellationToken cancellationToken = default)
+    {
+        var client = _httpClientFactory.CreateClient(ClientName);
+        try
+        {
+            var dto = await client
+                .GetFromJsonAsync<PortalOperationsSummaryDto>(
+                    $"api/portal/v1/operations-summary?period={Uri.EscapeDataString(period)}",
+                    cancellationToken)
+                .ConfigureAwait(false);
+
+            if (dto is null) return null;
+
+            return new OperationsSummary(
+                Period: new OperationsPeriod(dto.Period.Key, dto.Period.From, dto.Period.To),
+                Stages: dto.Stages
+                    .Select(s => new OperationsStageData(s.Key, s.Label, s.Count))
+                    .ToList(),
+                Statuses: dto.Statuses
+                    .Select(s => new OperationsStatusCount(s.Status, s.Count))
+                    .ToList(),
+                CreatedByDay: dto.CreatedByDay
+                    .Select(d => new OperationsDayCount(d.Date, d.Count))
+                    .ToList(),
+                CompletedByDay: dto.CompletedByDay
+                    .Select(d => new OperationsDayCount(d.Date, d.Count))
+                    .ToList());
+        }
+        catch (Exception ex) when (ex is HttpRequestException
+                                      or TaskCanceledException
+                                      or System.Text.Json.JsonException)
+        {
+            _logger.LogWarning(ex,
+                "Portal API GET /operations-summary failed for period={Period}; using fallback data",
+                period);
+            return null;
+        }
+    }
+
     private static ModuleStatus ParseStatus(string raw) =>
         raw switch
         {
@@ -275,6 +322,18 @@ public sealed class PortalApiClient
         string Excerpt,
         string Date,
         string? Url);
+
+    private sealed record PortalOperationsSummaryDto(
+        PortalPeriodDto Period,
+        IReadOnlyList<PortalStageDtoItem> Stages,
+        IReadOnlyList<PortalStatusCountDtoItem> Statuses,
+        IReadOnlyList<PortalDayCountDtoItem> CreatedByDay,
+        IReadOnlyList<PortalDayCountDtoItem> CompletedByDay);
+
+    private sealed record PortalPeriodDto(string Key, string From, string To);
+    private sealed record PortalStageDtoItem(string Key, string Label, int Count);
+    private sealed record PortalStatusCountDtoItem(string Status, int Count);
+    private sealed record PortalDayCountDtoItem(string Date, int Count);
 }
 
 /// <summary>


### PR DESCRIPTION
## Summary

- Add `dbo.mes_OperationsSummary` stored procedure (SQL Server 2014) that returns 5 result sets: period metadata, 8 stage counts, raw status counts, created-by-day and completed-by-day
- Add `GET /api/portal/v1/operations-summary?period=this|last` in Portal.Api backed by a direct MSSQL read via `SqlOperationsSummaryService` (fails soft when connection string absent)
- Wire Portal home dashboard stage grid and daily-bars sparkline to real API data; falls back to `PortalDashboardData` mock when API unavailable; period toggle reloads live

## Key business rules encoded in SP

- Excludes test branch (FilialoID != 7)
- Excludes customer-cancelled orders: Sugadintas=1 AND sNotes='Kliento prasymu anuliuotas'
- completedByDay uses ISNULL(dtFinishingOrderDate, dtDateInsert) as completion date

## Test plan

- [ ] Deploy portal-api with ConnectionStrings__LKvitaiDb set — /api/portal/v1/operations-summary?period=this returns real stage counts
- [ ] Without connection string — endpoint returns 503, home dashboard renders mock data
- [ ] Period toggle This month / Last month reloads data without full page refresh
- [ ] SKIRTINGAI orders appear in the mixed stage, not intake
