### PR TITLE
feat(portal): branches on track real metric — issued vs ready by branch

### DIFF
--- a/docs/sql/mes-operations-summary.sql
+++ b/docs/sql/mes-operations-summary.sql
@@ -10,12 +10,13 @@
 --   @Period  NVARCHAR(10)  'this' = current month (default)
 --                          'last' = previous calendar month
 --
--- Result sets (always 5, always in this order)
+-- Result sets (always 6, always in this order)
 --   1. Period      (1 row)   PeriodKey, PeriodFrom, PeriodTo
 --   2. Stages      (8 rows)  StageKey, StageLabel, StageCount
 --   3. Statuses    (n rows)  StatusName, StatusCount
 --   4. CreatedByDay          Day (DATE), DayCount
 --   5. CompletedByDay        Day (DATE), DayCount
+--   6. BranchesOnTrack       BranchName, ReadyBasis, ReadyCount, IssuedCount, OnTrackPercent (INT NULL)
 --
 -- Business rules
 --   * Exclude test branch: FilialoID <> 7
@@ -24,6 +25,10 @@
 --       AND LTRIM(RTRIM(ISNULL(sNotes,''))) = 'Kliento prasymu anuliuotas'
 --   * Period scope : dtDateInsert in [@From, @To)  (@To = first day of next month)
 --   * completedByDay date: ISNULL(dtFinishingOrderDate, dtDateInsert)
+--   * branchesOnTrack readiness:
+--       Klaipeda (FilialoID=1): ready = Pagamintas (StateID=1173102374) + Isduotas klientui (StateID=2)
+--       All other branches:     ready = Issistas i filiala (StateID=1173102376) + Isduotas klientui (StateID=2)
+--       onTrackPercent = IssuedCount * 100 / ReadyCount  (NULL when ReadyCount = 0)
 -- ============================================================
 
 IF OBJECT_ID(N'dbo.mes_OperationsSummary', N'P') IS NOT NULL
@@ -155,6 +160,55 @@ BEGIN
         )
     GROUP BY CAST(ISNULL(u.dtFinishingOrderDate, u.dtDateInsert) AS DATE)
     ORDER BY [Day];
+
+    -- -------------------------------------------------------
+    -- Result set 6 — Branches on track
+    --   For Klaipeda (FilialoID=1):
+    --     ready = Pagamintas (StateID=1173102374) + Isduotas klientui (StateID=2)
+    --   For all other branches:
+    --     ready = Issistas i filiala (StateID=1173102376) + Isduotas klientui (StateID=2)
+    --   onTrackPercent = IssuedCount * 100 / ReadyCount  (NULL when ReadyCount=0)
+    -- -------------------------------------------------------
+    ;WITH BranchOrders AS (
+        SELECT us.FilialoID, u.StateID
+        FROM dbo.Uzsakymai u
+        INNER JOIN dbo.Zinynas_UzsakymoSerijos us ON us.UzsakymoSerijaID = u.UzsakymoSerija
+        WHERE
+            us.FilialoID <> 7
+            AND CAST(u.dtDateInsert AS DATE) >= @From
+            AND CAST(u.dtDateInsert AS DATE) <  @To
+            AND (
+                u.Sugadintas = 0
+                OR LTRIM(RTRIM(ISNULL(u.sNotes, N''))) <> N'Kliento prasymu anuliuotas'
+            )
+    ),
+    BranchAgg AS (
+        SELECT
+            o.FilialoID,
+            SUM(CASE
+                WHEN o.FilialoID = 1
+                    THEN CASE WHEN o.StateID IN (1173102374, 2) THEN 1 ELSE 0 END
+                ELSE
+                    CASE WHEN o.StateID IN (1173102376, 2) THEN 1 ELSE 0 END
+            END) AS ReadyCount,
+            SUM(CASE WHEN o.StateID = 2 THEN 1 ELSE 0 END) AS IssuedCount,
+            COUNT(*) AS TotalCount
+        FROM BranchOrders o
+        GROUP BY o.FilialoID
+    )
+    SELECT
+        f.FilialoPavadinimas                                                        AS BranchName,
+        CASE WHEN f.FilialoID = 1 THEN N'Pagamintas' ELSE N'Išsiųstas į filialą' END AS ReadyBasis,
+        a.ReadyCount,
+        a.IssuedCount,
+        CASE WHEN a.ReadyCount > 0
+             THEN CAST(ROUND(a.IssuedCount * 100.0 / a.ReadyCount, 0) AS INT)
+             ELSE NULL
+        END AS OnTrackPercent
+    FROM BranchAgg a
+    INNER JOIN dbo.Zinynas_filialai f ON f.FilialoID = a.FilialoID
+    WHERE a.TotalCount > 0
+    ORDER BY f.FilialoPavadinimas;
 
 END;
 GO

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Models/PortalApiContracts.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Models/PortalApiContracts.cs
@@ -86,7 +86,8 @@ public sealed record PortalOperationsSummaryResponse(
     IReadOnlyList<PortalStageDto> Stages,
     IReadOnlyList<PortalStatusCountDto> Statuses,
     IReadOnlyList<PortalDayCountDto> CreatedByDay,
-    IReadOnlyList<PortalDayCountDto> CompletedByDay);
+    IReadOnlyList<PortalDayCountDto> CompletedByDay,
+    IReadOnlyList<PortalBranchOnTrackDto> BranchesOnTrack);
 
 /// <summary>Calendar period described by the summary.</summary>
 public sealed record PortalPeriodInfo(
@@ -109,3 +110,22 @@ public sealed record PortalStatusCountDto(
 public sealed record PortalDayCountDto(
     string Date,
     int Count);
+
+/// <summary>
+/// Per-branch readiness metric for one calendar month period.
+/// <para>
+/// <see cref="ReadyBasis"/> is the localized Lithuanian status name used
+/// as the readiness threshold: <c>Išsiųstas į filialą</c> for normal branches
+/// and <c>Pagamintas</c> for Klaipėda.
+/// </para>
+/// <para>
+/// <see cref="OnTrackPercent"/> is <c>null</c> when <see cref="Ready"/> is zero
+/// (no orders have reached the readiness threshold yet in the period).
+/// </para>
+/// </summary>
+public sealed record PortalBranchOnTrackDto(
+    string Branch,
+    string ReadyBasis,
+    int Ready,
+    int Issued,
+    int? OnTrackPercent);

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.Api/Services/SqlOperationsSummaryService.cs
@@ -7,7 +7,7 @@ namespace LKvitai.MES.Modules.Portal.Api.Services;
 
 /// <summary>
 /// Executes <c>dbo.mes_OperationsSummary</c> against the legacy SQL Server
-/// database (LKvitaiDb) and maps the five result sets into a
+/// database (LKvitaiDb) and maps the six result sets into a
 /// <see cref="PortalOperationsSummaryResponse"/>.
 ///
 /// Fails soft: if <see cref="SalesDbOptions.ConnectionString"/> is absent or
@@ -129,14 +129,30 @@ public sealed class SqlOperationsSummaryService
                     Count: reader.GetInt32(1)));
             }
 
+            // ---------------------------------------------------------
+            // Result set 6 — Branches on track
+            // ---------------------------------------------------------
+            await reader.NextResultAsync(cancellationToken).ConfigureAwait(false);
+            var branchesOnTrack = new List<PortalBranchOnTrackDto>();
+            while (await reader.ReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                branchesOnTrack.Add(new PortalBranchOnTrackDto(
+                    Branch:         reader.GetString(0),
+                    ReadyBasis:     reader.GetString(1),
+                    Ready:          reader.GetInt32(2),
+                    Issued:         reader.GetInt32(3),
+                    OnTrackPercent: reader.IsDBNull(4) ? null : reader.GetInt32(4)));
+            }
+
             var resolvedPeriod = periodInfo ?? new PortalPeriodInfo(normalised, string.Empty, string.Empty);
 
             return new PortalOperationsSummaryResponse(
-                Period:         resolvedPeriod,
-                Stages:         stages,
-                Statuses:       statuses,
-                CreatedByDay:   PadToFullPeriod(createdByDay,   resolvedPeriod.From, resolvedPeriod.To),
-                CompletedByDay: PadToFullPeriod(completedByDay, resolvedPeriod.From, resolvedPeriod.To));
+                Period:          resolvedPeriod,
+                Stages:          stages,
+                Statuses:        statuses,
+                CreatedByDay:    PadToFullPeriod(createdByDay,   resolvedPeriod.From, resolvedPeriod.To),
+                CompletedByDay:  PadToFullPeriod(completedByDay, resolvedPeriod.From, resolvedPeriod.To),
+                BranchesOnTrack: branchesOnTrack);
         }
         catch (Exception ex) when (ex is SqlException
                                       or TaskCanceledException

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Models/PortalDashboardData.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Models/PortalDashboardData.cs
@@ -38,7 +38,12 @@ public sealed record OperationsStage(
     int ThisMonth,
     int LastMonth);
 
-public sealed record BranchOnTrack(string Name, int PercentOnTrack);
+public sealed record BranchOnTrack(
+    string Name,
+    string ReadyBasis,
+    int Ready,
+    int Issued,
+    int? OnTrackPercent);
 
 public sealed record NewsItem(
     string Tag,
@@ -58,7 +63,8 @@ public sealed record OperationsSummary(
     IReadOnlyList<OperationsStageData> Stages,
     IReadOnlyList<OperationsStatusCount> Statuses,
     IReadOnlyList<OperationsDayCount> CreatedByDay,
-    IReadOnlyList<OperationsDayCount> CompletedByDay);
+    IReadOnlyList<OperationsDayCount> CompletedByDay,
+    IReadOnlyList<BranchOnTrack> BranchesOnTrack);
 
 public sealed record OperationsPeriod(string Key, string From, string To);
 
@@ -108,9 +114,9 @@ public static class PortalDashboardData
 
     public static IReadOnlyList<BranchOnTrack> Branches { get; } = new[]
     {
-        new BranchOnTrack("Vilnius",  94),
-        new BranchOnTrack("Kaunas",   89),
-        new BranchOnTrack("Klaipeda", 91),
-        new BranchOnTrack("Siauliai", 84),
+        new BranchOnTrack("Vilnius",  "Išsiųstas į filialą", 50, 47, 94),
+        new BranchOnTrack("Kaunas",   "Išsiųstas į filialą", 55, 49, 89),
+        new BranchOnTrack("Klaipeda", "Pagamintas",           42, 38, 91),
+        new BranchOnTrack("Siauliai", "Išsiųstas į filialą", 44, 37, 84),
     };
 }

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
@@ -143,11 +143,27 @@
             <div>
                 <div class="operations__label mono">Branches on track</div>
                 <div class="branch-grid">
-                    @foreach (var branch in PortalDashboardData.Branches)
+                    @{
+                        var branches = _summary?.BranchesOnTrack is { Count: > 0 } realBranches
+                            ? realBranches
+                            : (IReadOnlyList<BranchOnTrack>)PortalDashboardData.Branches;
+                    }
+                    @foreach (var branch in branches)
                     {
-                        <div class="branch @(branch.PercentOnTrack < 90 ? "is-warning" : null)">
+                        var pct = branch.OnTrackPercent;
+                        <div class="branch @(pct.HasValue && pct < 90 ? "is-warning" : null)">
                             <span>@branch.Name</span>
-                            <strong class="mono">@branch.PercentOnTrack%</strong>
+                            @if (pct.HasValue)
+                            {
+                                <div class="branch__metric">
+                                    <strong class="mono">@pct%</strong>
+                                    <small class="mono">@branch.Issued&nbsp;/&nbsp;@branch.Ready</small>
+                                </div>
+                            }
+                            else
+                            {
+                                <strong class="mono">–</strong>
+                            }
                         </div>
                     }
                 </div>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Services/PortalApiClient.cs
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Services/PortalApiClient.cs
@@ -252,6 +252,9 @@ public sealed class PortalApiClient
                     .ToList(),
                 CompletedByDay: dto.CompletedByDay
                     .Select(d => new OperationsDayCount(d.Date, d.Count))
+                    .ToList(),
+                BranchesOnTrack: dto.BranchesOnTrack
+                    .Select(b => new BranchOnTrack(b.Branch, b.ReadyBasis, b.Ready, b.Issued, b.OnTrackPercent))
                     .ToList());
         }
         catch (Exception ex) when (ex is HttpRequestException
@@ -328,12 +331,19 @@ public sealed class PortalApiClient
         IReadOnlyList<PortalStageDtoItem> Stages,
         IReadOnlyList<PortalStatusCountDtoItem> Statuses,
         IReadOnlyList<PortalDayCountDtoItem> CreatedByDay,
-        IReadOnlyList<PortalDayCountDtoItem> CompletedByDay);
+        IReadOnlyList<PortalDayCountDtoItem> CompletedByDay,
+        IReadOnlyList<PortalBranchOnTrackDtoItem> BranchesOnTrack);
 
     private sealed record PortalPeriodDto(string Key, string From, string To);
     private sealed record PortalStageDtoItem(string Key, string Label, int Count);
     private sealed record PortalStatusCountDtoItem(string Status, int Count);
     private sealed record PortalDayCountDtoItem(string Date, int Count);
+    private sealed record PortalBranchOnTrackDtoItem(
+        string Branch,
+        string ReadyBasis,
+        int Ready,
+        int Issued,
+        int? OnTrackPercent);
 }
 
 /// <summary>

--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/wwwroot/styles.css
@@ -525,6 +525,20 @@ input {
   color: var(--warning);
 }
 
+.branch__metric {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0;
+}
+
+.branch__metric small {
+  font-size: 9px;
+  color: var(--n-500);
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
 /* ── Modules + Side panel grid ──────────────────────────────────── */
 
 .content-grid {


### PR DESCRIPTION
﻿Adds real branch on-track metric to the Portal operations summary dashboard panel.

SQL SP: added result set 6 (BranchesOnTrack) to dbo.mes_OperationsSummary. For Klaipeda (FilialoID=1) readiness is Pagamintas + Isduotas klientui; for all other branches readiness is Issistas i filiala + Isduotas klientui. onTrackPercent = IssuedCount * 100 / ReadyCount, NULL when ReadyCount=0.

API: PortalBranchOnTrackDto added to PortalApiContracts. SqlOperationsSummaryService reads the 6th result set. PortalOperationsSummaryResponse includes BranchesOnTrack.

WebUI: BranchOnTrack record extended with ReadyBasis/Ready/Issued/OnTrackPercent. Home.razor renders pct% + issued/ready subtitle; warning style when pct < 90; dash when no threshold orders yet. Falls back to mock data when API returns empty.

CSS: branch__metric flex column for the two-line percent + count display.
