### PR TITLE
[codex] Compute warehouse visualization height from viewport

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js
@@ -1049,6 +1049,19 @@
                 return;
             }
 
+            const syncVisualizationHeight = () => {
+                const page = container.closest(".viz-page");
+                if (!page) {
+                    return;
+                }
+
+                const top = page.getBoundingClientRect().top;
+                const availableHeight = Math.max(300, window.innerHeight - top);
+                page.style.height = `${availableHeight}px`;
+            };
+
+            syncVisualizationHeight();
+
             log("render: start", {
                 containerId,
                 binCount: Array.isArray(data) ? data.length : (Array.isArray(data?.bins) ? data.bins.length : 0),
@@ -1896,6 +1909,7 @@
             }
 
             const onResize = () => {
+                syncVisualizationHeight();
                 const nextWidth = Math.max(container.clientWidth, 300);
                 const nextHeight = Math.max(container.clientHeight, 300);
                 camera.aspect = nextWidth / nextHeight;


### PR DESCRIPTION
## Summary
- Fixes the previous 300px canvas fallback by setting the visualization page height from its actual viewport top offset.
- Recomputes the height before Three.js renderer initialization and on resize.
- Keeps the layout responsive when environment banners, topbars, or DevTools change the available viewport.

## Validation
- node --check src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/js/warehouseVisualization.js
- git diff --check
- dotnet build src/LKvitai.MES.sln --no-restore