### PR TITLE
[codex] Fix portal module status summary

### DIFF
--- a/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
+++ b/src/Modules/Portal/LKvitai.MES.Modules.Portal.WebUI/Pages/Home.razor
@@ -277,7 +277,7 @@
                 </header>
                 <div class="status-row"><span>Environment</span><strong class="mono @_envStatusRowClass">@_envName</strong></div>
                 <div class="status-row"><span>Version</span><strong class="mono">@_displayVersion</strong></div>
-                <div class="status-row"><span>Modules</span><strong class="mono">@_liveCount live / @_pilotCount pilot / @_modules.Count total</strong></div>
+                <div class="status-row"><span>Modules</span><strong class="mono">@FormatModuleStatusSummary()</strong></div>
                 <div class="status-row"><span>Current module</span><strong>Portal</strong></div>
                 <div class="status-row"><span>Channel</span><strong class="mono">@_envChannel</strong></div>
             </section>
@@ -509,6 +509,17 @@
 
     private static string ShortSha(string fullSha) =>
         fullSha.Length <= 7 ? fullSha : fullSha[..7];
+
+    private string FormatModuleStatusSummary()
+    {
+        var parts = new List<string>(5);
+        if (_liveCount > 0) parts.Add($"{_liveCount} live");
+        if (_pilotCount > 0) parts.Add($"{_pilotCount} pilot");
+        if (_developingCount > 0) parts.Add($"{_developingCount} developing");
+        if (_plannedCount > 0) parts.Add($"{_plannedCount} planned");
+        parts.Add($"{_modules.Count} total");
+        return string.Join(" / ", parts);
+    }
 
     private sealed record RecentShortcut(string Key, string Title, string Url, bool IsPrimary);
 


### PR DESCRIPTION
## Summary

Fixes the Portal home `Modules` status row so it reports every configured module state instead of only `live / pilot / total`.

The Portal module data already tracks the four allowed statuses: `Planned`, `Developing`, `Pilot`, and `Live`. The side status panel now formats a summary from all four counters and appends the total.

## Impact

Users can now see the real breakdown of module states on the Portal home status panel, for example `1 live / 3 pilot / 8 planned / 12 total` instead of a misleading partial summary.

## Validation

- Ran `git diff --check` locally.
- Could not run `dotnet build` in this Codex environment because `dotnet` is not installed.
