### PR TITLE
fix(warehouse): restore Bootstrap CSS and fix MudDrawer after shell integration

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/_Layout.cshtml
@@ -10,6 +10,7 @@
     <base href="~/" />
     <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-tokens.css" rel="stylesheet" />
     <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="css/site.css" rel="stylesheet" />

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Shared/MainLayout.razor
@@ -1,15 +1,17 @@
 @inherits LayoutComponentBase
 
+<MudThemeProvider />
+<MudDialogProvider />
+<MudSnackbarProvider />
+
 <PortalAuthenticatedShell>
     <ChildContent>
-        <MudLayout style="flex:1;min-height:0">
+        <MudLayout style="flex:1;min-height:0;overflow:hidden">
             <MudDrawer Class="sidebar bg-dark text-white"
-                       Variant="DrawerVariant.Responsive"
-                       Breakpoint="Breakpoint.Md"
+                       Variant="DrawerVariant.Persistent"
                        Width="250px"
-                       Elevation="1"
-                       @bind-Open="_drawerOpen"
-                       ClipMode="DrawerClipMode.Never">
+                       Elevation="0"
+                       @bind-Open="_drawerOpen">
                 <NavMenu />
             </MudDrawer>
 


### PR DESCRIPTION
Bootstrap CSS was removed during header integration but Warehouse pages use Bootstrap grid. Restore it. Switch MudDrawer from Responsive to Persistent to fix fixed-position conflict with in-flow portal topbar. Add missing MudThemeProvider/DialogProvider/SnackbarProvider.

Made with [Cursor](https://cursor.com)