### PR TITLE
feat(portal): branches on track real metric + lkvitai.lauresta.com alias

### DIFF
--- a/deploy/traefik/README.md
+++ b/deploy/traefik/README.md
@@ -21,14 +21,17 @@ api.mes.lauresta.com/portal      -> http://10.11.12.9:5011
 api.mes.lauresta.com/warehouse   -> http://10.11.12.9:5001
 ```
 
-Test VM `lkvitai-test`:
+Test VM `lkvitai-test` (both hostnames via `HostRegexp`):
 
 ```text
-mes-test.lauresta.com/                 -> redirects to /portal/
-mes-test.lauresta.com/portal          -> http://10.11.12.15:5010
-mes-test.lauresta.com/warehouse       -> http://10.11.12.15:5000
-mes-test.lauresta.com/api/portal      -> http://10.11.12.15:5011
-mes-test.lauresta.com/api/warehouse   -> http://10.11.12.15:5001
+mes-test.lauresta.com  \
+lkvitai.lauresta.com    /  -> same backends, cert resolved per SNI by Let's Encrypt
+
+/                      -> redirects to /portal/
+/portal                -> http://10.11.12.15:5010
+/warehouse             -> http://10.11.12.15:5000
+/api/portal            -> http://10.11.12.15:5011
+/api/warehouse         -> http://10.11.12.15:5001
 ```
 
 Production API routers strip the module prefix before forwarding. For example,

--- a/deploy/traefik/dynamic/mes-test.yml
+++ b/deploy/traefik/dynamic/mes-test.yml
@@ -1,14 +1,14 @@
-# Test environment — routers, middlewares, services for *.mes-test.lauresta.com
+# Test environment — routers, middlewares, services for mes-test.lauresta.com
+# and its alias lkvitai.lauresta.com (Cloudflare CNAME → mes-test.lauresta.com).
 #
-# Path-based routing under the single mes-test.lauresta.com host. API prefixes
-# are stripped before forwarding so each module's ASP.NET Core host only sees
-# its own routes (e.g. the Warehouse API sees /api/auth/login, the Sales API
-# sees /api/sales/ping). Scaffolded modules (Sales/Frontline/Scanning) mirror
-# the Warehouse/Portal routing pattern exactly.
+# All routers use HostRegexp so both hostnames are covered without duplication.
+# Traefik resolves Let's Encrypt certificates per SNI on first request.
+# Scaffolded modules (Sales/Frontline/Scanning) mirror the Warehouse/Portal
+# routing pattern exactly.
 http:
   routers:
     mes-test-portal-root:
-      rule: "Host(`mes-test.lauresta.com`) && Path(`/`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && Path(`/`)"
       entryPoints: [websecure]
       middlewares: [mes-test-redirect-root-to-portal]
       service: mes-test-portal-webui
@@ -17,7 +17,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-portal:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/portal`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/portal`)"
       entryPoints: [websecure]
       service: mes-test-portal-webui
       priority: 100
@@ -25,7 +25,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-warehouse:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/warehouse`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/warehouse`)"
       entryPoints: [websecure]
       service: mes-test-warehouse-webui
       priority: 100
@@ -33,7 +33,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-sales:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/sales`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/sales`)"
       entryPoints: [websecure]
       service: mes-test-sales-webui
       priority: 100
@@ -41,7 +41,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-frontline:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/frontline`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/frontline`)"
       entryPoints: [websecure]
       service: mes-test-frontline-webui
       priority: 100
@@ -49,7 +49,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-scan:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/scan`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/scan`)"
       entryPoints: [websecure]
       service: mes-test-scanning-webui
       priority: 100
@@ -57,7 +57,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-portal:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/portal`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/portal`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-portal]
       service: mes-test-portal-api
@@ -66,7 +66,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-warehouse:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/warehouse`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/warehouse`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-warehouse]
       service: mes-test-warehouse-api
@@ -75,7 +75,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-sales:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/sales`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/sales`)"
       entryPoints: [websecure]
       service: mes-test-sales-api
       priority: 200
@@ -83,7 +83,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-frontline:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/frontline`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/frontline`)"
       entryPoints: [websecure]
       service: mes-test-frontline-api
       priority: 200
@@ -91,7 +91,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-scan:
-      rule: "Host(`mes-test.lauresta.com`) && PathPrefix(`/api/scan`)"
+      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/scan`)"
       entryPoints: [websecure]
       service: mes-test-scanning-api
       priority: 200
@@ -101,8 +101,8 @@ http:
   middlewares:
     mes-test-redirect-root-to-portal:
       redirectRegex:
-        regex: "^https://mes-test\\.lauresta\\.com/$"
-        replacement: "https://mes-test.lauresta.com/portal/"
+        regex: "^https://(mes-test|lkvitai)\\.lauresta\\.com/$"
+        replacement: "https://${1}.lauresta.com/portal/"
         permanent: false
 
     mes-test-strip-api-portal:


### PR DESCRIPTION
﻿## Changes

### Portal issue #95 - Branches on track real metric
- SQL: added result set 6 (BranchesOnTrack) to dbo.mes_OperationsSummary. Klaipeda (FilialoID=1) uses Pagamintas as readiness basis; all other branches use Issistas i filiala. onTrackPercent = IssuedCount * 100 / ReadyCount, NULL when ReadyCount=0.
- API: added PortalBranchOnTrackDto to contracts; SqlOperationsSummaryService reads the 6th result set; PortalOperationsSummaryResponse includes BranchesOnTrack.
- WebUI: BranchOnTrack record extended with ReadyBasis/Ready/Issued/OnTrackPercent. Home.razor renders pct% + issued/ready subtitle; warning style when pct < 90; dash when no threshold orders yet. Falls back to mock data when API returns empty.
- CSS: .branch__metric flex column for the two-line percent + count display.

### Traefik - lkvitai.lauresta.com alias
- Replaced Host() || Host() duplication with HostRegexp in all 11 routers.
- Redirect middleware regex updated to preserve domain via capture group.
- Let's Encrypt cert for lkvitai.lauresta.com obtained automatically on first HTTPS request.
