### PR TITLE
fix(ci): accept HostRegexp in traefik mes-test.yml validation

### DIFF
--- a/.github/workflows/deploy-traefik-dynamic.yml
+++ b/.github/workflows/deploy-traefik-dynamic.yml
@@ -37,7 +37,7 @@ jobs:
           grep -q 'Host(`portal.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`warehouse.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`api.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
-          grep -q 'Host(`mes-test.lauresta.com`)' deploy/traefik/dynamic/mes-test.yml
+          grep -qE 'Host\(`mes-test\.lauresta\.com`\)|HostRegexp\(.*mes-test' deploy/traefik/dynamic/mes-test.yml
           grep -q 'PathPrefix(`/api/portal`)' deploy/traefik/dynamic/mes-test.yml
           grep -q 'PathPrefix(`/api/warehouse`)' deploy/traefik/dynamic/mes-test.yml
 


### PR DESCRIPTION
The deploy-traefik-dynamic.yml validator was checking for the literal string \Host(\mes-test.lauresta.com\)\ which no longer exists after switching to \HostRegexp\ in PR #132. Updated the grep to accept either form: \Host(\mes-test...\)\ or \HostRegexp(...mes-test...)\.

Made with [Cursor](https://cursor.com)