### PR TITLE
fix(warehouse): CSS cache-bust + move --content-max to shared tokens (1600px)

### DIFF
--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-tokens.css
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-tokens.css
@@ -93,4 +93,10 @@
   --r-sm: 4px;
   --r-md: 6px;
   --r-lg: 8px;
+
+  /* Shell layout — content cap shared across all modules (Sales, Warehouse,
+     Frontline, Portal). Each module's main content wrapper uses this value.
+     1600px fits comfortably on 1920px monitors (160px side breathing room)
+     while keeping dense operational tables scannable. */
+  --content-max: 1600px;
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/_Layout.cshtml
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/_Layout.cshtml
@@ -8,12 +8,12 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <base href="~/" />
-    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-tokens.css" rel="stylesheet" />
-    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" />
+    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-tokens.css" rel="stylesheet" asp-append-version="true" />
+    <link href="_content/LKvitai.MES.BuildingBlocks.WebUI/css/portal-shell.css" rel="stylesheet" asp-append-version="true" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
-    <link href="css/site.css" rel="stylesheet" />
+    <link href="css/site.css" rel="stylesheet" asp-append-version="true" />
     <link href="LKvitai.MES.Modules.Warehouse.WebUI.styles.css" rel="stylesheet" />
     <component type="typeof(HeadOutlet)" render-mode="ServerPrerendered" />
 </head>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -17,7 +17,6 @@
 
 /* ─── Warehouse-local layout constants ────────────────────────────────── */
 :root {
-  --content-max: 1600px;
   --sidebar-w: 240px;
   --sidebar-w-collapsed: 52px;
 }


### PR DESCRIPTION
﻿## Summary

Hotfix commits on top of merged PR #147.

- **CSS cache-bust** — added `asp-append-version="true"` to all local CSS links in Warehouse `_Layout.cshtml` (`portal-tokens.css`, `portal-shell.css`, `site.css`). Without this ASP.NET fingerprint, browsers and Cloudflare served the old CSS after deploy — sidebar sections appeared white-on-white (invisible).
- **`--content-max` moved to shared tokens** — added `--content-max: 1600px` to `portal-tokens.css` (BuildingBlocks). All modules now resolve the variable from the shared source. The duplicate declaration removed from Warehouse `site.css`.

## Width decision

**1600px** chosen over 1440 / 1800 / 100%:
- Fits comfortably on 1920px monitors (160px breathing room per side)
- Dense operational tables remain scannable (1800 is too wide for horizontal scanning)
- Avoids full-bleed awkwardness on 4K / ultrawide

## Test plan

- [ ] Hard-refresh `/warehouse/dashboard` — sidebar sections (Stock, Inbound, Operations…) visible with correct light styling
- [ ] Hard-refresh `/sales/` — table width fills ~1600px, not full-bleed
- [ ] On 1920px monitor: content is capped, no excessive blank margins
- [ ] No new JS console errors on circuit connect

Closes #140 #141 #142 #145 #146 (cache-bust unblocks visual QA of all five)
