### PR TITLE
[codex] Fix warehouse visualization viewport height

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor.css
@@ -1,7 +1,8 @@
 .viz-page {
     display: flex;
     flex-direction: column;
-    height: calc(100vh - 56px);
+    flex: 1;
+    min-height: 0;
     overflow: hidden;
     background:
         radial-gradient(circle at top left, rgba(191, 219, 254, 0.18), transparent 28%),

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -313,6 +313,7 @@ h1:focus { outline: none; }
   flex-direction: column;
   background: var(--n-100);
   min-height: 0;
+  overflow: hidden;
 }
 
 .main__inner {
@@ -320,6 +321,21 @@ h1:focus { outline: none; }
   max-width: var(--content-max, 1600px);
   margin: 0 auto;
   padding: clamp(20px, 2.4vw, 36px);
+}
+
+.mud-main-content:has(.viz-page) {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.main__inner:has(> .viz-page) {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  max-width: none;
+  padding: 0;
+  overflow: hidden;
 }
 
 /* ─── Bootstrap button overrides → teal ───────────────────────────────── */


### PR DESCRIPTION
## Summary
- Removes the hard-coded 100vh-based height from the warehouse visualization page.
- Lets the 3D visualization fill the actual layout container using flex/min-height instead of overflowing behind the browser bottom.
- Removes the main content padding only for visualization pages so the canvas, legend, and mouse controls remain visible.

## Validation
- git diff --check
- dotnet build src/LKvitai.MES.sln --no-restore