### PR TITLE
[codex] fix warehouse sidebar shell width

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@ Warehouse modular monolith (Phase refactor branch).
 - `docs/` - architecture, blueprint, audit, and status documents
 - `scripts/` - operational and deployment scripts
 
+## Shell Layout
+
+The shared portal shell is full-bleed: the test strip, topbar, and module body
+span the viewport. Module content is capped inside the body with
+`--content-max: 1600px`; Warehouse uses `.main__inner` for this cap while its
+sidebar remains a fixed-width column (`240px` expanded, `52px` collapsed).
+
+Do not reintroduce a centered `max-width` on `.app-shell`. It separates
+MudBlazor's persistent drawer from the centered topbar/content on wide screens,
+which makes the Warehouse sidebar appear to drift to the far left.
+
 ## Refactor Blueprint
 
 - Source of truth: `docs/blueprints/repo-refactor-blueprint.md`

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-shell.css
@@ -11,7 +11,8 @@
 }
 
 .app-shell {
-  max-width: 1440px;
+  width: 100%;
+  max-width: none;
   min-height: 100vh;
   margin: 0 auto;
   background: var(--n-50);


### PR DESCRIPTION
## Summary
- Make the shared portal app shell full-bleed instead of capped at 1440px.
- Document the 1600px content cap and why `.app-shell` must not be centered.

## Root cause
Warehouse content already caps inside `.main__inner` via `--content-max: 1600px`, but the shared `.app-shell` still had `max-width: 1440px`. MudBlazor's persistent drawer is positioned relative to the viewport, so on wide screens the sidebar separated from the centered topbar/content.

## Validation
- `dotnet restore src/LKvitai.MES.sln`
- `dotnet build src/LKvitai.MES.sln -c Release --no-restore`

Build passed with existing warnings for package advisories and XML comments.