### PR TITLE
fix(portal): operations summary crashing on Day column type cast

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
@@ -113,7 +113,7 @@ public sealed class SqlOperationsSummaryService
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 createdByDay.Add(new PortalDayCountDto(
-                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
+                    Date:  reader.GetString(0),
                     Count: reader.GetInt32(1)));
             }
 
@@ -125,7 +125,7 @@ public sealed class SqlOperationsSummaryService
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 completedByDay.Add(new PortalDayCountDto(
-                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
+                    Date:  reader.GetString(0),
                     Count: reader.GetInt32(1)));
             }
 
@@ -138,7 +138,8 @@ public sealed class SqlOperationsSummaryService
         }
         catch (Exception ex) when (ex is SqlException
                                       or TaskCanceledException
-                                      or InvalidOperationException)
+                                      or InvalidOperationException
+                                      or InvalidCastException)
         {
             _logger.LogWarning(ex,
                 "SqlOperationsSummaryService: failed to fetch operations summary for period={Period}",


### PR DESCRIPTION
﻿Root cause

Day column in SP is CONVERT(VARCHAR(10),...) - a string. GetValue(0) returns string, cast (DateTime) throws InvalidCastException. Not in catch filter, bubbles as 500. WebUI gets HttpRequestException, returns null, shows Sample data.

Fix: use GetString(0) directly. Added InvalidCastException to catch filter.
