### PR TITLE
feat(portal): show full month bar chart, fix weekend highlighting

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
@@ -129,12 +129,14 @@ public sealed class SqlOperationsSummaryService
                     Count: reader.GetInt32(1)));
             }
 
+            var resolvedPeriod = periodInfo ?? new PortalPeriodInfo(normalised, string.Empty, string.Empty);
+
             return new PortalOperationsSummaryResponse(
-                Period:         periodInfo ?? new PortalPeriodInfo(normalised, string.Empty, string.Empty),
+                Period:         resolvedPeriod,
                 Stages:         stages,
                 Statuses:       statuses,
-                CreatedByDay:   createdByDay,
-                CompletedByDay: completedByDay);
+                CreatedByDay:   PadToFullPeriod(createdByDay,   resolvedPeriod.From, resolvedPeriod.To),
+                CompletedByDay: PadToFullPeriod(completedByDay, resolvedPeriod.From, resolvedPeriod.To));
         }
         catch (Exception ex) when (ex is SqlException
                                       or TaskCanceledException
@@ -146,5 +148,36 @@ public sealed class SqlOperationsSummaryService
                 normalised);
             return null;
         }
+    }
+
+    /// <summary>
+    /// Expands a sparse list of day-count entries into a dense list that
+    /// contains one entry for every calendar day in [from, to], filling
+    /// missing days with a zero count.  This ensures the UI bar chart
+    /// always renders the full month width regardless of data density.
+    /// </summary>
+    private static IReadOnlyList<PortalDayCountDto> PadToFullPeriod(
+        IReadOnlyList<PortalDayCountDto> data,
+        string fromStr,
+        string toStr)
+    {
+        if (!DateTime.TryParse(fromStr, out var from) ||
+            !DateTime.TryParse(toStr,   out var to)   || from > to)
+        {
+            return data;
+        }
+
+        var lookup = data.ToDictionary(d => d.Date, StringComparer.Ordinal);
+        var result = new List<PortalDayCountDto>((int)(to - from).TotalDays + 1);
+
+        for (var day = from; day <= to; day = day.AddDays(1))
+        {
+            var key = day.ToString("yyyy-MM-dd");
+            result.Add(lookup.TryGetValue(key, out var dto)
+                ? dto
+                : new PortalDayCountDto(key, 0));
+        }
+
+        return result;
     }
 }

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
@@ -101,25 +101,32 @@
             </div>
 
             <div class="daily-card">
-                <div class="daily-card__label mono">Completed / day <span>30d</span></div>
+                <div class="daily-card__label mono">Completed / day <span>@(_period == "last" ? "last mo." : "this mo.")</span></div>
                 <div class="daily-card__bars" aria-hidden="true">
                     @{
-                        IReadOnlyList<int> values;
+                        IReadOnlyList<(int Count, bool IsWeekend)> bars;
                         if (_summary is not null && _summary.CompletedByDay.Count > 0)
                         {
-                            values = _summary.CompletedByDay.Select(d => d.Count).ToList();
+                            bars = _summary.CompletedByDay
+                                .Select(d => (
+                                    d.Count,
+                                    IsWeekend: DateTime.TryParse(d.Date, out var dt) &&
+                                               (dt.DayOfWeek is DayOfWeek.Saturday or DayOfWeek.Sunday)))
+                                .ToList();
                         }
                         else
                         {
-                            values = PortalDashboardData.Daily[_period];
+                            bars = PortalDashboardData.Daily[_period]
+                                .Select((count, i) => (Count: count, IsWeekend: i % 7 is 5 or 6))
+                                .ToList();
                         }
-                        var max = values.Max();
+                        var maxVal = bars.Count > 0 ? bars.Max(b => b.Count) : 1;
+                        if (maxVal == 0) maxVal = 1;
                     }
-                    @for (var index = 0; index < values.Count; index++)
+                    @for (var index = 0; index < bars.Count; index++)
                     {
-                        var raw = values[index];
-                        var height = Math.Max(4, (int)Math.Round(raw / (double)max * 26d));
-                        var weekend = index % 7 is 5 or 6;
+                        var (raw, weekend) = bars[index];
+                        var height = Math.Max(4, (int)Math.Round(raw / (double)maxVal * 26d));
                         <i class="@(weekend ? "is-weekend" : null)" style="--bar-height: @(height)px"></i>
                     }
                 </div>


### PR DESCRIPTION
﻿The SP only returns rows for days that have orders. Days 1-3 had no completions so only 1 bar showed.

Fix 1 - SqlOperationsSummaryService: added PadToFullPeriod() helper. After reading createdByDay and completedByDay from the SP, expands both lists to cover every calendar day in the period (from..to inclusive), filling missing days with count=0. Now May always renders 31 bars.

Fix 2 - Home.razor: replaced index%7 weekend detection with actual DayOfWeek parsed from the date string. Previously bars 6 and 7 of the array were marked weekend regardless of what day of month the period started on. Now Saturdays and Sundays are correctly greyed.

Fix 3 - Home.razor: updated the daily-card label from hardcoded 30d to this mo./last mo.
