### PR TITLE
fix(traefik): revert HostRegexp to Host()||Host() — fixes 404 on mes-test

### DIFF
--- a/.github/workflows/deploy-traefik-dynamic.yml
+++ b/.github/workflows/deploy-traefik-dynamic.yml
@@ -38,6 +38,7 @@ jobs:
           grep -q 'Host(`warehouse.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -q 'Host(`api.mes.lauresta.com`)' deploy/traefik/dynamic/mes.yml
           grep -qE 'Host\(`mes-test\.lauresta\.com`\)|HostRegexp\(.*mes-test' deploy/traefik/dynamic/mes-test.yml
+          grep -qE 'lkvitai\.lauresta\.com' deploy/traefik/dynamic/mes-test.yml
           grep -q 'PathPrefix(`/api/portal`)' deploy/traefik/dynamic/mes-test.yml
           grep -q 'PathPrefix(`/api/warehouse`)' deploy/traefik/dynamic/mes-test.yml
 

--- a/deploy/traefik/dynamic/mes-test.yml
+++ b/deploy/traefik/dynamic/mes-test.yml
@@ -1,14 +1,14 @@
 # Test environment — routers, middlewares, services for mes-test.lauresta.com
 # and its alias lkvitai.lauresta.com (Cloudflare CNAME → mes-test.lauresta.com).
 #
-# All routers use HostRegexp so both hostnames are covered without duplication.
-# Traefik resolves Let's Encrypt certificates per SNI on first request.
+# Path-based routing under both hostnames. API prefixes are stripped before
+# forwarding so each module's ASP.NET Core host only sees its own routes.
 # Scaffolded modules (Sales/Frontline/Scanning) mirror the Warehouse/Portal
 # routing pattern exactly.
 http:
   routers:
     mes-test-portal-root:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && Path(`/`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && Path(`/`)"
       entryPoints: [websecure]
       middlewares: [mes-test-redirect-root-to-portal]
       service: mes-test-portal-webui
@@ -17,7 +17,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-portal:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/portal`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/portal`)"
       entryPoints: [websecure]
       service: mes-test-portal-webui
       priority: 100
@@ -25,7 +25,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-warehouse:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/warehouse`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/warehouse`)"
       entryPoints: [websecure]
       service: mes-test-warehouse-webui
       priority: 100
@@ -33,7 +33,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-sales:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/sales`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/sales`)"
       entryPoints: [websecure]
       service: mes-test-sales-webui
       priority: 100
@@ -41,7 +41,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-frontline:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/frontline`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/frontline`)"
       entryPoints: [websecure]
       service: mes-test-frontline-webui
       priority: 100
@@ -49,7 +49,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-scan:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/scan`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/scan`)"
       entryPoints: [websecure]
       service: mes-test-scanning-webui
       priority: 100
@@ -57,7 +57,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-portal:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/portal`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/api/portal`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-portal]
       service: mes-test-portal-api
@@ -66,7 +66,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-warehouse:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/warehouse`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/api/warehouse`)"
       entryPoints: [websecure]
       middlewares: [mes-test-strip-api-warehouse]
       service: mes-test-warehouse-api
@@ -75,7 +75,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-sales:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/sales`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/api/sales`)"
       entryPoints: [websecure]
       service: mes-test-sales-api
       priority: 200
@@ -83,7 +83,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-frontline:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/frontline`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/api/frontline`)"
       entryPoints: [websecure]
       service: mes-test-frontline-api
       priority: 200
@@ -91,7 +91,7 @@ http:
         certResolver: letsencrypt
 
     mes-test-api-scan:
-      rule: "HostRegexp(`{d:(mes-test|lkvitai)\\.lauresta\\.com}`) && PathPrefix(`/api/scan`)"
+      rule: "(Host(`mes-test.lauresta.com`) || Host(`lkvitai.lauresta.com`)) && PathPrefix(`/api/scan`)"
       entryPoints: [websecure]
       service: mes-test-scanning-api
       priority: 200


### PR DESCRIPTION
HostRegexp broke routing on mes-test.lauresta.com — Traefik v2 does not reuse existing Let's Encrypt certs when switching from Host() to HostRegexp(), causing 404 after deploy. Reverts to the explicit Host() || Host() pattern which is proven to work. Both domains are still covered. Also adds lkvitai.lauresta.com presence check to the CI validator.