### PR TITLE
Frontline fabric photo storage, import, and serving

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.Playwright" Version="1.51.0" />

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ Or open `src/LKvitai.MES.sln` in Visual Studio / Rider and run from IDE.
 | `UseJaegerExporter` | No | `false` | `true` → traces to Jaeger UI; `false` → traces to console |
 | `Jaeger__AgentHost` | No | `localhost` | Jaeger UDP agent host |
 
+Fabric photos for Frontline use the same object-storage configuration but are
+stored under `fabric-photos/{fabricCode}/{photoId}/...` and mapped in
+`public.fabric_photos`, separate from Warehouse `item_photos`. See
+`docs/frontline/fabric-photos.md` for importer and API details.
+
 ### Build & Test
 
 ```bash

--- a/docs/frontline/fabric-photos.md
+++ b/docs/frontline/fabric-photos.md
@@ -78,6 +78,12 @@ path instead. The importer is idempotent: the stable photo id is derived from
 `FabricCode + Sha256` when possible, and `FabricCode + Sha256` updates existing
 rows instead of creating duplicate logical photos.
 
+Prepared CSV packages may contain duplicate rows for the same fabric image.
+Duplicate detection is by `FabricCode + Sha256`, and `IsPrimary` is monotonic:
+once a logical photo is primary, later duplicate rows cannot downgrade it to
+non-primary. If a non-primary duplicate is seen first and the primary duplicate
+arrives later, the existing row is promoted to primary.
+
 ## API
 
 Frontline enriches legacy fabric responses with MES photo URLs:

--- a/docs/frontline/fabric-photos.md
+++ b/docs/frontline/fabric-photos.md
@@ -1,0 +1,94 @@
+# Frontline Fabric Photos
+
+Fabric photos are stored separately from Warehouse `item_photos`.
+
+Frontline fabric codes such as `R85`, `R88`, and `R101` come from the legacy
+fabric catalogue and do not imply a Warehouse `items.Id`. MES stores only a
+photo mapping table plus object-storage keys; the legacy database remains the
+source of truth for fabric name, stock, status, widths, suppliers, and incoming
+meters.
+
+## Storage
+
+Objects live in the existing MinIO/object-storage bucket configured by the
+`ItemImages` settings. The `ITEMIMAGES__...` variables are the repo's existing
+shared media/object-storage configuration; fabric photos are separated by the
+`fabric-photos/...` prefix and `fabric_photos` table, not by a separate bucket.
+
+- original: `fabric-photos/{fabricCode}/{photoId}/original{extension}`
+- thumbnail: `fabric-photos/{fabricCode}/{photoId}/thumb.webp`
+
+Example:
+
+```text
+fabric-photos/R85/018f6f2e/original.JPG
+fabric-photos/R85/018f6f2e/thumb.webp
+```
+
+## Database
+
+The MES table is `public.fabric_photos`.
+
+Important columns:
+
+- `Id` (`uuid`) stable photo id
+- `FabricCode` legacy fabric code, for example `R85`
+- `OriginalObjectKey`, `ThumbObjectKey`
+- `SourceImageUrl`, `SourcePageUrl`, `SourceImageFileName`
+- `Sha256`, `ImageWidth`, `ImageHeight`, `FileSizeBytes`
+- `IsPrimary`, `CreatedAt`, `UpdatedAt`
+
+`fabric_photos` has no foreign key to Warehouse `items` and does not write to
+`item_photos`.
+
+## Import
+
+The importer reads a prepared package:
+
+```text
+output/fabric_photos.csv
+images/original/
+images/thumb/
+```
+
+Required configuration:
+
+```bash
+export ConnectionStrings__WarehouseDb='Host=...;Port=5432;Database=...;Username=...;Password=...'
+export ITEMIMAGES__ENDPOINT='minio.example.com:9000'
+export ITEMIMAGES__BUCKET='...'
+export ITEMIMAGES__ACCESSKEY='...'
+export ITEMIMAGES__SECRETKEY='...'
+export ITEMIMAGES__USESSL='false'
+```
+
+`ConnectionStrings__WarehouseDb` is the existing MES PostgreSQL state database
+connection name in this repo. It does not mean `fabric_photos` belongs to the
+Warehouse domain. Where supported, `ConnectionStrings__FabricPhotosDb` can be
+used as a clearer alias/fallback.
+
+Run:
+
+```bash
+dotnet run --project tools/FabricPhotoImporter -- --input /Users/bykovas/Desktop/fabrics/fabric-image-import
+```
+
+If the package is placed exactly at `~/Desktop/fabric-image-import`, pass that
+path instead. The importer is idempotent: the stable photo id is derived from
+`FabricCode + Sha256` when possible, and `FabricCode + Sha256` updates existing
+rows instead of creating duplicate logical photos.
+
+## API
+
+Frontline enriches legacy fabric responses with MES photo URLs:
+
+- `GET /api/frontline/fabric/{code}`
+- `GET /api/frontline/fabric/low-stock`
+
+Photo streams are served by:
+
+- `GET /api/frontline/fabric/{fabricCode}/photo?size=thumb`
+- `GET /api/frontline/fabric/{fabricCode}/photo?size=original`
+
+List views use thumbnail URLs only. The stream endpoint uses object-storage
+ETags and `Cache-Control: public, max-age={ITEMIMAGES__CACHEMAXAGESECONDS}`.

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/IObjectStorageService.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/IObjectStorageService.cs
@@ -1,0 +1,16 @@
+namespace LKvitai.MES.BuildingBlocks.ObjectStorage;
+
+public interface IObjectStorageService
+{
+    ObjectStorageOptions Options { get; }
+    Task<ObjectStorageAvailability> EnsureAvailableAsync(CancellationToken cancellationToken = default);
+    Task PutObjectAsync(
+        string objectKey,
+        Stream stream,
+        long size,
+        string contentType,
+        CancellationToken cancellationToken = default);
+    Task<MemoryStream> GetObjectAsync(string objectKey, CancellationToken cancellationToken = default);
+    Task<string?> TryGetObjectEtagAsync(string objectKey, CancellationToken cancellationToken = default);
+    Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken = default);
+}

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/LKvitai.MES.BuildingBlocks.ObjectStorage.csproj
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/LKvitai.MES.BuildingBlocks.ObjectStorage.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>LKvitai.MES.BuildingBlocks.ObjectStorage</RootNamespace>
+    <AssemblyName>LKvitai.MES.BuildingBlocks.ObjectStorage</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Minio" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+</Project>

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/MinioObjectStorageService.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/MinioObjectStorageService.cs
@@ -1,0 +1,136 @@
+using Microsoft.Extensions.Logging;
+using Minio;
+using Minio.DataModel.Args;
+using Minio.Exceptions;
+
+namespace LKvitai.MES.BuildingBlocks.ObjectStorage;
+
+public sealed class MinioObjectStorageService : IObjectStorageService
+{
+    private readonly IMinioClient _minioClient;
+    private readonly ILogger<MinioObjectStorageService> _logger;
+    private readonly SemaphoreSlim _availabilityLock = new(1, 1);
+
+    private DateTimeOffset _lastAvailabilityCheck = DateTimeOffset.MinValue;
+    private ObjectStorageAvailability _lastAvailability = new(false, "Object storage not initialized.");
+
+    public MinioObjectStorageService(
+        IMinioClient minioClient,
+        ObjectStorageOptions options,
+        ILogger<MinioObjectStorageService> logger)
+    {
+        _minioClient = minioClient;
+        Options = options;
+        _logger = logger;
+    }
+
+    public ObjectStorageOptions Options { get; }
+
+    public async Task<ObjectStorageAvailability> EnsureAvailableAsync(CancellationToken cancellationToken = default)
+    {
+        if (DateTimeOffset.UtcNow - _lastAvailabilityCheck < TimeSpan.FromSeconds(30))
+        {
+            return _lastAvailability;
+        }
+
+        await _availabilityLock.WaitAsync(cancellationToken);
+        try
+        {
+            if (DateTimeOffset.UtcNow - _lastAvailabilityCheck < TimeSpan.FromSeconds(30))
+            {
+                return _lastAvailability;
+            }
+
+            if (!Options.HasRequiredConfiguration)
+            {
+                _lastAvailability = new ObjectStorageAvailability(false, "Missing object storage configuration.");
+                _lastAvailabilityCheck = DateTimeOffset.UtcNow;
+                return _lastAvailability;
+            }
+
+            try
+            {
+                var exists = await _minioClient.BucketExistsAsync(
+                    new BucketExistsArgs().WithBucket(Options.BucketName),
+                    cancellationToken);
+
+                _lastAvailability = exists
+                    ? new ObjectStorageAvailability(true, null)
+                    : new ObjectStorageAvailability(false, $"Bucket '{Options.BucketName}' does not exist.");
+            }
+            catch (AccessDeniedException)
+            {
+                _lastAvailability = new ObjectStorageAvailability(false, $"Access denied for bucket '{Options.BucketName}'.");
+            }
+            catch (MinioException ex)
+            {
+                _logger.LogWarning(ex, "Failed validating object storage access.");
+                _lastAvailability = new ObjectStorageAvailability(false, ex.Message);
+            }
+
+            _lastAvailabilityCheck = DateTimeOffset.UtcNow;
+            return _lastAvailability;
+        }
+        finally
+        {
+            _availabilityLock.Release();
+        }
+    }
+
+    public async Task PutObjectAsync(
+        string objectKey,
+        Stream stream,
+        long size,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        await _minioClient.PutObjectAsync(
+            new PutObjectArgs()
+                .WithBucket(Options.BucketName)
+                .WithObject(objectKey)
+                .WithStreamData(stream)
+                .WithObjectSize(size)
+                .WithContentType(contentType),
+            cancellationToken);
+    }
+
+    public async Task<MemoryStream> GetObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        var result = new MemoryStream();
+        await _minioClient.GetObjectAsync(
+            new GetObjectArgs()
+                .WithBucket(Options.BucketName)
+                .WithObject(objectKey)
+                .WithCallbackStream(stream => stream.CopyTo(result)),
+            cancellationToken);
+        result.Position = 0;
+        return result;
+    }
+
+    public async Task<string?> TryGetObjectEtagAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var stat = await _minioClient.StatObjectAsync(
+                new StatObjectArgs()
+                    .WithBucket(Options.BucketName)
+                    .WithObject(objectKey),
+                cancellationToken);
+
+            return stat.ETag?.Trim('"');
+        }
+        catch (ObjectNotFoundException)
+        {
+            return null;
+        }
+    }
+
+    public async Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        await _minioClient.RemoveObjectAsync(
+            new RemoveObjectArgs()
+                .WithBucket(Options.BucketName)
+                .WithObject(objectKey),
+            cancellationToken);
+    }
+}

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/ObjectStorageOptions.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/ObjectStorageOptions.cs
@@ -1,0 +1,19 @@
+namespace LKvitai.MES.BuildingBlocks.ObjectStorage;
+
+public sealed record ObjectStorageAvailability(bool IsAvailable, string? Reason);
+
+public sealed class ObjectStorageOptions
+{
+    public string Endpoint { get; init; } = string.Empty;
+    public string BucketName { get; init; } = string.Empty;
+    public bool UseSsl { get; init; }
+    public string AccessKey { get; init; } = string.Empty;
+    public string SecretKey { get; init; } = string.Empty;
+    public int CacheMaxAgeSeconds { get; init; } = 86400;
+
+    public bool HasRequiredConfiguration =>
+        !string.IsNullOrWhiteSpace(Endpoint) &&
+        !string.IsNullOrWhiteSpace(BucketName) &&
+        !string.IsNullOrWhiteSpace(AccessKey) &&
+        !string.IsNullOrWhiteSpace(SecretKey);
+}

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/UnavailableObjectStorageService.cs
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/UnavailableObjectStorageService.cs
@@ -1,0 +1,29 @@
+namespace LKvitai.MES.BuildingBlocks.ObjectStorage;
+
+public sealed class UnavailableObjectStorageService : IObjectStorageService
+{
+    private readonly string _reason;
+
+    public UnavailableObjectStorageService(ObjectStorageOptions options, string reason)
+    {
+        Options = options;
+        _reason = reason;
+    }
+
+    public ObjectStorageOptions Options { get; }
+
+    public Task<ObjectStorageAvailability> EnsureAvailableAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new ObjectStorageAvailability(false, _reason));
+
+    public Task PutObjectAsync(string objectKey, Stream stream, long size, string contentType, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(_reason);
+
+    public Task<MemoryStream> GetObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(_reason);
+
+    public Task<string?> TryGetObjectEtagAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult<string?>(null);
+
+    public Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+        => throw new InvalidOperationException(_reason);
+}

--- a/src/LKvitai.MES.sln
+++ b/src/LKvitai.MES.sln
@@ -93,6 +93,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.BuildingBlocks.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.BuildingBlocks.WebUI", "BuildingBlocks\LKvitai.MES.BuildingBlocks.WebUI\LKvitai.MES.BuildingBlocks.WebUI.csproj", "{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.BuildingBlocks.ObjectStorage", "BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj", "{0830107D-6D6E-4BC3-912A-85810ACAB646}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FabricPhotoImporter", "..\tools\FabricPhotoImporter\FabricPhotoImporter.csproj", "{FFA563AE-E24C-4C9C-AF48-27CC79263412}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LKvitai.MES.Tests.Frontline.Unit", "..\tests\Modules\Frontline\LKvitai.MES.Tests.Frontline.Unit\LKvitai.MES.Tests.Frontline.Unit.csproj", "{E67E72C8-2861-494B-B0EF-881C383A1D32}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -535,6 +541,42 @@ Global
 		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x64.Build.0 = Release|Any CPU
 		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x86.ActiveCfg = Release|Any CPU
 		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3}.Release|x86.Build.0 = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|x64.Build.0 = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Debug|x86.Build.0 = Debug|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|x64.ActiveCfg = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|x64.Build.0 = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|x86.ActiveCfg = Release|Any CPU
+		{0830107D-6D6E-4BC3-912A-85810ACAB646}.Release|x86.Build.0 = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|x64.Build.0 = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Debug|x86.Build.0 = Debug|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|x64.ActiveCfg = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|x64.Build.0 = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|x86.ActiveCfg = Release|Any CPU
+		{FFA563AE-E24C-4C9C-AF48-27CC79263412}.Release|x86.Build.0 = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|x64.Build.0 = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Debug|x86.Build.0 = Debug|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|x64.ActiveCfg = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|x64.Build.0 = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|x86.ActiveCfg = Release|Any CPU
+		{E67E72C8-2861-494B-B0EF-881C383A1D32}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -581,5 +623,6 @@ Global
 		{C064108B-603E-44EC-9AF7-FE630A05AEEE} = {E517C80E-57DC-40DC-B774-86FB3BB2E677}
 		{62AF2A2A-F474-4644-8EAA-43740A0D8994} = {12C1EE8E-A2E0-45AF-BB0B-AE1B9FE15B43}
 		{A0CD62CF-0F06-4B81-AA01-A08041E78BD3} = {12C1EE8E-A2E0-45AF-BB0B-AE1B9FE15B43}
+		{0830107D-6D6E-4BC3-912A-85810ACAB646} = {12C1EE8E-A2E0-45AF-BB0B-AE1B9FE15B43}
 	EndGlobalSection
 EndGlobal

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Composition/FrontlineFabricPhotos.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Composition/FrontlineFabricPhotos.cs
@@ -1,0 +1,103 @@
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore;
+using Minio;
+using Npgsql;
+
+namespace LKvitai.MES.Modules.Frontline.Api.Composition;
+
+public static class FrontlineFabricPhotos
+{
+    public static IServiceCollection AddFrontlineFabricPhotos(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        var rawConnectionString = configuration.GetConnectionString("WarehouseDb")
+            ?? configuration.GetConnectionString("FabricPhotosDb");
+
+        if (!string.IsNullOrWhiteSpace(rawConnectionString))
+        {
+            var builder = new NpgsqlConnectionStringBuilder(rawConnectionString)
+            {
+                MinPoolSize = 1,
+                MaxPoolSize = 20,
+                Timeout = 30
+            };
+
+            services.AddDbContext<FabricPhotoDbContext>(options =>
+            {
+                options.UseNpgsql(builder.ConnectionString, npgsqlOptions =>
+                {
+                    npgsqlOptions.MigrationsHistoryTable("__EFMigrationsHistory", "public");
+                    npgsqlOptions.EnableRetryOnFailure(maxRetryCount: 3);
+                });
+            });
+        }
+        else
+        {
+            services.AddDbContext<FabricPhotoDbContext>(options =>
+                options.UseInMemoryDatabase("frontline-fabric-photos-disabled"));
+        }
+
+        var storageOptions = ReadObjectStorageOptions(configuration);
+        services.AddSingleton(storageOptions);
+        if (storageOptions.HasRequiredConfiguration)
+        {
+            services.AddSingleton<IMinioClient>(_ => new MinioClient()
+                .WithEndpoint(storageOptions.Endpoint)
+                .WithCredentials(storageOptions.AccessKey, storageOptions.SecretKey)
+                .WithSSL(storageOptions.UseSsl)
+                .Build());
+            services.AddSingleton<IObjectStorageService, MinioObjectStorageService>();
+        }
+        else
+        {
+            services.AddSingleton<IObjectStorageService>(sp =>
+                new UnavailableObjectStorageService(
+                    sp.GetRequiredService<ObjectStorageOptions>(),
+                    "Fabric photo object storage is not configured."));
+        }
+        services.AddScoped<IFabricPhotoService, FabricPhotoService>();
+        return services;
+    }
+
+    private static ObjectStorageOptions ReadObjectStorageOptions(IConfiguration configuration)
+    {
+        var section = configuration.GetSection("ItemImages");
+        var rawEndpoint = ReadValue(section, "Endpoint", "ITEMIMAGES__ENDPOINT");
+
+        return new ObjectStorageOptions
+        {
+            Endpoint = NormalizeEndpoint(rawEndpoint),
+            BucketName = ReadValue(section, "BucketName", "ITEMIMAGES__BUCKET", section["Bucket"] ?? string.Empty),
+            UseSsl = bool.TryParse(ReadValue(section, "UseSsl", "ITEMIMAGES__USESSL"), out var useSsl) && useSsl,
+            AccessKey = ReadValue(section, "AccessKey", "ITEMIMAGES__ACCESSKEY"),
+            SecretKey = ReadValue(section, "SecretKey", "ITEMIMAGES__SECRETKEY"),
+            CacheMaxAgeSeconds = int.TryParse(ReadValue(section, "CacheMaxAgeSeconds", "ITEMIMAGES__CACHEMAXAGESECONDS"), out var ttl)
+                ? ttl
+                : 86400
+        };
+    }
+
+    private static string ReadValue(IConfigurationSection section, string key, string envKey, string defaultValue = "")
+    {
+        var fromSection = section[key];
+        if (!string.IsNullOrWhiteSpace(fromSection)) return fromSection;
+        var fromEnv = Environment.GetEnvironmentVariable(envKey);
+        return string.IsNullOrWhiteSpace(fromEnv) ? defaultValue : fromEnv;
+    }
+
+    private static string NormalizeEndpoint(string raw)
+    {
+        if (string.IsNullOrWhiteSpace(raw)) return string.Empty;
+        var value = raw.Trim();
+        if (value.Contains("://", StringComparison.Ordinal) &&
+            Uri.TryCreate(value, UriKind.Absolute, out var absolute))
+        {
+            return absolute.IsDefaultPort ? absolute.Host : $"{absolute.Host}:{absolute.Port}";
+        }
+
+        var slashIndex = value.IndexOf('/');
+        return slashIndex >= 0 ? value[..slashIndex] : value;
+    }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Dockerfile
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Dockerfile
@@ -10,6 +10,7 @@ COPY global.json .
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/LKvitai.MES.BuildingBlocks.SharedKernel.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/LKvitai.MES.BuildingBlocks.ModuleStartup.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/LKvitai.MES.BuildingBlocks.ObjectStorage.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/LKvitai.MES.Modules.Frontline.Contracts.csproj Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Application/LKvitai.MES.Modules.Frontline.Application.csproj Modules/Frontline/LKvitai.MES.Modules.Frontline.Application/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/LKvitai.MES.Modules.Frontline.Infrastructure.csproj Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/
@@ -20,6 +21,7 @@ RUN dotnet restore Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/LKvitai.M
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/ BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/ BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/ BuildingBlocks/LKvitai.MES.BuildingBlocks.ModuleStartup/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/ BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/ Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Application/ Modules/Frontline/LKvitai.MES.Modules.Frontline.Application/
 COPY src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/ Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Endpoints/FabricAvailabilityEndpoints.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Endpoints/FabricAvailabilityEndpoints.cs
@@ -3,7 +3,9 @@ using System.Text.RegularExpressions;
 using LKvitai.MES.Modules.Frontline.Application.Ports;
 using LKvitai.MES.Modules.Frontline.Contracts.Common;
 using LKvitai.MES.Modules.Frontline.Contracts.Fabric;
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Logging;
 
@@ -45,6 +47,13 @@ public static class FabricAvailabilityEndpoints
             .WithName("GetFrontlineFabricLowStock")
             .Produces<PagedResult<FabricLowStockDto>>(StatusCodes.Status200OK);
 
+        fabric.MapGet("/{code}/photo", GetPhotoAsync)
+            .WithName("GetFrontlineFabricPhoto")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status304NotModified)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status404NotFound);
+
         return group;
     }
 
@@ -54,6 +63,7 @@ public static class FabricAvailabilityEndpoints
         int? lowThreshold,
         int? enoughThreshold,
         IFabricQueryService fabric,
+        IFabricPhotoService photos,
         IFabricLookupRecorder recorder,
         HttpContext httpContext,
         ILoggerFactory loggerFactory,
@@ -79,6 +89,10 @@ public static class FabricAvailabilityEndpoints
             EnoughThreshold: enoughThreshold ?? 25);
 
         var card = await fabric.GetMobileCardAsync(query, cancellationToken).ConfigureAwait(false);
+        if (card is not null)
+        {
+            card = await EnrichCardAsync(card, photos, cancellationToken).ConfigureAwait(false);
+        }
         sw.Stop();
 
         // Record the lookup attempt regardless of hit/miss — purchasing wants
@@ -99,12 +113,14 @@ public static class FabricAvailabilityEndpoints
     private static async Task<IResult> GetLowStockListAsync(
         [AsParameters] LowStockListRequest request,
         IFabricQueryService fabric,
+        IFabricPhotoService photos,
         ILoggerFactory loggerFactory,
         CancellationToken cancellationToken)
     {
         var sw = Stopwatch.StartNew();
         var query = request.ToQueryParams();
         var page = await fabric.GetLowStockListAsync(query, cancellationToken).ConfigureAwait(false);
+        page = await EnrichPageAsync(page, photos, cancellationToken).ConfigureAwait(false);
         sw.Stop();
 
         loggerFactory.CreateLogger("LKvitai.MES.Modules.Frontline.Api.Endpoints.Fabric").LogInformation(
@@ -116,6 +132,97 @@ public static class FabricAvailabilityEndpoints
             !string.IsNullOrWhiteSpace(query.Supplier), sw.ElapsedMilliseconds);
 
         return Results.Ok(page);
+    }
+
+    private static async Task<IResult> GetPhotoAsync(
+        string code,
+        string? size,
+        IFabricPhotoService photos,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(code))
+        {
+            return Results.BadRequest(new { error = "Code is required." });
+        }
+
+        var normalised = code.Trim().ToUpperInvariant();
+        if (!CodeShape.IsMatch(normalised))
+        {
+            return Results.BadRequest(new { error = $"Wrong format: '{normalised}'." });
+        }
+
+        var requestedSize = string.IsNullOrWhiteSpace(size) ? "thumb" : size.Trim();
+        if (!string.Equals(requestedSize, "thumb", StringComparison.OrdinalIgnoreCase) &&
+            !string.Equals(requestedSize, "original", StringComparison.OrdinalIgnoreCase))
+        {
+            return Results.BadRequest(new { error = "Query parameter 'size' must be 'thumb' or 'original'." });
+        }
+
+        var photo = await photos.GetPhotoAsync(normalised, requestedSize, cancellationToken).ConfigureAwait(false);
+        if (photo is null)
+        {
+            return Results.NotFound();
+        }
+
+        var normalizedEtag = photo.ETag.Trim('"');
+        httpContext.Response.Headers[HeaderNames.CacheControl] = $"public, max-age={photos.CacheMaxAgeSeconds}";
+        httpContext.Response.Headers[HeaderNames.ETag] = $"\"{normalizedEtag}\"";
+
+        if (httpContext.Request.Headers.TryGetValue(HeaderNames.IfNoneMatch, out var ifNoneMatchValues))
+        {
+            var matches = ifNoneMatchValues.Any(x =>
+                string.Equals(x?.Trim('"'), normalizedEtag, StringComparison.OrdinalIgnoreCase));
+            if (matches)
+            {
+                return Results.StatusCode(StatusCodes.Status304NotModified);
+            }
+        }
+
+        return Results.File(photo.Stream, photo.ContentType);
+    }
+
+    private static async Task<FabricCardDto> EnrichCardAsync(
+        FabricCardDto card,
+        IFabricPhotoService photos,
+        CancellationToken cancellationToken)
+    {
+        var codes = card.Alternatives
+            .Select(x => x.Code)
+            .Append(card.Code);
+        var urlMap = await photos.GetPrimaryUrlsAsync(codes, cancellationToken).ConfigureAwait(false);
+
+        var enrichedCard = urlMap.TryGetValue(card.Code, out var cardUrls)
+            ? card with { PhotoUrl = cardUrls.PhotoUrl, ThumbnailUrl = cardUrls.ThumbnailUrl }
+            : card;
+
+        if (card.Alternatives.Count == 0)
+        {
+            return enrichedCard;
+        }
+
+        var alternatives = card.Alternatives
+            .Select(x => urlMap.TryGetValue(x.Code, out var urls)
+                ? x with { PhotoUrl = urls.PhotoUrl, ThumbnailUrl = urls.ThumbnailUrl }
+                : x)
+            .ToArray();
+
+        return enrichedCard with { Alternatives = alternatives };
+    }
+
+    private static async Task<PagedResult<FabricLowStockDto>> EnrichPageAsync(
+        PagedResult<FabricLowStockDto> page,
+        IFabricPhotoService photos,
+        CancellationToken cancellationToken)
+    {
+        var urlMap = await photos.GetPrimaryUrlsAsync(page.Items.Select(x => x.Code), cancellationToken).ConfigureAwait(false);
+        var enriched = page.Items
+            .Select(x => urlMap.TryGetValue(x.Code, out var urls)
+                ? x with { PhotoUrl = urls.PhotoUrl, ThumbnailUrl = urls.ThumbnailUrl }
+                : x)
+            .ToArray();
+
+        return new PagedResult<FabricLowStockDto>(enriched, page.Total, page.Page, page.PageSize);
     }
 
     /// <summary>

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/LKvitai.MES.Modules.Frontline.Api.csproj
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/LKvitai.MES.Modules.Frontline.Api.csproj
@@ -9,12 +9,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Minio" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="Npgsql" />
     <PackageReference Include="Serilog.AspNetCore" />
     <PackageReference Include="Serilog.Sinks.Console" />
     <PackageReference Include="Serilog.Sinks.File" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.ModuleStartup\LKvitai.MES.BuildingBlocks.ModuleStartup.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Frontline.Application\LKvitai.MES.Modules.Frontline.Application.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Frontline.Contracts\LKvitai.MES.Modules.Frontline.Contracts.csproj" />

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Program.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Api/Program.cs
@@ -14,6 +14,7 @@ builder.Services.AddScaffoldApiCore();
 // derived from the legacy web_RemainsAll view, at which point the default
 // will flip to Sql/Auto.
 builder.Services.AddFrontlineFabricDataSource(builder.Configuration, builder.Environment);
+builder.Services.AddFrontlineFabricPhotos(builder.Configuration);
 
 var app = builder.Build();
 

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricAlternativeDto.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricAlternativeDto.cs
@@ -8,6 +8,7 @@ namespace LKvitai.MES.Modules.Frontline.Contracts.Fabric;
 public sealed record FabricAlternativeDto(
     string Code,
     string PhotoUrl,
+    string? ThumbnailUrl,
     int WidthMm,
     FabricAvailabilityStatus Status,
     int? StockMeters,

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricCardDto.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricCardDto.cs
@@ -15,6 +15,7 @@ public sealed record FabricCardDto(
     string Code,
     string Name,
     string PhotoUrl,
+    string? ThumbnailUrl,
     string? Notes,
     int? DiscountPercent,
     IReadOnlyList<WidthStockDto> Widths,

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricLowStockDto.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Contracts/Fabric/FabricLowStockDto.cs
@@ -29,6 +29,7 @@ public sealed record FabricLowStockDto(
     string Code,
     string Name,
     string PhotoUrl,
+    string? ThumbnailUrl,
     int WidthMm,
     int AvailableMeters,
     int ThresholdMeters,

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/LKvitai.MES.Modules.Frontline.Infrastructure.csproj
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/LKvitai.MES.Modules.Frontline.Infrastructure.csproj
@@ -10,10 +10,13 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Data.SqlClient" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.SharedKernel\LKvitai.MES.BuildingBlocks.SharedKernel.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Frontline.Application\LKvitai.MES.Modules.Frontline.Application.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Frontline.Contracts\LKvitai.MES.Modules.Frontline.Contracts.csproj" />

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhoto.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhoto.cs
@@ -1,0 +1,19 @@
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+
+public sealed class FabricPhoto
+{
+    public Guid Id { get; set; }
+    public string FabricCode { get; set; } = string.Empty;
+    public string OriginalObjectKey { get; set; } = string.Empty;
+    public string ThumbObjectKey { get; set; } = string.Empty;
+    public string? SourceImageUrl { get; set; }
+    public string? SourcePageUrl { get; set; }
+    public string? SourceImageFileName { get; set; }
+    public string? Sha256 { get; set; }
+    public int? ImageWidth { get; set; }
+    public int? ImageHeight { get; set; }
+    public long? FileSizeBytes { get; set; }
+    public bool IsPrimary { get; set; }
+    public DateTimeOffset CreatedAt { get; set; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset? UpdatedAt { get; set; }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoDbContext.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoDbContext.cs
@@ -1,0 +1,43 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+
+public sealed class FabricPhotoDbContext : DbContext
+{
+    public FabricPhotoDbContext(DbContextOptions<FabricPhotoDbContext> options)
+        : base(options)
+    {
+    }
+
+    public DbSet<FabricPhoto> FabricPhotos => Set<FabricPhoto>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasDefaultSchema("public");
+
+        modelBuilder.Entity<FabricPhoto>(entity =>
+        {
+            entity.ToTable("fabric_photos");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.FabricCode).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.OriginalObjectKey).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.ThumbObjectKey).HasMaxLength(500).IsRequired();
+            entity.Property(e => e.SourceImageUrl).HasMaxLength(1000);
+            entity.Property(e => e.SourcePageUrl).HasMaxLength(1000);
+            entity.Property(e => e.SourceImageFileName).HasMaxLength(500);
+            entity.Property(e => e.Sha256).HasMaxLength(64);
+            entity.Property(e => e.CreatedAt).IsRequired();
+            entity.Property(e => e.UpdatedAt);
+            entity.Property(e => e.IsPrimary).IsRequired();
+
+            entity.HasIndex(e => e.FabricCode);
+            entity.HasIndex(e => new { e.FabricCode, e.IsPrimary });
+            entity.HasIndex(e => new { e.FabricCode, e.Sha256 })
+                .IsUnique()
+                .HasFilter("\"Sha256\" IS NOT NULL");
+            entity.HasIndex(e => new { e.FabricCode, e.IsPrimary })
+                .IsUnique()
+                .HasFilter("\"IsPrimary\" = true");
+        });
+    }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoKeyBuilder.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoKeyBuilder.cs
@@ -1,0 +1,38 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+
+public static class FabricPhotoKeyBuilder
+{
+    public const string Prefix = "fabric-photos";
+
+    public static Guid BuildStablePhotoId(string fabricCode, string? sha256, string? originalFile)
+    {
+        var code = NormalizeFabricCode(fabricCode);
+        var fingerprint = !string.IsNullOrWhiteSpace(sha256)
+            ? sha256.Trim().ToLowerInvariant()
+            : (originalFile ?? string.Empty).Trim().ToLowerInvariant();
+        var input = $"{code}|{fingerprint}";
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(input));
+        return new Guid(bytes[..16]);
+    }
+
+    public static string NormalizeFabricCode(string fabricCode) => fabricCode.Trim().ToUpperInvariant();
+
+    public static string BuildOriginalKey(string fabricCode, Guid photoId, string originalFile)
+    {
+        var extension = Path.GetExtension(originalFile);
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            extension = ".jpg";
+        }
+
+        return $"{Prefix}/{NormalizeFabricCode(fabricCode)}/{ToShortId(photoId)}/original{extension}";
+    }
+
+    public static string BuildThumbKey(string fabricCode, Guid photoId)
+        => $"{Prefix}/{NormalizeFabricCode(fabricCode)}/{ToShortId(photoId)}/thumb.webp";
+
+    public static string ToShortId(Guid photoId) => photoId.ToString("N")[..8];
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoService.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Media/FabricPhotoService.cs
@@ -1,0 +1,123 @@
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
+using Microsoft.EntityFrameworkCore;
+
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+
+public sealed record FabricPhotoUrls(string PhotoUrl, string ThumbnailUrl);
+
+public sealed record FabricPhotoStreamResult(Stream Stream, string ContentType, string ETag);
+
+public interface IFabricPhotoService
+{
+    int CacheMaxAgeSeconds { get; }
+    Task<FabricPhotoUrls?> GetPrimaryUrlsAsync(string fabricCode, CancellationToken cancellationToken = default);
+    Task<IReadOnlyDictionary<string, FabricPhotoUrls>> GetPrimaryUrlsAsync(
+        IEnumerable<string> fabricCodes,
+        CancellationToken cancellationToken = default);
+    Task<FabricPhotoStreamResult?> GetPhotoAsync(
+        string fabricCode,
+        string size,
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class FabricPhotoService : IFabricPhotoService
+{
+    private readonly FabricPhotoDbContext _dbContext;
+    private readonly IObjectStorageService _storage;
+
+    public FabricPhotoService(FabricPhotoDbContext dbContext, IObjectStorageService storage)
+    {
+        _dbContext = dbContext;
+        _storage = storage;
+    }
+
+    public int CacheMaxAgeSeconds => Math.Max(1, _storage.Options.CacheMaxAgeSeconds);
+
+    public async Task<FabricPhotoUrls?> GetPrimaryUrlsAsync(string fabricCode, CancellationToken cancellationToken = default)
+    {
+        var map = await GetPrimaryUrlsAsync(new[] { fabricCode }, cancellationToken);
+        return map.TryGetValue(FabricPhotoKeyBuilder.NormalizeFabricCode(fabricCode), out var urls) ? urls : null;
+    }
+
+    public async Task<IReadOnlyDictionary<string, FabricPhotoUrls>> GetPrimaryUrlsAsync(
+        IEnumerable<string> fabricCodes,
+        CancellationToken cancellationToken = default)
+    {
+        var codes = fabricCodes
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(FabricPhotoKeyBuilder.NormalizeFabricCode)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        if (codes.Length == 0)
+        {
+            return new Dictionary<string, FabricPhotoUrls>(StringComparer.OrdinalIgnoreCase);
+        }
+
+        var rows = await _dbContext.FabricPhotos
+            .AsNoTracking()
+            .Where(x => codes.Contains(x.FabricCode))
+            .OrderByDescending(x => x.IsPrimary)
+            .ThenByDescending(x => x.CreatedAt)
+            .Select(x => new { x.FabricCode })
+            .ToListAsync(cancellationToken);
+
+        return rows
+            .GroupBy(x => x.FabricCode, StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(
+                x => x.Key,
+                x => BuildUrls(x.Key),
+                StringComparer.OrdinalIgnoreCase);
+    }
+
+    public async Task<FabricPhotoStreamResult?> GetPhotoAsync(
+        string fabricCode,
+        string size,
+        CancellationToken cancellationToken = default)
+    {
+        var code = FabricPhotoKeyBuilder.NormalizeFabricCode(fabricCode);
+        var photo = await _dbContext.FabricPhotos
+            .AsNoTracking()
+            .Where(x => x.FabricCode == code)
+            .OrderByDescending(x => x.IsPrimary)
+            .ThenByDescending(x => x.CreatedAt)
+            .Select(x => new { x.OriginalObjectKey, x.ThumbObjectKey })
+            .FirstOrDefaultAsync(cancellationToken);
+
+        if (photo is null)
+        {
+            return null;
+        }
+
+        var useThumb = string.Equals(size, "thumb", StringComparison.OrdinalIgnoreCase);
+        var objectKey = useThumb ? photo.ThumbObjectKey : photo.OriginalObjectKey;
+        var etag = await _storage.TryGetObjectEtagAsync(objectKey, cancellationToken);
+        if (etag is null)
+        {
+            return null;
+        }
+
+        var stream = await _storage.GetObjectAsync(objectKey, cancellationToken);
+        return new FabricPhotoStreamResult(stream, useThumb ? "image/webp" : GuessContentType(objectKey), etag);
+    }
+
+    private static FabricPhotoUrls BuildUrls(string fabricCode)
+    {
+        var escaped = Uri.EscapeDataString(fabricCode);
+        return new FabricPhotoUrls(
+            PhotoUrl: $"/api/frontline/fabric/{escaped}/photo?size=original",
+            ThumbnailUrl: $"/api/frontline/fabric/{escaped}/photo?size=thumb");
+    }
+
+    private static string GuessContentType(string objectKey)
+    {
+        var ext = Path.GetExtension(objectKey).ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".png" => "image/png",
+            ".webp" => "image/webp",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Persistence/Migrations/20260514223000_AddFabricPhotos.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Persistence/Migrations/20260514223000_AddFabricPhotos.cs
@@ -1,0 +1,70 @@
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Persistence.Migrations
+{
+    [DbContext(typeof(FabricPhotoDbContext))]
+    [Migration("20260514223000_AddFabricPhotos")]
+    public partial class AddFabricPhotos : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "fabric_photos",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    FabricCode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    OriginalObjectKey = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    ThumbObjectKey = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    SourceImageUrl = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    SourcePageUrl = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    SourceImageFileName = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    Sha256 = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    ImageWidth = table.Column<int>(type: "integer", nullable: true),
+                    ImageHeight = table.Column<int>(type: "integer", nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: true),
+                    IsPrimary = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_fabric_photos", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_fabric_photos_FabricCode",
+                schema: "public",
+                table: "fabric_photos",
+                column: "FabricCode");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_fabric_photos_FabricCode_IsPrimary_unique",
+                schema: "public",
+                table: "fabric_photos",
+                columns: new[] { "FabricCode", "IsPrimary" },
+                unique: true,
+                filter: "\"IsPrimary\" = true");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_fabric_photos_FabricCode_Sha256",
+                schema: "public",
+                table: "fabric_photos",
+                columns: new[] { "FabricCode", "Sha256" },
+                unique: true,
+                filter: "\"Sha256\" IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "fabric_photos",
+                schema: "public");
+        }
+    }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Persistence/Migrations/FabricPhotoDbContextModelSnapshot.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Persistence/Migrations/FabricPhotoDbContextModelSnapshot.cs
@@ -1,0 +1,90 @@
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Frontline.Infrastructure.Persistence.Migrations
+{
+    [DbContext(typeof(FabricPhotoDbContext))]
+    partial class FabricPhotoDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+            modelBuilder
+                .HasDefaultSchema("public")
+                .HasAnnotation("ProductVersion", "8.0.13");
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Frontline.Infrastructure.Media.FabricPhoto", b =>
+            {
+                b.Property<Guid>("Id")
+                    .ValueGeneratedOnAdd()
+                    .HasColumnType("uuid");
+
+                b.Property<DateTimeOffset>("CreatedAt")
+                    .HasColumnType("timestamp with time zone");
+
+                b.Property<string>("FabricCode")
+                    .IsRequired()
+                    .HasMaxLength(50)
+                    .HasColumnType("character varying(50)");
+
+                b.Property<long?>("FileSizeBytes")
+                    .HasColumnType("bigint");
+
+                b.Property<int?>("ImageHeight")
+                    .HasColumnType("integer");
+
+                b.Property<int?>("ImageWidth")
+                    .HasColumnType("integer");
+
+                b.Property<bool>("IsPrimary")
+                    .HasColumnType("boolean");
+
+                b.Property<string>("OriginalObjectKey")
+                    .IsRequired()
+                    .HasMaxLength(500)
+                    .HasColumnType("character varying(500)");
+
+                b.Property<string>("Sha256")
+                    .HasMaxLength(64)
+                    .HasColumnType("character varying(64)");
+
+                b.Property<string>("SourceImageFileName")
+                    .HasMaxLength(500)
+                    .HasColumnType("character varying(500)");
+
+                b.Property<string>("SourceImageUrl")
+                    .HasMaxLength(1000)
+                    .HasColumnType("character varying(1000)");
+
+                b.Property<string>("SourcePageUrl")
+                    .HasMaxLength(1000)
+                    .HasColumnType("character varying(1000)");
+
+                b.Property<string>("ThumbObjectKey")
+                    .IsRequired()
+                    .HasMaxLength(500)
+                    .HasColumnType("character varying(500)");
+
+                b.Property<DateTimeOffset?>("UpdatedAt")
+                    .HasColumnType("timestamp with time zone");
+
+                b.HasKey("Id");
+
+                b.HasIndex("FabricCode");
+
+                b.HasIndex("FabricCode", "IsPrimary")
+                    .IsUnique()
+                    .HasFilter("\"IsPrimary\" = true");
+
+                b.HasIndex("FabricCode", "Sha256")
+                    .IsUnique()
+                    .HasFilter("\"Sha256\" IS NOT NULL");
+
+                b.ToTable("fabric_photos", "public");
+            });
+        }
+    }
+}

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Sql/SqlFabricQueryService.cs
@@ -165,6 +165,7 @@ public sealed class SqlFabricQueryService : IFabricQueryService
             alternatives.Add(new FabricAlternativeDto(
                 Code:         ReadString(reader, "Code", string.Empty),
                 PhotoUrl:     ReadString(reader, "PhotoUrl", PlaceholderPhotoUrl),
+                ThumbnailUrl: null,
                 WidthMm:      ReadInt(reader, "WidthMm"),
                 Status:       ReadStatus(reader, "Status"),
                 StockMeters:  ReadIntOrNull(reader, "StockMeters"),
@@ -197,6 +198,7 @@ public sealed class SqlFabricQueryService : IFabricQueryService
             Code:            code,
             Name:            name,
             PhotoUrl:        photoUrl,
+            ThumbnailUrl:    null,
             Notes:           notes,
             DiscountPercent: discount,
             Widths:          widths,
@@ -246,6 +248,7 @@ public sealed class SqlFabricQueryService : IFabricQueryService
                 Code:             ReadString(reader, "Code", string.Empty),
                 Name:             ReadString(reader, "Name", string.Empty),
                 PhotoUrl:         ReadString(reader, "PhotoUrl", PlaceholderPhotoUrl),
+                ThumbnailUrl:     null,
                 WidthMm:          ReadInt(reader, "WidthMm"),
                 AvailableMeters:  ReadInt(reader, "AvailableMeters"),
                 ThresholdMeters:  ReadInt(reader, "ThresholdMeters"),

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Stub/StubFabricQueryService.cs
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.Infrastructure/Stub/StubFabricQueryService.cs
@@ -156,6 +156,7 @@ public sealed class StubFabricQueryService : IFabricQueryService
                 Code: "R120",
                 Name: "Linen texture, warm grey",
                 PhotoUrl: PlaceholderPhoto,
+                ThumbnailUrl: null,
                 Notes: "Use with white bottom bar. Similar tone to R118.",
                 DiscountPercent: 15,
                 Widths: new WidthStockDto[]
@@ -167,14 +168,15 @@ public sealed class StubFabricQueryService : IFabricQueryService
                 SelectedWidthMm: null,
                 Alternatives: new FabricAlternativeDto[]
                 {
-                    new("R118", PlaceholderPhoto, 2000, FabricAvailabilityStatus.Enough, 34, null),
-                    new("R124", PlaceholderPhoto, 2000, FabricAvailabilityStatus.Low,    11, new DateOnly(2026, 5, 6)),
-                    new("R130", PlaceholderPhoto, 2000, FabricAvailabilityStatus.Enough, 68, null),
+                    new("R118", PlaceholderPhoto, null, 2000, FabricAvailabilityStatus.Enough, 34, null),
+                    new("R124", PlaceholderPhoto, null, 2000, FabricAvailabilityStatus.Low,    11, new DateOnly(2026, 5, 6)),
+                    new("R130", PlaceholderPhoto, null, 2000, FabricAvailabilityStatus.Enough, 68, null),
                 }),
             ["DN45"] = new(
                 Code: "DN45",
                 Name: "Day-night graphite stripe",
                 PhotoUrl: PlaceholderPhoto,
+                ThumbnailUrl: null,
                 Notes: null,
                 DiscountPercent: null,
                 Widths: new WidthStockDto[]
@@ -185,13 +187,14 @@ public sealed class StubFabricQueryService : IFabricQueryService
                 SelectedWidthMm: null,
                 Alternatives: new FabricAlternativeDto[]
                 {
-                    new("DN47", PlaceholderPhoto, 1800, FabricAvailabilityStatus.Enough, 56, null),
-                    new("DN51", PlaceholderPhoto, 1800, FabricAvailabilityStatus.Low,    14, new DateOnly(2026, 5, 9)),
+                    new("DN47", PlaceholderPhoto, null, 1800, FabricAvailabilityStatus.Enough, 56, null),
+                    new("DN51", PlaceholderPhoto, null, 1800, FabricAvailabilityStatus.Low,    14, new DateOnly(2026, 5, 9)),
                 }),
             ["V78"] = new(
                 Code: "V78",
                 Name: "Vertical blind sand",
                 PhotoUrl: PlaceholderPhoto,
+                ThumbnailUrl: null,
                 Notes: "Pairs naturally with V80 for two-tone installs.",
                 DiscountPercent: null,
                 Widths: new WidthStockDto[]
@@ -201,7 +204,7 @@ public sealed class StubFabricQueryService : IFabricQueryService
                 SelectedWidthMm: null,
                 Alternatives: new FabricAlternativeDto[]
                 {
-                    new("V80", PlaceholderPhoto, 2500, FabricAvailabilityStatus.Enough, 11, null),
+                    new("V80", PlaceholderPhoto, null, 2500, FabricAvailabilityStatus.Enough, 11, null),
                 }),
         };
     }
@@ -221,6 +224,7 @@ public sealed class StubFabricQueryService : IFabricQueryService
                 Code:             code,
                 Name:             name,
                 PhotoUrl:         "/img/fabric_pl.png",
+                ThumbnailUrl:     null,
                 WidthMm:          widthMm,
                 AvailableMeters:  available,
                 ThresholdMeters:  25,

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
@@ -139,6 +139,13 @@
 
                         <article class="fabric-card" aria-live="polite">
                             <div class="fabric-hero" role="img" aria-label="@($"{_result.Code} fabric photo")">
+                                @if (TryPhotoUrl(_result.ThumbnailUrl ?? _result.PhotoUrl) is { } photoUrl)
+                                {
+                                    <img src="@photoUrl"
+                                         alt=""
+                                         loading="lazy"
+                                         decoding="async" />
+                                }
                                 @if (_result.DiscountPercent is { } d)
                                 {
                                     <span class="fabric-hero__ribbon">−@d % · CAMPAIGN</span>
@@ -221,7 +228,15 @@
                                                 <button class="alt-card"
                                                         type="button"
                                                         @onclick="@(() => OpenAlternativeAsync(captured))">
-                                                    <div class="alt-img @AltImgClass(captured.Code)"></div>
+                                                    <div class="alt-img @AltImgClass(captured.Code)">
+                                                        @if (TryPhotoUrl(captured.ThumbnailUrl ?? captured.PhotoUrl) is { } altPhotoUrl)
+                                                        {
+                                                            <img src="@altPhotoUrl"
+                                                                 alt=""
+                                                                 loading="lazy"
+                                                                 decoding="async" />
+                                                        }
+                                                    </div>
                                                     <div class="alt-body">
                                                         <div class="alt-body__code">@alt.Code · @alt.WidthMm</div>
                                                         <div class="alt-body__row">
@@ -455,6 +470,12 @@
             _ => "alt-img--red",
         };
     }
+
+    private static string? TryPhotoUrl(string? url)
+        => string.IsNullOrWhiteSpace(url) ||
+           string.Equals(url, "/img/fabric_pl.png", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : url;
 
     /// <summary>
     /// Builds the absolute URL the sidebar QR points at. With no result on

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLookup.razor
@@ -136,16 +136,19 @@
                     {
                         var widths = _result.Widths;
                         var selected = widths.FirstOrDefault(w => w.WidthMm == _selectedWidth) ?? widths[0];
+                        var heroPhotoUrl = TryPhotoUrl(_result.ThumbnailUrl ?? _result.PhotoUrl);
 
                         <article class="fabric-card" aria-live="polite">
-                            <div class="fabric-hero" role="img" aria-label="@($"{_result.Code} fabric photo")">
-                                @if (TryPhotoUrl(_result.ThumbnailUrl ?? _result.PhotoUrl) is { } photoUrl)
+                            <div class="fabric-hero @(heroPhotoUrl is null ? "is-missing" : "has-photo")" role="img" aria-label="@($"{_result.Code} fabric photo")">
+                                @if (heroPhotoUrl is not null)
                                 {
-                                    <img src="@photoUrl"
+                                    <img src="@heroPhotoUrl"
                                          alt=""
                                          loading="lazy"
-                                         decoding="async" />
+                                         decoding="async"
+                                         onerror="this.style.display='none';this.parentElement.classList.remove('has-photo');this.parentElement.classList.add('is-missing');" />
                                 }
+                                <span class="photo-placeholder-label">No photo</span>
                                 @if (_result.DiscountPercent is { } d)
                                 {
                                     <span class="fabric-hero__ribbon">−@d % · CAMPAIGN</span>
@@ -225,17 +228,20 @@
                                             @foreach (var alt in _result.Alternatives)
                                             {
                                                 var captured = alt;
+                                                var altPhotoUrl = TryPhotoUrl(captured.ThumbnailUrl ?? captured.PhotoUrl);
                                                 <button class="alt-card"
                                                         type="button"
                                                         @onclick="@(() => OpenAlternativeAsync(captured))">
-                                                    <div class="alt-img @AltImgClass(captured.Code)">
-                                                        @if (TryPhotoUrl(captured.ThumbnailUrl ?? captured.PhotoUrl) is { } altPhotoUrl)
+                                                    <div class="alt-img @AltImgClass(captured.Code) @(altPhotoUrl is null ? "is-missing" : "has-photo")">
+                                                        @if (altPhotoUrl is not null)
                                                         {
                                                             <img src="@altPhotoUrl"
                                                                  alt=""
                                                                  loading="lazy"
-                                                                 decoding="async" />
+                                                                 decoding="async"
+                                                                 onerror="this.style.display='none';this.parentElement.classList.remove('has-photo');this.parentElement.classList.add('is-missing');" />
                                                         }
+                                                        <span class="photo-placeholder-label">No photo</span>
                                                     </div>
                                                     <div class="alt-body">
                                                         <div class="alt-body__code">@alt.Code · @alt.WidthMm</div>

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
@@ -172,16 +172,19 @@
                     }
                     @foreach (var r in _rows)
                     {
+                        var thumbUrl = TryPhotoUrl(r.ThumbnailUrl ?? r.PhotoUrl);
                         <tr>
                             <td>
-                                <span class="row-thumb @ThumbClass(r.Code)">
-                                    @if (TryPhotoUrl(r.ThumbnailUrl ?? r.PhotoUrl) is { } thumbUrl)
+                                <span class="row-thumb @ThumbClass(r.Code) @(thumbUrl is null ? "is-missing" : "has-photo")">
+                                    @if (thumbUrl is not null)
                                     {
                                         <img src="@thumbUrl"
                                              alt=""
                                              loading="lazy"
-                                             decoding="async" />
+                                             decoding="async"
+                                             onerror="this.style.display='none';this.parentElement.classList.remove('has-photo');this.parentElement.classList.add('is-missing');" />
                                     }
+                                    <span class="photo-placeholder-label">No photo</span>
                                 </span>
                             </td>
                             <td><a class="fabric-link" href="@($"fabric?code={r.Code}")">@r.Code</a></td>

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/Pages/FabricLowStock.razor
@@ -173,7 +173,17 @@
                     @foreach (var r in _rows)
                     {
                         <tr>
-                            <td><span class="row-thumb @ThumbClass(r.Code)"></span></td>
+                            <td>
+                                <span class="row-thumb @ThumbClass(r.Code)">
+                                    @if (TryPhotoUrl(r.ThumbnailUrl ?? r.PhotoUrl) is { } thumbUrl)
+                                    {
+                                        <img src="@thumbUrl"
+                                             alt=""
+                                             loading="lazy"
+                                             decoding="async" />
+                                    }
+                                </span>
+                            </td>
                             <td><a class="fabric-link" href="@($"fabric?code={r.Code}")">@r.Code</a></td>
                             <td><span class="fabric-name-cell">@r.Name</span></td>
                             <td class="mono">@r.WidthMm mm</td>
@@ -631,6 +641,12 @@
         2 => "row-thumb--green",
         _ => "row-thumb--red",
     };
+
+    private static string? TryPhotoUrl(string? url)
+        => string.IsNullOrWhiteSpace(url) ||
+           string.Equals(url, "/img/fabric_pl.png", StringComparison.OrdinalIgnoreCase)
+            ? null
+            : url;
 
     private static string FormatLastChecked(DateTimeOffset? value)
     {

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
@@ -216,11 +216,19 @@ button, input, select { font: inherit; }
 }
 .fabric-hero {
   position: relative;
-  display: block; width: 100%; aspect-ratio: 16 / 10;
+  display: block; width: 100%; aspect-ratio: 16 / 10; overflow: hidden;
   background:
     linear-gradient(135deg, rgb(255 255 255 / 35%), transparent),
     repeating-linear-gradient(45deg, #d7d1c4 0, #d7d1c4 7px, #c9c1b3 7px, #c9c1b3 14px);
   border-bottom: 1px solid var(--n-150);
+}
+.fabric-hero img,
+.alt-img img,
+.row-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
 }
 .fabric-hero--blue {
   background:
@@ -360,7 +368,7 @@ button, input, select { font: inherit; }
 }
 .alt-card:hover { border-color: var(--accent-500); }
 .alt-img {
-  display: block; width: 100%; aspect-ratio: 4 / 3;
+  display: block; width: 100%; aspect-ratio: 4 / 3; overflow: hidden;
   background: repeating-linear-gradient(135deg, #e1ded8 0, #e1ded8 8px, #d2ccc0 8px, #d2ccc0 16px);
   border-bottom: 1px solid var(--n-150);
 }
@@ -609,7 +617,7 @@ td.is-meters.is-disc { color: var(--n-400); }
 /* Row thumbnail */
 .row-thumb {
   display: block; width: 36px; height: 28px;
-  border: 1px solid var(--n-150); border-radius: var(--r-xs);
+  border: 1px solid var(--n-150); border-radius: var(--r-xs); overflow: hidden;
   background: repeating-linear-gradient(135deg, #d7d1c4 0, #d7d1c4 6px, #c9c1b3 6px, #c9c1b3 12px);
 }
 .row-thumb--blue  { background: repeating-linear-gradient(135deg, #cfd9dc 0, #cfd9dc 6px, #bdccd0 6px, #bdccd0 12px); }

--- a/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
+++ b/src/Modules/Frontline/LKvitai.MES.Modules.Frontline.WebUI/wwwroot/css/fabric.css
@@ -222,6 +222,22 @@ button, input, select { font: inherit; }
     repeating-linear-gradient(45deg, #d7d1c4 0, #d7d1c4 7px, #c9c1b3 7px, #c9c1b3 14px);
   border-bottom: 1px solid var(--n-150);
 }
+.photo-placeholder-label {
+  position: absolute;
+  left: 8px;
+  bottom: 7px;
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 6px;
+  border-radius: 3px;
+  background: rgb(255 255 255 / 82%);
+  color: var(--n-600);
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+.has-photo .photo-placeholder-label { display: none; }
 .fabric-hero img,
 .alt-img img,
 .row-thumb img {
@@ -368,6 +384,7 @@ button, input, select { font: inherit; }
 }
 .alt-card:hover { border-color: var(--accent-500); }
 .alt-img {
+  position: relative;
   display: block; width: 100%; aspect-ratio: 4 / 3; overflow: hidden;
   background: repeating-linear-gradient(135deg, #e1ded8 0, #e1ded8 8px, #d2ccc0 8px, #d2ccc0 16px);
   border-bottom: 1px solid var(--n-150);
@@ -616,9 +633,17 @@ td.is-meters.is-disc { color: var(--n-400); }
 
 /* Row thumbnail */
 .row-thumb {
+  position: relative;
   display: block; width: 36px; height: 28px;
   border: 1px solid var(--n-150); border-radius: var(--r-xs); overflow: hidden;
   background: repeating-linear-gradient(135deg, #d7d1c4 0, #d7d1c4 6px, #c9c1b3 6px, #c9c1b3 12px);
+}
+.row-thumb .photo-placeholder-label {
+  left: 3px;
+  bottom: 3px;
+  padding: 1px 3px;
+  font-size: 6.5px;
+  line-height: 1;
 }
 .row-thumb--blue  { background: repeating-linear-gradient(135deg, #cfd9dc 0, #cfd9dc 6px, #bdccd0 6px, #bdccd0 12px); }
 .row-thumb--green { background: repeating-linear-gradient(135deg, #cedbcf 0, #cedbcf 6px, #bdd0be 6px, #bdd0be 12px); }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Configuration/ItemImageOptions.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
 
 namespace LKvitai.MES.Modules.Warehouse.Api.Configuration;
 
@@ -18,6 +19,16 @@ public sealed class ItemImageOptions
     public double MinSearchScore { get; init; } = DefaultMinSearchScore;
 
     public const double DefaultMinSearchScore = 0.35d;
+
+    public ObjectStorageOptions ToObjectStorageOptions() => new()
+    {
+        Endpoint = Endpoint,
+        BucketName = BucketName,
+        UseSsl = UseSsl,
+        AccessKey = AccessKey,
+        SecretKey = SecretKey,
+        CacheMaxAgeSeconds = CacheMaxAgeSeconds
+    };
 
     public static ItemImageOptions FromConfiguration(IConfiguration configuration)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Dockerfile
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Dockerfile
@@ -19,6 +19,7 @@ COPY src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/LKvitai.MES.M
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/LKvitai.MES.BuildingBlocks.SharedKernel.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/LKvitai.MES.BuildingBlocks.PortalAuth.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/LKvitai.MES.BuildingBlocks.ObjectStorage.csproj BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/
 
 # Restore dependencies
 RUN dotnet restore Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj
@@ -35,6 +36,7 @@ COPY src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/ Modules/Ware
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/ BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/ BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/
 COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/ BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/
+COPY src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/ BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/
 
 # Build and publish
 WORKDIR /src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj
@@ -43,6 +43,7 @@
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Projections\LKvitai.MES.Modules.Warehouse.Projections.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Sagas\LKvitai.MES.Modules.Warehouse.Sagas.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Integration\LKvitai.MES.Modules.Warehouse.Integration.csproj" />
+    <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj" />
     <ProjectReference Include="..\..\..\BuildingBlocks\LKvitai.MES.BuildingBlocks.PortalAuth\LKvitai.MES.BuildingBlocks.PortalAuth.csproj" />
   </ItemGroup>
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -1,4 +1,5 @@
 using LKvitai.MES.Modules.Warehouse.Api.Configuration;
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
 using LKvitai.MES.Modules.Warehouse.Api.ErrorHandling;
 using LKvitai.MES.Modules.Warehouse.Api.Middleware;
 using LKvitai.MES.Modules.Warehouse.Api.Observability;
@@ -73,6 +74,7 @@ builder.Services.Configure<OAuthOptions>(builder.Configuration.GetSection(OAuthO
 builder.Services.Configure<MfaOptions>(builder.Configuration.GetSection(MfaOptions.SectionName));
 builder.Services.Configure<LabelPrintingConfig>(builder.Configuration.GetSection("LabelPrinting"));
 builder.Services.AddSingleton(_ => ItemImageOptions.FromConfiguration(builder.Configuration));
+builder.Services.AddSingleton(sp => sp.GetRequiredService<ItemImageOptions>().ToObjectStorageOptions());
 builder.Services.AddSingleton<IMinioClient>(sp =>
 {
     var options = sp.GetRequiredService<ItemImageOptions>();
@@ -82,6 +84,7 @@ builder.Services.AddSingleton<IMinioClient>(sp =>
         .WithSSL(options.UseSsl)
         .Build();
 });
+builder.Services.AddSingleton<IObjectStorageService, MinioObjectStorageService>();
 builder.Services.AddSingleton<IItemImageStorageService, ItemImageStorageService>();
 builder.Services.AddScoped<IItemPhotoService, ItemPhotoService>();
 builder.Services.AddScoped<IItemImageSearchCapabilityService, ItemImageSearchCapabilityService>();

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageStorageService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/ItemImageStorageService.cs
@@ -1,7 +1,5 @@
 using LKvitai.MES.Modules.Warehouse.Api.Configuration;
-using Minio;
-using Minio.DataModel.Args;
-using Minio.Exceptions;
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
 
 namespace LKvitai.MES.Modules.Warehouse.Api.Services;
 
@@ -24,20 +22,14 @@ public interface IItemImageStorageService
 
 public sealed class ItemImageStorageService : IItemImageStorageService
 {
-    private readonly IMinioClient _minioClient;
-    private readonly ILogger<ItemImageStorageService> _logger;
-    private readonly SemaphoreSlim _availabilityLock = new(1, 1);
-
-    private DateTimeOffset _lastAvailabilityCheck = DateTimeOffset.MinValue;
-    private ItemImageAvailability _lastAvailability = new(false, "ItemImages not initialized.");
+    private readonly IObjectStorageService _objectStorage;
 
     public ItemImageStorageService(
-        IMinioClient minioClient,
+        IObjectStorageService objectStorage,
         ItemImageOptions options,
         ILogger<ItemImageStorageService> logger)
     {
-        _minioClient = minioClient;
-        _logger = logger;
+        _objectStorage = objectStorage;
         Options = options;
     }
 
@@ -45,58 +37,14 @@ public sealed class ItemImageStorageService : IItemImageStorageService
 
     public async Task<ItemImageAvailability> EnsureAvailableAsync(CancellationToken cancellationToken = default)
     {
-        if (DateTimeOffset.UtcNow - _lastAvailabilityCheck < TimeSpan.FromSeconds(30))
+        var missing = GetMissingConfigurationKeys();
+        if (missing.Count > 0)
         {
-            return _lastAvailability;
+            return new ItemImageAvailability(false, $"Missing ItemImages configuration: {string.Join(", ", missing)}");
         }
 
-        await _availabilityLock.WaitAsync(cancellationToken);
-        try
-        {
-            if (DateTimeOffset.UtcNow - _lastAvailabilityCheck < TimeSpan.FromSeconds(30))
-            {
-                return _lastAvailability;
-            }
-
-            var missing = GetMissingConfigurationKeys();
-            if (missing.Count > 0)
-            {
-                _lastAvailability = new ItemImageAvailability(
-                    false,
-                    $"Missing ItemImages configuration: {string.Join(", ", missing)}");
-                _lastAvailabilityCheck = DateTimeOffset.UtcNow;
-                return _lastAvailability;
-            }
-
-            try
-            {
-                var exists = await _minioClient.BucketExistsAsync(
-                    new BucketExistsArgs().WithBucket(Options.BucketName),
-                    cancellationToken);
-
-                _lastAvailability = exists
-                    ? new ItemImageAvailability(true, null)
-                    : new ItemImageAvailability(false, $"Bucket '{Options.BucketName}' does not exist.");
-            }
-            catch (AccessDeniedException)
-            {
-                _lastAvailability = new ItemImageAvailability(
-                    false,
-                    $"Access denied for bucket '{Options.BucketName}'.");
-            }
-            catch (MinioException ex)
-            {
-                _logger.LogWarning(ex, "Failed validating MinIO access.");
-                _lastAvailability = new ItemImageAvailability(false, ex.Message);
-            }
-
-            _lastAvailabilityCheck = DateTimeOffset.UtcNow;
-            return _lastAvailability;
-        }
-        finally
-        {
-            _availabilityLock.Release();
-        }
+        var availability = await _objectStorage.EnsureAvailableAsync(cancellationToken);
+        return new ItemImageAvailability(availability.IsAvailable, availability.Reason);
     }
 
     public async Task PutObjectAsync(
@@ -106,54 +54,22 @@ public sealed class ItemImageStorageService : IItemImageStorageService
         string contentType,
         CancellationToken cancellationToken = default)
     {
-        await _minioClient.PutObjectAsync(
-            new PutObjectArgs()
-                .WithBucket(Options.BucketName)
-                .WithObject(objectKey)
-                .WithStreamData(stream)
-                .WithObjectSize(size)
-                .WithContentType(contentType),
-            cancellationToken);
+        await _objectStorage.PutObjectAsync(objectKey, stream, size, contentType, cancellationToken);
     }
 
     public async Task<MemoryStream> GetObjectAsync(string objectKey, CancellationToken cancellationToken = default)
     {
-        var result = new MemoryStream();
-        await _minioClient.GetObjectAsync(
-            new GetObjectArgs()
-                .WithBucket(Options.BucketName)
-                .WithObject(objectKey)
-                .WithCallbackStream(stream => stream.CopyTo(result)),
-            cancellationToken);
-        result.Position = 0;
-        return result;
+        return await _objectStorage.GetObjectAsync(objectKey, cancellationToken);
     }
 
     public async Task<string?> TryGetObjectEtagAsync(string objectKey, CancellationToken cancellationToken = default)
     {
-        try
-        {
-            var stat = await _minioClient.StatObjectAsync(
-                new StatObjectArgs()
-                    .WithBucket(Options.BucketName)
-                    .WithObject(objectKey),
-                cancellationToken);
-
-            return stat.ETag?.Trim('"');
-        }
-        catch (ObjectNotFoundException)
-        {
-            return null;
-        }
+        return await _objectStorage.TryGetObjectEtagAsync(objectKey, cancellationToken);
     }
 
     public async Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken = default)
     {
-        await _minioClient.RemoveObjectAsync(
-            new RemoveObjectArgs()
-                .WithBucket(Options.BucketName)
-                .WithObject(objectKey),
-            cancellationToken);
+        await _objectStorage.DeleteObjectAsync(objectKey, cancellationToken);
     }
 
     private List<string> GetMissingConfigurationKeys()

--- a/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/FabricPhotoImporterTests.cs
+++ b/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/FabricPhotoImporterTests.cs
@@ -51,6 +51,58 @@ public class FabricPhotoImporterTests
     }
 
     [Fact]
+    public async Task ImportAsync_WhenPrimaryDuplicateIsFollowedByNonPrimary_KeepsPrimary()
+    {
+        using var fixture = FabricImportFixture.CreateWithDuplicateRows(primaryFirst: true);
+        await using var db = CreateDbContext();
+        var importer = new FabricPhotoImporterService(db, new FakeObjectStorageService(), TextWriter.Null);
+
+        var result = await importer.ImportAsync(fixture.Root);
+
+        result.Imported.Should().Be(1);
+        result.Updated.Should().Be(1);
+        db.FabricPhotos.Should().ContainSingle(x =>
+            x.FabricCode == "R416" &&
+            x.Sha256 == FabricImportFixture.DuplicateSha &&
+            x.IsPrimary);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenNonPrimaryDuplicateIsFollowedByPrimary_PromotesToPrimary()
+    {
+        using var fixture = FabricImportFixture.CreateWithDuplicateRows(primaryFirst: false);
+        await using var db = CreateDbContext();
+        var importer = new FabricPhotoImporterService(db, new FakeObjectStorageService(), TextWriter.Null);
+
+        var result = await importer.ImportAsync(fixture.Root);
+
+        result.Imported.Should().Be(1);
+        result.Updated.Should().Be(1);
+        db.FabricPhotos.Should().ContainSingle(x =>
+            x.FabricCode == "R416" &&
+            x.Sha256 == FabricImportFixture.DuplicateSha &&
+            x.IsPrimary);
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenDuplicatePackageIsRunRepeatedly_RemainsIdempotent()
+    {
+        using var fixture = FabricImportFixture.CreateWithDuplicateRows(primaryFirst: true);
+        await using var db = CreateDbContext();
+        var importer = new FabricPhotoImporterService(db, new FakeObjectStorageService(), TextWriter.Null);
+
+        await importer.ImportAsync(fixture.Root);
+        var second = await importer.ImportAsync(fixture.Root);
+
+        second.Imported.Should().Be(0);
+        second.Updated.Should().Be(2);
+        db.FabricPhotos.Should().ContainSingle(x =>
+            x.FabricCode == "R416" &&
+            x.Sha256 == FabricImportFixture.DuplicateSha &&
+            x.IsPrimary);
+    }
+
+    [Fact]
     public async Task FabricPhotoService_MapsFabricCodeToPhotoUrlsWithoutWarehouseItemPhoto()
     {
         await using var db = CreateDbContext();
@@ -130,6 +182,8 @@ internal sealed class FakeObjectStorageService : IObjectStorageService
 
 internal sealed class FabricImportFixture : IDisposable
 {
+    public const string DuplicateSha = "c54f7dbf2179cc9fe2624bb43d69a181f80e6cf6516af6b7b5cde80f4c5fceaa";
+
     private FabricImportFixture(string root, string csvPath)
     {
         Root = root;
@@ -156,6 +210,37 @@ internal sealed class FabricImportFixture : IDisposable
             FabricCode,FabricGroup,SourceImageUrl,SourcePageUrl,OriginalFile,ThumbFile,ImageWidth,ImageHeight,FileSizeBytes,Sha256,IsPrimary,Notes
             R85,Group,https://example.test/R85.JPG,https://example.test/page,images/original/R85.JPG,images/thumb/R85.webp,10,12,3,abcdef,true,
             """);
+
+        return new FabricImportFixture(root, csvPath);
+    }
+
+    public static FabricImportFixture CreateWithDuplicateRows(bool primaryFirst)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "fabric-import-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "output"));
+        Directory.CreateDirectory(Path.Combine(root, "images", "original"));
+        Directory.CreateDirectory(Path.Combine(root, "images", "thumb"));
+
+        File.WriteAllBytes(Path.Combine(root, "images", "original", "R416_A.JPG"), new byte[] { 1, 2, 3 });
+        File.WriteAllBytes(Path.Combine(root, "images", "original", "R416_B.JPG"), new byte[] { 4, 5, 6 });
+        File.WriteAllBytes(Path.Combine(root, "images", "thumb", "R416.webp"), new byte[] { 7, 8, 9 });
+        File.WriteAllBytes(Path.Combine(root, "images", "thumb", "R416_2.webp"), new byte[] { 10, 11, 12 });
+
+        var primaryRow =
+            $"R416,Group,https://example.test/R416_A.JPG,https://example.test/page,images/original/R416_A.JPG,images/thumb/R416.webp,10,12,3,{DuplicateSha},true,";
+        var nonPrimaryRow =
+            $"R416,Group,https://example.test/R416_B.JPG,https://example.test/page,images/original/R416_B.JPG,images/thumb/R416_2.webp,10,12,3,{DuplicateSha},false,";
+        var rows = primaryFirst
+            ? new[] { primaryRow, nonPrimaryRow }
+            : new[] { nonPrimaryRow, primaryRow };
+
+        var csvPath = Path.Combine(root, "output", "fabric_photos.csv");
+        File.WriteAllText(
+            csvPath,
+            "FabricCode,FabricGroup,SourceImageUrl,SourcePageUrl,OriginalFile,ThumbFile,ImageWidth,ImageHeight,FileSizeBytes,Sha256,IsPrimary,Notes" +
+            Environment.NewLine +
+            string.Join(Environment.NewLine, rows) +
+            Environment.NewLine);
 
         return new FabricImportFixture(root, csvPath);
     }

--- a/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/FabricPhotoImporterTests.cs
+++ b/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/FabricPhotoImporterTests.cs
@@ -1,0 +1,170 @@
+using FabricPhotoImporter;
+using FluentAssertions;
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Frontline.Unit;
+
+public class FabricPhotoImporterTests
+{
+    [Fact]
+    public void CsvReader_ReadsPreparedPackageShape()
+    {
+        using var fixture = FabricImportFixture.Create();
+
+        var rows = FabricPhotoCsvReader.Read(fixture.CsvPath);
+
+        rows.Should().ContainSingle();
+        rows[0].FabricCode.Should().Be("R85");
+        rows[0].SourceImageUrl.Should().Be("https://example.test/R85.JPG");
+        rows[0].IsPrimary.Should().BeTrue();
+    }
+
+    [Fact]
+    public void KeyBuilder_UsesExpectedFabricPhotoPrefix()
+    {
+        var id = FabricPhotoKeyBuilder.BuildStablePhotoId("r85", "ABCDEF", "images/original/R85.JPG");
+
+        FabricPhotoKeyBuilder.BuildOriginalKey("r85", id, "images/original/R85.JPG")
+            .Should().Be($"fabric-photos/R85/{id:N}"[..26] + $"/original.JPG");
+        FabricPhotoKeyBuilder.BuildThumbKey("r85", id)
+            .Should().Be($"fabric-photos/R85/{id:N}"[..26] + $"/thumb.webp");
+    }
+
+    [Fact]
+    public async Task ImportAsync_WhenRunTwice_UpdatesExistingFabricPhoto()
+    {
+        using var fixture = FabricImportFixture.Create();
+        await using var db = CreateDbContext();
+        var storage = new FakeObjectStorageService();
+        var importer = new FabricPhotoImporterService(db, storage, TextWriter.Null);
+
+        var first = await importer.ImportAsync(fixture.Root);
+        var second = await importer.ImportAsync(fixture.Root);
+
+        first.Imported.Should().Be(1);
+        second.Updated.Should().Be(1);
+        db.FabricPhotos.Should().ContainSingle(x => x.FabricCode == "R85");
+        storage.UploadedKeys.Should().Contain(key => key.StartsWith("fabric-photos/R85/", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task FabricPhotoService_MapsFabricCodeToPhotoUrlsWithoutWarehouseItemPhoto()
+    {
+        await using var db = CreateDbContext();
+        var photoId = FabricPhotoKeyBuilder.BuildStablePhotoId("R85", "abc", "R85.JPG");
+        db.FabricPhotos.Add(new FabricPhoto
+        {
+            Id = photoId,
+            FabricCode = "R85",
+            OriginalObjectKey = FabricPhotoKeyBuilder.BuildOriginalKey("R85", photoId, "R85.JPG"),
+            ThumbObjectKey = FabricPhotoKeyBuilder.BuildThumbKey("R85", photoId),
+            Sha256 = "abc",
+            IsPrimary = true
+        });
+        await db.SaveChangesAsync();
+
+        var sut = new FabricPhotoService(db, new FakeObjectStorageService());
+
+        var urls = await sut.GetPrimaryUrlsAsync("R85");
+
+        urls.Should().NotBeNull();
+        urls!.ThumbnailUrl.Should().Be("/api/frontline/fabric/R85/photo?size=thumb");
+        urls.PhotoUrl.Should().Be("/api/frontline/fabric/R85/photo?size=original");
+    }
+
+    private static FabricPhotoDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<FabricPhotoDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString("N"))
+            .Options;
+        return new FabricPhotoDbContext(options);
+    }
+}
+
+internal sealed class FakeObjectStorageService : IObjectStorageService
+{
+    private readonly Dictionary<string, byte[]> _objects = new(StringComparer.Ordinal);
+
+    public ObjectStorageOptions Options { get; } = new()
+    {
+        Endpoint = "localhost:9000",
+        BucketName = "test",
+        AccessKey = "test",
+        SecretKey = "test",
+        CacheMaxAgeSeconds = 60
+    };
+
+    public List<string> UploadedKeys { get; } = new();
+
+    public Task<ObjectStorageAvailability> EnsureAvailableAsync(CancellationToken cancellationToken = default)
+        => Task.FromResult(new ObjectStorageAvailability(true, null));
+
+    public async Task PutObjectAsync(
+        string objectKey,
+        Stream stream,
+        long size,
+        string contentType,
+        CancellationToken cancellationToken = default)
+    {
+        using var buffer = new MemoryStream();
+        await stream.CopyToAsync(buffer, cancellationToken);
+        _objects[objectKey] = buffer.ToArray();
+        UploadedKeys.Add(objectKey);
+    }
+
+    public Task<MemoryStream> GetObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult(new MemoryStream(_objects.GetValueOrDefault(objectKey, Array.Empty<byte>())));
+
+    public Task<string?> TryGetObjectEtagAsync(string objectKey, CancellationToken cancellationToken = default)
+        => Task.FromResult(_objects.ContainsKey(objectKey) ? "etag" : null);
+
+    public Task DeleteObjectAsync(string objectKey, CancellationToken cancellationToken = default)
+    {
+        _objects.Remove(objectKey);
+        return Task.CompletedTask;
+    }
+}
+
+internal sealed class FabricImportFixture : IDisposable
+{
+    private FabricImportFixture(string root, string csvPath)
+    {
+        Root = root;
+        CsvPath = csvPath;
+    }
+
+    public string Root { get; }
+    public string CsvPath { get; }
+
+    public static FabricImportFixture Create()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "fabric-import-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(Path.Combine(root, "output"));
+        Directory.CreateDirectory(Path.Combine(root, "images", "original"));
+        Directory.CreateDirectory(Path.Combine(root, "images", "thumb"));
+
+        File.WriteAllBytes(Path.Combine(root, "images", "original", "R85.JPG"), new byte[] { 1, 2, 3 });
+        File.WriteAllBytes(Path.Combine(root, "images", "thumb", "R85.webp"), new byte[] { 4, 5, 6 });
+
+        var csvPath = Path.Combine(root, "output", "fabric_photos.csv");
+        File.WriteAllText(
+            csvPath,
+            """
+            FabricCode,FabricGroup,SourceImageUrl,SourcePageUrl,OriginalFile,ThumbFile,ImageWidth,ImageHeight,FileSizeBytes,Sha256,IsPrimary,Notes
+            R85,Group,https://example.test/R85.JPG,https://example.test/page,images/original/R85.JPG,images/thumb/R85.webp,10,12,3,abcdef,true,
+            """);
+
+        return new FabricImportFixture(root, csvPath);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(Root))
+        {
+            Directory.Delete(Root, recursive: true);
+        }
+    }
+}

--- a/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/LKvitai.MES.Tests.Frontline.Unit.csproj
+++ b/tests/Modules/Frontline/LKvitai.MES.Tests.Frontline.Unit/LKvitai.MES.Tests.Frontline.Unit.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <RootNamespace>LKvitai.MES.Tests.Frontline.Unit</RootNamespace>
+    <AssemblyName>LKvitai.MES.Tests.Frontline.Unit</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="FluentAssertions" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" />
+    <PackageReference Include="coverlet.collector" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\src\BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj" />
+    <ProjectReference Include="..\..\..\..\src\Modules\Frontline\LKvitai.MES.Modules.Frontline.Infrastructure\LKvitai.MES.Modules.Frontline.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\..\..\tools\FabricPhotoImporter\FabricPhotoImporter.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/FabricPhotoImporter/FabricPhotoCsvReader.cs
+++ b/tools/FabricPhotoImporter/FabricPhotoCsvReader.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+using CsvHelper;
+using CsvHelper.Configuration;
+
+namespace FabricPhotoImporter;
+
+public static class FabricPhotoCsvReader
+{
+    public static IReadOnlyList<FabricPhotoImportRow> Read(string csvPath)
+    {
+        using var reader = File.OpenText(csvPath);
+        using var csv = new CsvReader(reader, new CsvConfiguration(CultureInfo.InvariantCulture)
+        {
+            MissingFieldFound = null,
+            HeaderValidated = null,
+            TrimOptions = TrimOptions.Trim
+        });
+
+        return csv.GetRecords<FabricPhotoImportRow>().ToList();
+    }
+}

--- a/tools/FabricPhotoImporter/FabricPhotoImportRow.cs
+++ b/tools/FabricPhotoImporter/FabricPhotoImportRow.cs
@@ -1,0 +1,17 @@
+namespace FabricPhotoImporter;
+
+public sealed class FabricPhotoImportRow
+{
+    public string FabricCode { get; set; } = string.Empty;
+    public string? FabricGroup { get; set; }
+    public string? SourceImageUrl { get; set; }
+    public string? SourcePageUrl { get; set; }
+    public string OriginalFile { get; set; } = string.Empty;
+    public string ThumbFile { get; set; } = string.Empty;
+    public int? ImageWidth { get; set; }
+    public int? ImageHeight { get; set; }
+    public long? FileSizeBytes { get; set; }
+    public string? Sha256 { get; set; }
+    public bool IsPrimary { get; set; }
+    public string? Notes { get; set; }
+}

--- a/tools/FabricPhotoImporter/FabricPhotoImporter.csproj
+++ b/tools/FabricPhotoImporter/FabricPhotoImporter.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RootNamespace>FabricPhotoImporter</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CsvHelper" />
+    <PackageReference Include="Minio" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\BuildingBlocks\LKvitai.MES.BuildingBlocks.ObjectStorage\LKvitai.MES.BuildingBlocks.ObjectStorage.csproj" />
+    <ProjectReference Include="..\..\src\Modules\Frontline\LKvitai.MES.Modules.Frontline.Infrastructure\LKvitai.MES.Modules.Frontline.Infrastructure.csproj" />
+  </ItemGroup>
+</Project>

--- a/tools/FabricPhotoImporter/FabricPhotoImporterService.cs
+++ b/tools/FabricPhotoImporter/FabricPhotoImporterService.cs
@@ -123,7 +123,7 @@ public sealed class FabricPhotoImporterService
                     existing.ImageWidth = row.ImageWidth;
                     existing.ImageHeight = row.ImageHeight;
                     existing.FileSizeBytes = row.FileSizeBytes;
-                    existing.IsPrimary = row.IsPrimary;
+                    existing.IsPrimary = existing.IsPrimary || row.IsPrimary;
                     existing.UpdatedAt = DateTimeOffset.UtcNow;
                     updated++;
                 }

--- a/tools/FabricPhotoImporter/FabricPhotoImporterService.cs
+++ b/tools/FabricPhotoImporter/FabricPhotoImporterService.cs
@@ -1,0 +1,189 @@
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore;
+
+namespace FabricPhotoImporter;
+
+public sealed record FabricPhotoImportResult(int TotalRows, int Imported, int Updated, int Skipped, int Failed);
+
+public sealed class FabricPhotoImporterService
+{
+    private readonly FabricPhotoDbContext _dbContext;
+    private readonly IObjectStorageService _storage;
+    private readonly TextWriter _log;
+
+    public FabricPhotoImporterService(
+        FabricPhotoDbContext dbContext,
+        IObjectStorageService storage,
+        TextWriter? log = null)
+    {
+        _dbContext = dbContext;
+        _storage = storage;
+        _log = log ?? Console.Out;
+    }
+
+    public async Task<FabricPhotoImportResult> ImportAsync(
+        string inputRoot,
+        CancellationToken cancellationToken = default)
+    {
+        var csvPath = Path.Combine(inputRoot, "output", "fabric_photos.csv");
+        if (!File.Exists(csvPath))
+        {
+            throw new FileNotFoundException("Fabric photo CSV was not found.", csvPath);
+        }
+
+        var rows = FabricPhotoCsvReader.Read(csvPath);
+        var imported = 0;
+        var updated = 0;
+        var skipped = 0;
+        var failed = 0;
+
+        foreach (var row in rows)
+        {
+            try
+            {
+                if (string.IsNullOrWhiteSpace(row.FabricCode) ||
+                    string.IsNullOrWhiteSpace(row.OriginalFile) ||
+                    string.IsNullOrWhiteSpace(row.ThumbFile))
+                {
+                    skipped++;
+                    await _log.WriteLineAsync("Skipped row with missing FabricCode, OriginalFile, or ThumbFile.");
+                    continue;
+                }
+
+                var code = FabricPhotoKeyBuilder.NormalizeFabricCode(row.FabricCode);
+                var originalPath = ResolvePackagePath(inputRoot, row.OriginalFile);
+                var thumbPath = ResolvePackagePath(inputRoot, row.ThumbFile);
+                if (!File.Exists(originalPath) || !File.Exists(thumbPath))
+                {
+                    failed++;
+                    await _log.WriteLineAsync($"Failed {code}: missing image file(s).");
+                    continue;
+                }
+
+                var photoId = FabricPhotoKeyBuilder.BuildStablePhotoId(code, row.Sha256, row.OriginalFile);
+                var originalKey = FabricPhotoKeyBuilder.BuildOriginalKey(code, photoId, row.OriginalFile);
+                var thumbKey = FabricPhotoKeyBuilder.BuildThumbKey(code, photoId);
+
+                await using (var originalStream = File.OpenRead(originalPath))
+                {
+                    await _storage.PutObjectAsync(
+                        originalKey,
+                        originalStream,
+                        originalStream.Length,
+                        GuessContentType(originalPath),
+                        cancellationToken);
+                }
+
+                await using (var thumbStream = File.OpenRead(thumbPath))
+                {
+                    await _storage.PutObjectAsync(
+                        thumbKey,
+                        thumbStream,
+                        thumbStream.Length,
+                        "image/webp",
+                        cancellationToken);
+                }
+
+                var existing = await FindExistingAsync(code, photoId, row.Sha256, cancellationToken);
+                if (row.IsPrimary)
+                {
+                    await ClearOtherPrimariesAsync(code, photoId, cancellationToken);
+                    await _dbContext.SaveChangesAsync(cancellationToken);
+                }
+
+                if (existing is null)
+                {
+                    _dbContext.FabricPhotos.Add(new FabricPhoto
+                    {
+                        Id = photoId,
+                        FabricCode = code,
+                        OriginalObjectKey = originalKey,
+                        ThumbObjectKey = thumbKey,
+                        SourceImageUrl = NullIfWhiteSpace(row.SourceImageUrl),
+                        SourcePageUrl = NullIfWhiteSpace(row.SourcePageUrl),
+                        SourceImageFileName = Path.GetFileName(row.OriginalFile),
+                        Sha256 = NullIfWhiteSpace(row.Sha256)?.ToLowerInvariant(),
+                        ImageWidth = row.ImageWidth,
+                        ImageHeight = row.ImageHeight,
+                        FileSizeBytes = row.FileSizeBytes,
+                        IsPrimary = row.IsPrimary,
+                        CreatedAt = DateTimeOffset.UtcNow
+                    });
+                    imported++;
+                }
+                else
+                {
+                    existing.OriginalObjectKey = originalKey;
+                    existing.ThumbObjectKey = thumbKey;
+                    existing.SourceImageUrl = NullIfWhiteSpace(row.SourceImageUrl);
+                    existing.SourcePageUrl = NullIfWhiteSpace(row.SourcePageUrl);
+                    existing.SourceImageFileName = Path.GetFileName(row.OriginalFile);
+                    existing.Sha256 = NullIfWhiteSpace(row.Sha256)?.ToLowerInvariant();
+                    existing.ImageWidth = row.ImageWidth;
+                    existing.ImageHeight = row.ImageHeight;
+                    existing.FileSizeBytes = row.FileSizeBytes;
+                    existing.IsPrimary = row.IsPrimary;
+                    existing.UpdatedAt = DateTimeOffset.UtcNow;
+                    updated++;
+                }
+
+                await _dbContext.SaveChangesAsync(cancellationToken);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failed++;
+                await _log.WriteLineAsync($"Failed {row.FabricCode}: {ex.Message}");
+                _dbContext.ChangeTracker.Clear();
+            }
+        }
+
+        return new FabricPhotoImportResult(rows.Count, imported, updated, skipped, failed);
+    }
+
+    private async Task<FabricPhoto?> FindExistingAsync(
+        string code,
+        Guid photoId,
+        string? sha256,
+        CancellationToken cancellationToken)
+    {
+        var normalizedSha = NullIfWhiteSpace(sha256)?.ToLowerInvariant();
+        return await _dbContext.FabricPhotos
+            .FirstOrDefaultAsync(x =>
+                    x.Id == photoId ||
+                    (x.FabricCode == code && normalizedSha != null && x.Sha256 == normalizedSha),
+                cancellationToken);
+    }
+
+    private async Task ClearOtherPrimariesAsync(string code, Guid photoId, CancellationToken cancellationToken)
+    {
+        var otherPrimaries = await _dbContext.FabricPhotos
+            .Where(x => x.FabricCode == code && x.Id != photoId && x.IsPrimary)
+            .ToListAsync(cancellationToken);
+
+        foreach (var other in otherPrimaries)
+        {
+            other.IsPrimary = false;
+            other.UpdatedAt = DateTimeOffset.UtcNow;
+        }
+    }
+
+    private static string ResolvePackagePath(string inputRoot, string relativeOrAbsolute)
+        => Path.IsPathRooted(relativeOrAbsolute)
+            ? relativeOrAbsolute
+            : Path.GetFullPath(Path.Combine(inputRoot, relativeOrAbsolute));
+
+    private static string? NullIfWhiteSpace(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string GuessContentType(string path)
+    {
+        return Path.GetExtension(path).ToLowerInvariant() switch
+        {
+            ".jpg" or ".jpeg" => "image/jpeg",
+            ".png" => "image/png",
+            ".webp" => "image/webp",
+            _ => "application/octet-stream"
+        };
+    }
+}

--- a/tools/FabricPhotoImporter/Program.cs
+++ b/tools/FabricPhotoImporter/Program.cs
@@ -1,0 +1,100 @@
+using FabricPhotoImporter;
+using LKvitai.MES.BuildingBlocks.ObjectStorage;
+using LKvitai.MES.Modules.Frontline.Infrastructure.Media;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Minio;
+
+var input = ReadArg(args, "--input");
+if (string.IsNullOrWhiteSpace(input))
+{
+    Console.Error.WriteLine("Usage: dotnet run --project tools/FabricPhotoImporter -- --input <fabric-image-import-folder>");
+    return 2;
+}
+
+var connectionString = Environment.GetEnvironmentVariable("ConnectionStrings__WarehouseDb")
+    ?? Environment.GetEnvironmentVariable("ConnectionStrings__FabricPhotosDb");
+if (string.IsNullOrWhiteSpace(connectionString))
+{
+    Console.Error.WriteLine("Missing ConnectionStrings__WarehouseDb or ConnectionStrings__FabricPhotosDb.");
+    return 2;
+}
+
+var storageOptions = ReadStorageOptions();
+if (!storageOptions.HasRequiredConfiguration)
+{
+    Console.Error.WriteLine("Missing ITEMIMAGES__ENDPOINT, ITEMIMAGES__BUCKET, ITEMIMAGES__ACCESSKEY, or ITEMIMAGES__SECRETKEY.");
+    return 2;
+}
+
+var dbOptions = new DbContextOptionsBuilder<FabricPhotoDbContext>()
+    .UseNpgsql(connectionString, npgsql => npgsql.MigrationsHistoryTable("__EFMigrationsHistory", "public"))
+    .Options;
+
+await using var dbContext = new FabricPhotoDbContext(dbOptions);
+await dbContext.Database.MigrateAsync();
+
+var minio = new MinioClient()
+    .WithEndpoint(storageOptions.Endpoint)
+    .WithCredentials(storageOptions.AccessKey, storageOptions.SecretKey)
+    .WithSSL(storageOptions.UseSsl)
+    .Build();
+
+var storage = new MinioObjectStorageService(
+    minio,
+    storageOptions,
+    NullLogger<MinioObjectStorageService>.Instance);
+
+var availability = await storage.EnsureAvailableAsync();
+if (!availability.IsAvailable)
+{
+    Console.Error.WriteLine($"Object storage unavailable: {availability.Reason}");
+    return 2;
+}
+
+var importer = new FabricPhotoImporterService(dbContext, storage);
+var result = await importer.ImportAsync(Path.GetFullPath(input));
+Console.WriteLine($"Rows={result.TotalRows}, imported={result.Imported}, updated={result.Updated}, skipped={result.Skipped}, failed={result.Failed}");
+return result.Failed == 0 ? 0 : 1;
+
+static string? ReadArg(string[] args, string name)
+{
+    for (var i = 0; i < args.Length; i++)
+    {
+        if (string.Equals(args[i], name, StringComparison.OrdinalIgnoreCase) && i + 1 < args.Length)
+        {
+            return args[i + 1];
+        }
+    }
+
+    return null;
+}
+
+static ObjectStorageOptions ReadStorageOptions()
+{
+    return new ObjectStorageOptions
+    {
+        Endpoint = NormalizeEndpoint(Environment.GetEnvironmentVariable("ITEMIMAGES__ENDPOINT") ?? string.Empty),
+        BucketName = Environment.GetEnvironmentVariable("ITEMIMAGES__BUCKET") ?? string.Empty,
+        AccessKey = Environment.GetEnvironmentVariable("ITEMIMAGES__ACCESSKEY") ?? string.Empty,
+        SecretKey = Environment.GetEnvironmentVariable("ITEMIMAGES__SECRETKEY") ?? string.Empty,
+        UseSsl = bool.TryParse(Environment.GetEnvironmentVariable("ITEMIMAGES__USESSL"), out var useSsl) && useSsl,
+        CacheMaxAgeSeconds = int.TryParse(Environment.GetEnvironmentVariable("ITEMIMAGES__CACHEMAXAGESECONDS"), out var ttl)
+            ? ttl
+            : 86400
+    };
+}
+
+static string NormalizeEndpoint(string raw)
+{
+    if (string.IsNullOrWhiteSpace(raw)) return string.Empty;
+    var value = raw.Trim();
+    if (value.Contains("://", StringComparison.Ordinal) &&
+        Uri.TryCreate(value, UriKind.Absolute, out var absolute))
+    {
+        return absolute.IsDefaultPort ? absolute.Host : $"{absolute.Host}:{absolute.Port}";
+    }
+
+    var slashIndex = value.IndexOf('/');
+    return slashIndex >= 0 ? value[..slashIndex] : value;
+}


### PR DESCRIPTION
## Summary

- Add separate `fabric_photos` storage for Frontline fabric images, not Warehouse `item_photos`.
- Reuse shared object storage / MinIO infrastructure with a separate `fabric-photos/...` object key prefix.
- Add importer tooling for the prepared fabric image package.
- Enrich Frontline fabric API responses with `ThumbnailUrl` / `PhotoUrl` when a real fabric photo exists.
- Add Frontline UI thumbnail rendering with safe placeholder fallback for missing or broken photos.
- Make duplicate imports idempotent by `FabricCode + Sha256`.
- Ensure `IsPrimary` is monotonic: later duplicate non-primary rows cannot downgrade an existing primary photo.

## Architecture Notes

- Fabric photos are owned by Frontline, not Warehouse.
- `fabric_photos` has no foreign key to Warehouse `items`.
- Warehouse `item_photos` behavior is preserved.
- Legacy fabric stock/name/status remains the source of truth.
- MES stores only fabric photo metadata and object-storage keys.
- Existing `ITEMIMAGES__...` object-storage configuration is reused for the shared media bucket.
- Fabric photos are separated by the `fabric-photos/...` prefix and the `fabric_photos` table.

## TEST Status

The TEST import has already been executed before this final fix:

- CSV rows: 215
- imported=206
- updated=9
- failed=0
- TEST DB rows in `public.fabric_photos`: 206
- TEST MinIO bucket `lkvitai-test` contains uploaded `fabric-photos/...` objects

API/UI end-to-end verification is still pending because TEST containers were deployed from old image tag `7c06a6b...`, before this branch.

After this PR branch is deployed to TEST, rerun the idempotent importer once to repair the previously affected `IsPrimary` rows:

- R416
- R661
- R670
- R680
- R683
- R684
- R685
- R688

## Verification

- [x] `dotnet build src\LKvitai.MES.sln --nologo`
- [x] Frontline unit tests passed
- [x] Architecture tests passed
- [x] Warehouse item photo/image tests passed
- [x] No import package/images/secrets tracked
- [ ] Build and deploy new Frontline TEST containers from this branch
- [ ] Rerun idempotent importer once on TEST
- [ ] Verify `GET /api/frontline/fabric/R85`
- [ ] Verify `GET /api/frontline/fabric/R85/photo?size=thumb`
- [ ] Verify `GET /api/frontline/fabric/R85/photo?size=original`
- [ ] Verify `GET /api/frontline/fabric/low-stock`
- [ ] Verify UI shows thumbnails for fabrics with photos
- [ ] Verify UI shows patterned "No photo" placeholder for fabrics without photos
- [ ] Verify broken image loads fall back to placeholder

## Production Notes

Do not run production import until:
- PR is merged
- TEST is deployed from this branch
- TEST importer rerun succeeds
- TEST API/UI verification passes