### PR TITLE
fix(portal): OpenSSL TLS 1.0 patch for legacy SQL Server in Portal.Api Dockerfile

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Dockerfile
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Dockerfile
@@ -30,6 +30,18 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
 
+# Legacy LKvitaiDb (SQL Server 2008/2012) compatibility:
+# the .NET 8 base image (Debian 12) ships OpenSSL 3 with SECLEVEL=2 and
+# MinProtocol=TLSv1.2. The legacy SQL Server only offers TLS 1.0 with
+# SHA1-signed self-signed certs during the TDS pre-login handshake (which
+# is mandatory regardless of Encrypt=False), so the connection dies with
+# "SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed" before
+# any SQL is sent. Lower SECLEVEL and MinProtocol so the handshake can
+# complete; the actual data exchange is still unencrypted because the
+# connection string sets Encrypt=False;TrustServerCertificate=True.
+RUN sed -i 's|^\[openssl_init\]|[openssl_init]\nssl_conf = ssl_sect|' /etc/ssl/openssl.cnf \
+    && printf '\n[ssl_sect]\nsystem_default = system_default_sect\n\n[system_default_sect]\nMinProtocol = TLSv1\nCipherString = DEFAULT:@SECLEVEL=0\n' >> /etc/ssl/openssl.cnf
+
 # Use the base image's built-in non-root `app` user (uid 1654, gid 1654).
 # Standard .NET 8 convention. Published binaries deliberately stay
 # root-owned (read+exec for `app`, no write) — Sonar docker:S6504. Any

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
@@ -113,7 +113,7 @@ public sealed class SqlOperationsSummaryService
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 createdByDay.Add(new PortalDayCountDto(
-                    Date:  reader.GetString(0),
+                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
                     Count: reader.GetInt32(1)));
             }
 
@@ -125,7 +125,7 @@ public sealed class SqlOperationsSummaryService
             while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
             {
                 completedByDay.Add(new PortalDayCountDto(
-                    Date:  reader.GetString(0),
+                    Date:  ((DateTime)reader.GetValue(0)).ToString("yyyy-MM-dd"),
                     Count: reader.GetInt32(1)));
             }
 


### PR DESCRIPTION
﻿## Root cause

The Portal.Api Dockerfile was missing the OpenSSL TLS 1.0 compatibility patch that the Sales.Api Dockerfile already has.

The legacy SQL Server (2008/2012) only supports TLS 1.0 with SHA1-signed self-signed certs during the TDS pre-login handshake. The .NET 8 Docker base image (Debian 12 / Bookworm) ships OpenSSL 3 with SECLEVEL=2 and MinProtocol=TLSv1.2. The SQL Server connection failed immediately with 'SSL Provider, error: 31 - Encryption(ssl/tls) handshake failed' before any SQL was sent.

This SqlException was caught by SqlOperationsSummaryService.GetAsync, which returned null. The endpoint returned 503. The Portal.WebUI caught the HttpRequestException and fell back to mock/sample data. Sales.Api works because its Dockerfile has the OpenSSL patch.

## Changes

1. Portal.Api/Dockerfile: added the same OpenSSL MinProtocol=TLSv1 + SECLEVEL=0 patch used in Sales.Api Dockerfile (identical fix, same comment).
2. SqlOperationsSummaryService.cs: reverted the wrong GetString(0) from PR #128 back to (DateTime)reader.GetValue(0).ToString("yyyy-MM-dd"). The Day column is SQL DATE which returns System.DateTime via GetValue(), not string. GetString() on a DATE column throws InvalidCastException.
