### PR TITLE
feat(agnum): Slice 1 — Agnum import foundation (connector + entities + services)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,6 +25,8 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.13" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="8.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.2" />
     <PackageVersion Include="Microsoft.ML.OnnxRuntime" Version="1.20.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />

--- a/docs/adr/006-warehouse-agnum-document-based-integration.md
+++ b/docs/adr/006-warehouse-agnum-document-based-integration.md
@@ -1,0 +1,103 @@
+# ADR-006: Warehouse-Agnum Integration Is Document-Based, Not Stock-Ledger-Event-Based
+
+**Status:** Accepted  
+**Date:** 2026-05-18  
+**Decision Makers:** Implementation Team  
+**Relates To:** Warehouse module, StockLedger, Agnum integration, accounting export
+
+---
+
+## Context
+
+Warehouse uses `StockLedger` as the operational stock truth. The ledger records granular technical movements such as receipts, picks, transfers, adjustments, and internal stock changes through `StockMovedEvent`.
+
+Agnum is an accounting/business system. The reviewed Agnum API exposes business document operations such as sales documents, purchase receipts, customer returns, and accounting-like corrections. It does not behave like a raw stock event sink.
+
+Earlier planning included XML/CSV-style stock export and later a generic JSON stock snapshot. The Agnum API direction requires a clearer architectural boundary.
+
+---
+
+## Decision
+
+Warehouse-Agnum integration is document-based, not stock-ledger-event-based.
+
+MES `StockLedger` remains the operational stock truth.
+
+Agnum receives only confirmed accounting/business documents through explicit export outbox records.
+
+Raw `StockMovedEvent` is not exported directly to Agnum.
+
+Every Agnum export must have:
+
+- source business document/process;
+- mapped Agnum endpoint/document type;
+- idempotency key;
+- payload snapshot;
+- export status;
+- retry/review workflow.
+
+---
+
+## Rationale
+
+MES stock movements are too granular and technical for Agnum accounting semantics.
+
+Agnum expects business documents such as sales, purchase receipts, customer returns, and accounting corrections. Directly exporting raw stock ledger events would risk:
+
+- incorrect accounting semantics;
+- duplicate or fragmented Agnum documents;
+- loss of business context required by Agnum document APIs;
+- hard-to-debug reconciliation problems;
+- retries that replay technical movements instead of idempotent business documents.
+
+The integration boundary should translate confirmed MES business processes into Agnum documents, not replicate the internal stock ledger.
+
+---
+
+## Consequences
+
+Positive:
+
+- Accounting integration follows Agnum's document model.
+- Export retries can be idempotent per business document.
+- Operators can review failed exports using payload snapshots and source process context.
+- Stock ledger design remains focused on MES operational correctness.
+
+Negative:
+
+- Additional outbox/export state is required.
+- Each business flow needs explicit mapping to an Agnum endpoint and document type.
+- Some StockLedger movements may not have an Agnum export until business document semantics are confirmed.
+
+Implementation consequences:
+
+- Add an explicit Agnum export outbox model before exporting operational flows.
+- Do not subscribe to `StockMovedEvent` and POST directly to Agnum.
+- Use `StockMovedEvent` only as supporting evidence/input when building a confirmed business document payload.
+- Reconciliation must compare MES operational state and Agnum document/balance state through dedicated reports, not by assuming event-to-document parity.
+
+---
+
+## Rejected Alternative: Export Each StockMovedEvent
+
+Rejected because `StockMovedEvent` represents internal operational stock movement, not necessarily an accounting document.
+
+Examples:
+
+- Picking may be a warehouse operation, while Agnum may need a sales/invoice document only at shipment or accounting approval.
+- Internal transfers may need different Agnum handling depending on source/destination warehouse semantics.
+- Adjustments/write-offs may require reason codes, approval, or accounting correction document types.
+
+Direct event export would couple Agnum to MES internals and make later business corrections unsafe.
+
+---
+
+## References
+
+- `docs/agnum-integration-plan/01-as-is-warehouse.md`
+- `docs/agnum-integration-plan/02-agnum-api-findings.md`
+- `docs/agnum-integration-plan/03-target-solution-architecture.md`
+- `docs/agnum-integration-plan/04-implementation-plan.md`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Aggregates/StockLedger.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/Events/StockMovedEvent.cs`
+

--- a/docs/agnum-integration-plan/01-as-is-warehouse.md
+++ b/docs/agnum-integration-plan/01-as-is-warehouse.md
@@ -1,0 +1,97 @@
+# 01. As-Is Warehouse
+
+## High-Level Shape
+
+Warehouse is a modular monolith under `src/Modules/Warehouse`:
+
+- `Domain`: master data entities and core aggregates.
+- `Application`: commands, query handlers, orchestration ports.
+- `Infrastructure`: EF Core, Marten/event-store repositories, projections, imports.
+- `Contracts`: events, messages, read-model DTOs.
+- `Api`: ASP.NET controllers, command handlers, integration services, Hangfire jobs.
+- `WebUI`: Blazor Server UI.
+- `Sagas`: MassTransit state machines.
+- `Integration`: external integration ports.
+
+## Core Business Concepts Already Present
+
+Master data:
+
+- `Item` with `InternalSKU`, `Name`, `Description`, `CategoryId`, `BaseUoM`, `Weight`, `Volume`, lot/QC flags, `PrimaryBarcode`, `ProductConfigId`.
+- `ItemCategory`, `UnitOfMeasure`, `ItemUoMConversion`, `ItemBarcode`, `Supplier`, `SupplierItemMapping`.
+- `Location` with code, barcode, type, virtual flag, coordinates, rack/bin attributes, role, warehouse ownership.
+- `WarehouseLayout`/warehouse directory style data.
+
+Inventory ledger:
+
+- `StockLedger` is event-sourced and append-only.
+- One stream per `(warehouseId, location, sku)` via `StockLedgerStreamId`.
+- `StockMovedEvent` contains `MovementId`, `SKU`, `Quantity`, `FromLocation`, `ToLocation`, `MovementType`, `OperatorId`, optional HU/reason.
+- Negative balance protection lives in `StockLedger.RecordMovement`.
+
+Operational flows:
+
+- Receiving goods records stock movement from `SUPPLIER` to location.
+- Picking records stock movement before reservation consumption.
+- Transfers have entity workflow: Draft, PendingApproval, Approved, InTransit, Completed, Cancelled.
+- Cycle counts and adjustments exist.
+- Valuation exists through `OnHandValue`, with item/category, quantity, unit cost, total value.
+
+## Current Agnum Implementation
+
+Current Agnum code is mostly a financial snapshot export/reconciliation feature.
+
+API routes in `AgnumController`:
+
+- `GET /api/warehouse/v1/agnum/config`
+- `PUT /api/warehouse/v1/agnum/config`
+- `POST /api/warehouse/v1/agnum/test-connection`
+- `POST /api/warehouse/v1/agnum/export`
+- `GET /api/warehouse/v1/agnum/history`
+- `GET /api/warehouse/v1/agnum/history/{exportId}`
+- `POST /api/warehouse/v1/agnum/reconcile`
+- `GET /api/warehouse/v1/agnum/reconcile/{reportId}`
+
+Configuration:
+
+- Export scope: `ByWarehouse`, `ByCategory`, `ByLogicalWh`, `TotalOnly`.
+- Export format: `Csv` or `JsonApi`.
+- API endpoint and API key stored in `AgnumExportConfig`.
+- Mapping table maps source type/value to Agnum account code.
+- Schedule is stored as cron and registered in Hangfire as `agnum-daily-export`.
+
+Export:
+
+- `AgnumExportOrchestrator` loads `OnHandValue` and, when available, `AvailableStockView`.
+- Builds CSV with columns: `ExportDate`, `AccountCode`, `SKU`, `ItemName`, `Quantity`, `UnitCost`, `OnHandValue`.
+- If configured as `JsonApi`, posts grouped payloads to `api/v1/inventory/import`.
+- Sends `Authorization: Bearer <apiKey>` and `X-Export-ID`.
+- Maintains `AgnumExportHistory`.
+
+Reconciliation:
+
+- Reads latest successful export CSV for a date.
+- Uploads Agnum balance CSV.
+- Compares warehouse value against Agnum balance by SKU.
+- Stores reconciliation report in memory.
+
+Saga/events:
+
+- `AgnumExportStartedEvent`, `AgnumExportCompletedEvent`, `AgnumExportFailedEvent`.
+- `StartAgnumExport`, `AgnumExportSucceeded`, `AgnumExportFailed`.
+- `AgnumExportSaga` only tracks state; it does not own the actual HTTP workflow.
+
+## Main As-Is Gap
+
+The current Agnum integration assumes a batch stock valuation export to Agnum. It does not yet model Agnum as the operational accounting system API for:
+
+- Product/nomenclature synchronization.
+- Per-Agnum-warehouse product visibility and balances.
+- Sales/order document export.
+- Purchase receipt or inbound document export.
+- Customer returns.
+- Mapping MES stock movements to Agnum document types.
+- One API key per `sndid` warehouse context.
+
+The existing `JsonApi` endpoint path `api/v1/inventory/import` does not match the real API findings from `agnum-api-deploy`.
+

--- a/docs/agnum-integration-plan/02-agnum-api-findings.md
+++ b/docs/agnum-integration-plan/02-agnum-api-findings.md
@@ -1,0 +1,147 @@
+# 02. Agnum API Findings
+
+Source repository: `https://github.com/lauresta/agnum-api-deploy`
+
+Checked commit: `c059aa3` on 2026-05-18 09:47:35 +0300.
+
+## Deployment Shape
+
+The repo wraps `AgnumDBApi-1.39.jar`.
+
+Test VM layout documented there:
+
+- Runtime config: `/opt/agnum/application.properties`
+- Logs: `/opt/agnum/logs/`
+- Container: `agnum-api`
+- Image: `ghcr.io/lauresta/agnum-api`
+- Local health: `http://localhost:8181/doc/health`
+- Local Swagger: `http://localhost:8181/swagger-ui/index.html`
+- Local OpenAPI: `http://localhost:8181/v3/api-docs`
+
+The compose stack joins `lkvitai-mes_default`, so Warehouse API can likely call it by container/service DNS if deployed on the same network.
+
+## Authentication and Warehouse Context
+
+Agnum API uses header:
+
+```text
+X-API-KEY: <key>
+```
+
+Important behavior:
+
+- API key maps to an API user in `application.properties`.
+- Each API user has fixed `sndid`.
+- `sndid` is the Agnum warehouse/store context.
+- Product reads/writes use that context.
+- There is no confirmed request parameter to switch warehouse per call.
+- Multi-warehouse integration means multiple API users/keys.
+
+Example config from `application.properties.example`:
+
+```properties
+cfg.apiusers.sandelys.apiKey=CHANGE_ME_493
+cfg.apiusers.sandelys.dbalias=agnum
+cfg.apiusers.sandelys.sndid=493
+cfg.apiusers.sandelys.rights=READ_ALL,SAVE_ALL
+
+cfg.apiusers.gamyba.apiKey=CHANGE_ME_498
+cfg.apiusers.gamyba.dbalias=agnum
+cfg.apiusers.gamyba.sndid=498
+cfg.apiusers.gamyba.rights=READ_ALL,SAVE_ALL
+```
+
+Known test DB `sndid` values include:
+
+| sndid | Name | Description |
+| --- | --- | --- |
+| 493 | Sandelys | Centrinis sandelys |
+| 496 | Pardavimai | Pagaminta produkcija-pardavimai |
+| 498 | Gamyba | Gamybos sandelys |
+| 500 | Mazavertis | Mazavertis inventorius |
+| 502 | Kuras | Transportas ir kuras |
+| 507 | Ilgalaikis | Ilgalaikis turtas |
+| 509 | Visi | Visi sandeliai |
+| 1498 | Nebaigta s | Nebaigta statyba |
+| 12503 | Paslaugos | Paslaugos |
+| 142026 | PVZ | Pavyzdziai |
+| 142029 | Parduotuve | Internetine parduotuve |
+
+## Product/Nomenclature API
+
+Endpoints documented:
+
+- `GET /api/products/{id}`
+- `GET /api/products/search`
+- `GET /api/products/qty/search`
+- `GET /api/products/price/search`
+- `POST /api/products`
+- `PUT /api/products`
+
+Product create requires at least `code`; practical minimum:
+
+```json
+{
+  "code": "SKU-001",
+  "name": "Product name",
+  "pcs": "vnt",
+  "enabled": true,
+  "netto": 1,
+  "brutto": 1
+}
+```
+
+Key mapping facts:
+
+- `id` maps to `PRK.ID_PRK`, but it is not globally unique across warehouses. Treat product identity as `(sndid, id)` or `(warehouseKey, id)`.
+- `code` maps to `PRK.KOD` and should be treated as the primary SKU/code for integration unless we store Agnum references explicitly.
+- `balance` maps to `PRK.KIEKIS` for the API user's warehouse.
+- `pcs` maps to unit of measure.
+- `barcode`/`barcodes` may differ between API responses; importer should handle both defensively.
+- `f1` is likely Intrastat commodity code.
+- `f2` is supplier product code.
+- `f6` is likely Intrastat quantity coefficient.
+
+Known issue:
+
+- Product `limit`/`offset` is buggy in jar `1.39`, generating invalid SQL such as `ORDER BY P.ID_PRKROWS 5`.
+- Do not rely on pagination until jar is fixed.
+
+## Document APIs
+
+Sales/invoice-like document:
+
+- `POST /api/orders`
+- Jar maps this to `DokType VSK = pardavimas`.
+- Required top-level fields: `date`, `doc_no`, `sum`, `vat_sum`, `total`, `client`.
+- Treat `products[]` as required in practice.
+- Required line fields: `code`, `qty`, `price`, `vat`, `vat_proc`.
+- Optional line fields: `id`, `bk`, `mark`, `vat_code`, `memo`, `pcs`.
+
+Purchase receipt candidate:
+
+- `POST /api/receipts`
+- `GET /api/receipts/{docNo}`
+- Jar maps this to `DokType VKS = pajamavimas`.
+- This is not in current OpenAPI output and must be validated carefully before production use.
+
+Customer return:
+
+- `POST /api/customer-returns`
+- `GET /api/customer-returns/{docNo}`
+- `GET /api/customer-returns/search`
+- Jar maps this to `DokType GKS = grazinimas`.
+
+## Consequences for MES
+
+The integration should not be a single stock snapshot POST.
+
+It needs a small anti-corruption layer with:
+
+- Per-warehouse Agnum credentials and `sndid` mapping.
+- Product import/export/sync.
+- Document export for business events.
+- Idempotency and export history by document/movement.
+- Read-side diagnostics against Agnum products and balances.
+- Explicit business confirmation for each document type and direction.
+

--- a/docs/agnum-integration-plan/03-target-solution-architecture.md
+++ b/docs/agnum-integration-plan/03-target-solution-architecture.md
@@ -1,0 +1,178 @@
+# 03. Target Solution Architecture
+
+## Goal
+
+Rework Warehouse Agnum integration from a file-like financial snapshot into an API-based read/import foundation first.
+
+The first business-critical outcome is:
+
+- MES shows the full Agnum product/nomenclature list.
+- MES shows stock balances in each Agnum warehouse.
+- Each Agnum warehouse/`sndid` is represented as a MES virtual warehouse context.
+- Users can distribute imported virtual balances into real MES physical warehouses/locations/bins.
+- Users can search products and see where they physically are in 2D/3D.
+- Agnum document export is implemented only after this foundation works.
+
+Architectural guardrail: [ADR-006](../adr/006-warehouse-agnum-document-based-integration.md) states that Warehouse-Agnum integration is document-based, not raw `StockMovedEvent` export.
+
+Additional guardrail: phases 0-5 are read/import/distribution only. They must not POST or PUT anything back to Agnum.
+
+## Proposed Components
+
+### 1. Agnum Connector
+
+New connector in the Warehouse integration layer:
+
+- `IAgnumApiClient`
+- `AgnumApiClient`
+- Typed request/response DTOs for products and balances first.
+- Document DTOs later, after the physical MES foundation is working.
+- Uses `X-API-KEY`, not Bearer auth.
+- Resolves the correct API key by Agnum `sndid`/virtual warehouse context.
+- Handles retry, timeout, logging, response parsing, and redacted diagnostics.
+
+The current `IAgnumExportService` is too narrow. Keep it temporarily, but introduce a broader connector rather than stretching "export snapshot" to cover all Agnum behavior.
+
+### 2. Agnum Mapping Model
+
+Add persistent configuration for:
+
+- Agnum `sndid` to MES virtual warehouse context.
+- Agnum `sndid` to API key reference.
+- Virtual warehouse to allowed target MES physical warehouses/locations.
+- Agnum product reference: `(sndid, agnumProductId)` stored against MES `Item`.
+- SKU/code mapping and conflict status.
+- Unit mapping between MES UoM and Agnum `pcs`.
+- Agnum category/classifier import mapping: `group`, `category`, `subgroup`, `direction`, `branch`.
+- Agnum custom product attributes: `place`, `f1..f20`.
+- Document type mapping later: MES business process to Agnum endpoint and document type fields.
+
+Do not store raw API keys in normal tables. Reuse the existing protected secret approach or move to a secrets provider later.
+
+### 3. Product/Nomenclature Sync
+
+The first implementation direction is Agnum -> MES import:
+
+- Import Agnum products into MES master data per configured `sndid`.
+- Treat Agnum `code` as SKU candidate.
+- Store Agnum `(sndid, id)` as an external reference.
+- Detect duplicates, disabled products, UoM conflicts, and code collisions.
+- Do not create/update Agnum products from MES in the import phases.
+
+The current `Item.ProductConfigId` is not enough for this. It is a string and does not capture per-warehouse Agnum identity.
+
+### 4. Virtual Warehouse Balances
+
+Agnum balance is not an `Item` field.
+
+Import Agnum balances into a separate virtual warehouse balance model:
+
+- Agnum `sndid` virtual warehouse.
+- Agnum product identity `(sndid, agnumProductId)`.
+- MES item/SKU after product import/linking.
+- Quantity and UoM.
+- Import run/source hash/timestamps.
+
+These balances are used as:
+
+- stock visibility by Agnum warehouse;
+- opening stock source;
+- reconciliation source;
+- source for physical distribution into MES locations.
+
+### 5. Physical Distribution from Virtual Balance
+
+Users need a workflow to distribute imported Agnum virtual balances into real MES physical warehouses/locations/bins.
+
+The distribution workflow should:
+
+- start from an imported virtual balance;
+- create a draft distribution document;
+- select target physical warehouse/location/bin;
+- support partial distribution;
+- prevent over-distribution unless explicitly approved as a correction;
+- keep traceability to Agnum import run and source balance;
+- update MES physical stock through controlled commands.
+
+Physical MES locations are not the same thing as Agnum `sndid`.
+
+### 6. Search and 2D/3D Location Visibility
+
+After physical distribution exists, product search should show:
+
+- Agnum virtual balance by `sndid`;
+- distributed MES physical quantity by warehouse/location/bin;
+- remaining undistributed virtual balance;
+- 2D/3D location visibility using existing Warehouse visualization capabilities.
+
+### 7. Document Export Outbox
+
+Use an explicit outbox table/entity for Agnum exports:
+
+- `AgnumDocumentExport`
+- `AgnumDocumentExportLine`
+- Status: Pending, Sending, Sent, Failed, Cancelled, NeedsReview.
+- Idempotency key: MES document/movement ID plus type.
+- Request payload snapshot.
+- Agnum response snapshot.
+- Retry count and last error.
+
+This is safer than calling Agnum directly from UI/controller command handlers.
+
+This component belongs after product import, virtual balances, physical distribution, and core MES operations are working.
+
+### 8. Flow Handlers
+
+Map MES flows to export candidates:
+
+- Sales order shipment/invoice candidate -> `/api/orders`.
+- Purchase receipt/inbound candidate -> `/api/receipts` after validation.
+- Customer return -> `/api/customer-returns`.
+- Stock adjustment/write-off/transfer -> needs business confirmation; may require Agnum document types not yet confirmed in the API docs.
+
+Do not export every `StockMovedEvent` blindly. The ledger is a technical truth of stock, but Agnum expects accounting/business documents.
+
+### 9. Reconciliation
+
+Keep reconciliation, but expand it:
+
+- Product sync report: MES item vs Agnum product per warehouse.
+- Balance comparison: MES available/on-hand vs Agnum `balance` per API key/sndid.
+- Virtual-vs-physical distribution report: imported virtual balance, distributed quantity, remaining virtual quantity.
+- Document export report: Pending/failed/sent Agnum document exports.
+- Accounting value reconciliation remains, but should align with agreed Agnum endpoints and document semantics.
+
+## Suggested Runtime Configuration
+
+Warehouse API config should reference Agnum service with internal URL:
+
+```json
+{
+  "Agnum": {
+    "BaseUrl": "http://agnum-api:8181",
+    "TimeoutSeconds": 15
+  }
+}
+```
+
+Per-warehouse API keys should be configured through UI/admin config or secrets:
+
+| MES virtual warehouse context | Agnum sndid | API key secret |
+| --- | --- | --- |
+| AGNUM-SND-493 | 493 | protected secret |
+| AGNUM-SND-498 | 498 | protected secret |
+
+The final mapping names need business confirmation.
+
+## Migration Strategy
+
+Keep current export/reconciliation screens operational while building the new connector. Then:
+
+1. Add new Agnum read connector and mapping tables.
+2. Import Agnum products with preview/conflict detection/apply.
+3. Import/display Agnum balances as virtual warehouse balances.
+4. Add physical distribution from virtual balance into MES warehouses/locations/bins.
+5. Add product search and 2D/3D location visibility from physical distribution.
+6. Adapt real MES warehouse operations.
+7. Add document export outbox and confirmed Agnum document flows.
+8. Replace old `JsonApi` snapshot endpoint with real Agnum document endpoints or deprecate it.

--- a/docs/agnum-integration-plan/04-implementation-plan.md
+++ b/docs/agnum-integration-plan/04-implementation-plan.md
@@ -1,0 +1,224 @@
+# 04. Implementation Plan
+
+> **Current MVP scope:** Phases 1–3 are active (Slice 1). Phase 4 is Slice 2.
+> Phase 5 is Slice 3. **Phase 6 is not an implementation task** — packages A–F already implement
+> all MES warehouse operations; no changes are needed there.
+> **Phase 7 is backlog** — do not start until Phases 1–5 are stable.
+> See `MVP-SCOPE.md` for the authoritative scope gate and frozen file list.
+
+## Revised Business Priority
+
+The first critical goal is not Agnum document export.
+
+The first critical goal is to import and see the full Agnum nomenclature and stock balances in MES:
+
+- MES shows the full product/nomenclature list from Agnum.
+- MES shows how much stock exists in each Agnum warehouse.
+- Agnum warehouse/`sndid` is treated as a MES virtual warehouse context.
+- Users can correct/distribute those virtual balances into real MES physical warehouses and locations.
+- Users can search products and see where they are located in 2D/3D.
+- Only after this foundation works do we implement receiving new goods and Agnum accounting documents.
+
+## Guardrails
+
+- Agnum `sndid` = MES virtual warehouse context.
+- Physical MES locations are not the same as Agnum warehouses.
+- Agnum balance is not stored on `Item`.
+- Agnum balance is imported as virtual warehouse balance, opening stock source, and reconciliation source.
+- Product identity from Agnum is `(sndid, agnumProductId)`, not `agnumProductId` alone.
+- Agnum `code` is the SKU candidate unless business confirms otherwise.
+- Do not export raw `StockMovedEvent` to Agnum.
+- Do not start with UI-only screens; start with data model, import, mapping, conflict detection, and balance visibility.
+- Do not post anything back to Agnum in phases 0-5.
+
+## Phase 0 - Confirm Agnum Warehouse/Sndid Mapping and Product Identity Rules
+
+Deliverables:
+
+- Confirm Agnum test URL reachable from Warehouse API/container network.
+- Confirm API keys for each `sndid`.
+- Confirm which Agnum `sndid` values are in Warehouse scope.
+- Confirm whether each `sndid` should become a MES virtual warehouse.
+- Confirm product identity rule: `(sndid, agnumProductId)` plus Agnum `code` as SKU candidate.
+- Confirm how to handle the same Agnum `code` appearing in multiple `sndid` contexts.
+- Confirm UoM mapping rules for Agnum `pcs`.
+- Confirm whether Agnum `group/category/subgroup` should become MES category hierarchy.
+
+Output:
+
+- Seedable `AgnumWarehouseMapping` list.
+- Product identity decision.
+- UoM mapping decision.
+- Category mapping decision.
+- Clear exclusion list for non-WMS Agnum warehouses such as services/fixed assets if applicable.
+
+## Phase 1 - Build Agnum Read Connector for Products and Balances
+
+Implement:
+
+- `IAgnumApiClient` with `X-API-KEY` auth per `sndid`.
+- Product read DTOs for `/api/products/search`, `/api/products/{id}`, and balance-bearing product responses.
+- Defensive JSON handling for both `barcode` and `barcodes`.
+- Read-only connector methods:
+  - search products by code/name;
+  - load all visible products for a configured `sndid`;
+  - load product by Agnum ID;
+  - load balances per `sndid`.
+- Timeout, retry, logging, redacted diagnostics.
+- Integration tests with mocked Agnum responses.
+
+Avoid:
+
+- Product pagination until Agnum jar `1.39` `limit/offset` bug is fixed.
+- Any POST/PUT back to Agnum.
+- Any UI-only implementation before connector/data model exists.
+
+## Phase 2 - Import Agnum Products into MES Item Master
+
+Implement data model first:
+
+- `AgnumProductLink`
+  - `ItemId`
+  - `SndId`
+  - `AgnumProductId`
+  - `AgnumCode`
+  - `AgnumEnabled`
+  - Agnum create/modify timestamps
+  - import timestamps/source hash
+- `ItemExternalAttribute` for Agnum `group/category/subgroup/direction/branch/place/f1..f20`.
+- `AgnumUomMapping` for Agnum `pcs -> UnitOfMeasure.Code`.
+
+Implement import workflow:
+
+- Read products from each enabled `sndid`.
+- Build import preview before applying changes.
+- Detect conflicts:
+  - missing SKU;
+  - duplicate SKU in same `sndid`;
+  - same Agnum `code` across multiple `sndid` contexts;
+  - UoM not mapped;
+  - category/classifier not mapped;
+  - active/inactive status mismatch;
+  - existing MES item linked to different Agnum product.
+- Apply approved import into `Item`, `ItemBarcode`, `ItemCategory`, `AgnumProductLink`, and external attributes.
+
+Important:
+
+- Import product master only; do not store Agnum balance on `Item`.
+- Do not create/update Agnum products from MES in this phase.
+
+## Phase 3 - Import/Display Agnum Balances as MES Virtual Warehouse Balances
+
+Implement data model:
+
+- `AgnumVirtualWarehouseBalance`
+  - `SndId`
+  - `AgnumProductId`
+  - `ItemId`
+  - `Sku`
+  - `Quantity`
+  - `Uom`
+  - `ImportedAt`
+  - `SourceHash`
+  - `ImportRunId`
+- `AgnumBalanceImportRun`
+  - status, counts, started/finished timestamps, errors.
+
+Behavior:
+
+- Import balances per configured `sndid`.
+- Show balances grouped by Agnum virtual warehouse.
+- Keep imported balances separate from physical MES stock/location balances.
+- Use imported balances as:
+  - initial stock source;
+  - virtual warehouse visibility;
+  - reconciliation baseline.
+
+Do not:
+
+- Write Agnum balances to `Item`.
+- Treat Agnum `sndid` as a physical bin/location.
+- Post any stock movement or correction to Agnum.
+
+## Phase 4 - Distribute Imported Virtual Balances into Physical MES Locations/Bins
+
+Implement:
+
+- Distribution workflow from `AgnumVirtualWarehouseBalance` to physical MES warehouse/location/bin.
+- Draft distribution document:
+  - source `sndid` virtual warehouse;
+  - target MES physical warehouse/location;
+  - item/SKU;
+  - quantity;
+  - operator and reason;
+  - validation and approval state.
+- Apply distribution by creating MES physical stock/opening balance through controlled commands.
+- Keep traceability from physical stock to Agnum import run/source balance.
+- Support partial distribution and remaining virtual balance.
+- Prevent over-distribution beyond imported virtual balance unless explicitly approved as correction.
+
+Business meaning:
+
+- This is the bridge from Agnum accounting/store balance to actual MES physical reality.
+- Physical MES locations are created/managed separately from Agnum `sndid`.
+
+## Phase 5 - Product Search and 2D/3D Location Visibility
+
+Implement after physical distribution exists:
+
+- Search products by Agnum code/MES SKU/name/barcode.
+- Show virtual balance by `sndid`.
+- Show physical quantity by MES warehouse/location/bin.
+- Show where the product is located in existing 2D/3D visualization.
+- Support discrepancy view:
+  - imported virtual balance;
+  - distributed physical quantity;
+  - remaining undistributed virtual quantity;
+  - MES operational physical quantity.
+
+UI follows Warehouse UX rules and must be backed by real imported/distributed data, not static screens.
+
+## Phase 6 - Real MES Warehouse Operations
+
+Implement or adapt operational workflows after initial master/balance/location foundation:
+
+- receiving new goods;
+- internal movement;
+- correction/adjustment;
+- inventory/cycle count;
+- reservation;
+- picking.
+
+Rules:
+
+- MES `StockLedger` remains operational stock truth for physical MES stock.
+- Operations work on physical MES warehouses/locations, not directly on Agnum `sndid`.
+- Agnum imported balances remain reconciliation/opening-source data.
+
+## Phase 7 - Agnum Document Export for Confirmed Flows
+
+Only after phases 0-6 are working, implement exports back to Agnum.
+
+Confirmed export candidates:
+
+- purchase receipts;
+- sales documents;
+- customer returns;
+- write-offs/corrections.
+
+Implement:
+
+- `AgnumDocumentExport` outbox.
+- Mapped Agnum endpoint/document type.
+- Idempotency key.
+- Payload snapshot.
+- Export status.
+- Retry/review workflow.
+- Operator-facing failed export review.
+
+Rules:
+
+- Do not export raw `StockMovedEvent`.
+- Build Agnum documents from confirmed business processes/documents.
+- Preserve ADR-006 as the architectural guardrail.
+

--- a/docs/agnum-integration-plan/05-open-questions.md
+++ b/docs/agnum-integration-plan/05-open-questions.md
@@ -1,0 +1,46 @@
+# 05. Open Questions
+
+## Business Process
+
+1. Which Agnum `sndid` values are in scope for MES import?
+2. Should every in-scope `sndid` become a MES virtual warehouse?
+3. Which Agnum warehouses should be excluded from WMS operations, for example services/fixed assets/fuel?
+4. Who is allowed to approve distribution from virtual Agnum balances into physical MES bins?
+5. What is the business rule for over-distribution or under-distribution versus Agnum balance?
+6. Which exact Warehouse flows must create Agnum documents later, after import/distribution foundation is working?
+7. Which moment later triggers sales export: order creation, shipping, delivery, invoice approval, or accounting approval?
+8. Which moment later triggers purchase receipt export: receiving, QC acceptance, supplier invoice, or accountant approval?
+
+## Agnum API
+
+1. What is the test stand URL reachable from MES containers?
+2. Which API keys exist on the stand, and which `sndid` does each represent?
+3. Which endpoint is best for full product/balance import: `/api/products/search`, `/api/products/qty/search`, or another endpoint?
+4. Does `/api/products/search` balance represent current balance for the API key's `sndid`?
+5. Is there any supported way to pass warehouse/sndid per request instead of per API key?
+6. Will jar `1.39` product `limit`/`offset` bug be fixed soon?
+7. Later: is `/api/receipts` officially supported for purchase receipt/pajamavimas in production?
+8. Later: is `/api/orders` the final sales invoice/document endpoint, or only an order-like document?
+
+## Data Mapping
+
+1. Which Agnum `sndid` maps to each MES virtual warehouse?
+2. Should MES SKU equal Agnum `code` for all products?
+3. Do we need to preserve Agnum `(sndid, id)` on MES item records?
+4. How should duplicate product codes across warehouses be handled?
+5. Which UoM values are allowed in Agnum and MES?
+6. Are Agnum `f1`, `f2`, `f6` required in MES item details?
+7. Are Agnum product balances authoritative as opening virtual balances, or only reconciliation source?
+8. Should Agnum `group/category/subgroup` become one MES category hierarchy?
+9. Should Agnum `direction` and `branch` become separate classifiers, or only stored as imported attributes?
+10. Which Agnum source should be used for supplier master import? Product `f2` only gives supplier product code, not supplier identity.
+11. Which physical MES warehouses/locations can receive distribution from each Agnum virtual warehouse?
+
+## Operations
+
+1. Who owns failed product/balance import review?
+2. How long should Agnum import raw payload/hash snapshots be retained?
+3. How often should Agnum products and balances be refreshed?
+4. What is the fallback when Agnum API is down during import?
+5. Which users can configure API keys and trigger manual import?
+6. Later: who owns failed document export retry/review?

--- a/docs/agnum-integration-plan/05-open-questions.md
+++ b/docs/agnum-integration-plan/05-open-questions.md
@@ -1,5 +1,13 @@
 # 05. Open Questions
 
+## Resolved 2026-05-18
+
+| Question | Answer |
+| --- | --- |
+| Which sndid are in WMS scope? | **493** (Centrinis sandėlys) — main. **496** (Pagaminta produkcija-pardavimai) — secondary. **498** (Gamyba) — pending business confirmation. |
+| Which sndid to exclude? | 500 Mažavertis, 502 Kuras, 507 Ilgalaikis, 509 Visi, 1498 Nebaigta statyba, 12503 Paslaugos, 142026 PVZ, 142029 Parduotuvė, 144513 (null). |
+| Is sndid 498 Gamyba used? | Pending — Vytautas to confirm. |
+
 ## Business Process
 
 1. Which Agnum `sndid` values are in scope for MES import?

--- a/docs/agnum-integration-plan/06-master-data-mapping.md
+++ b/docs/agnum-integration-plan/06-master-data-mapping.md
@@ -1,0 +1,278 @@
+# 06. Master Data Mapping
+
+This document is the first mapping matrix for Agnum products, warehouses, categories, and suppliers against current Warehouse master data.
+
+## Short Answer
+
+Basic Warehouse fields exist for simple import/export:
+
+- product code/SKU;
+- name;
+- category;
+- base UoM;
+- weight;
+- active status;
+- primary and additional barcodes;
+- supplier master;
+- supplier item mapping;
+- warehouse and location master.
+
+But we do not yet have enough structure for a reliable Agnum read/import and balance foundation:
+
+- no first-class Agnum external product reference `(sndid, ID_PRK)`;
+- no first-class Agnum virtual warehouse mapping `(sndid -> MES virtual warehouse context)`;
+- no first-class mapping from Agnum virtual warehouse to allowed MES physical warehouses/locations;
+- no storage for Agnum product custom fields `group`, `category`, `subgroup`, `direction`, `branch`, `place`, `f1..f20`;
+- no virtual warehouse balance import table;
+- no distribution workflow from imported virtual balances to physical MES bins;
+- no clear supplier import source from Agnum API yet;
+- no history/status table for product import/export runs;
+- no raw Agnum payload snapshot for troubleshooting.
+
+So: simple mapping can be done now, production-grade mapping needs migrations.
+
+## Agnum Product to Warehouse Item
+
+| Agnum field | Meaning | Current Warehouse target | Exists now? | Recommendation |
+| --- | --- | --- | --- | --- |
+| `id` | `PRK.ID_PRK`; unique only inside `sndid` context | No safe target. `Item.ProductConfigId` is too weak. | Partial | Add `ItemExternalReference` or `AgnumProductLink` with `ItemId`, `SndId`, `AgnumProductId`, `ApiUserKeyName`, timestamps. |
+| `code` | Product code, max 25, required | `Item.InternalSKU` | Yes | Use as primary SKU for import/export unless business confirms different SKU source. |
+| `name` | Product name | `Item.Name` | Yes | Direct mapping. |
+| `enabled` | Active flag | `Item.Status` | Yes | `true -> Active`, `false -> Discontinued` or `Obsolete`; confirm final status rule. |
+| `pcs` | UoM | `Item.BaseUoM` | Yes | Needs UoM normalization table, because Agnum values include lower-case/free-form values like `vnt`, `m`, `m2`, `kompl`. |
+| `barcode` / `barcodes` | Product barcodes | `Item.PrimaryBarcode`, `ItemBarcode` | Yes | Import first barcode as primary, all as `ItemBarcode`; importer must accept both field names. |
+| `netto` | Net weight | `Item.Weight` | Yes | Direct mapping if unit is kg; confirm. |
+| `brutto` | Gross weight | No separate field | No | Add `GrossWeight` or store in custom attributes. Current `Weight` can only hold one weight. |
+| `balance` | Agnum current qty for API key's `sndid` | Separate virtual warehouse balance model | No | Do not write to `Item`. Import as `AgnumVirtualWarehouseBalance` and use as virtual balance/opening stock/reconciliation source. |
+| `modify_date` | Agnum modified timestamp | No external sync field | No | Store on external reference or sync state. |
+| `create_date` | Agnum created timestamp | `Item.CreatedAt` only for MES create time | Partial | Keep as Agnum metadata on external reference, not as MES `CreatedAt`. |
+| `place` | Agnum storage/bin place | `Location.Code` or `Location.Bin` | Partial | Use only if business says Agnum `place` is maintained. Needs mapping table, not direct overwrite. |
+| `group` | Product group | `ItemCategory` or custom classification | Partial | Could map to category level 1, but current category has only one hierarchy. Confirm whether `group/category/subgroup` should become hierarchy. |
+| `category` | Product category | `ItemCategory` | Partial | Same as above. Current `ItemCategory` can support hierarchy but not multiple independent classifier dimensions. |
+| `subgroup` | Product subgroup | `ItemCategory` | Partial | Same as above. |
+| `direction` | Product direction/classifier | None | No | Add custom attributes/classifiers if needed. |
+| `branch` | Product branch/classifier | None | No | Add custom attributes/classifiers if needed. |
+| `f1` | Intrastat commodity code | None | No | Add `ItemAttribute` or explicit `IntrastatCode`. |
+| `f2` | Supplier-provided product code | `SupplierItemMapping.SupplierSKU` | Partial | Needs supplier identity/source. If no supplier in payload, store as attribute or create pending supplier mapping. |
+| `f3..f5` | Custom text fields | None | No | Add flexible attributes if business wants retention. |
+| `f6` | Intrastat quantity coefficient | None | No | Add `ItemAttribute` or explicit numeric field. |
+| `f7..f10` | Custom numeric fields | None | No | Add flexible attributes if business wants retention. |
+| `f11..f15` | Custom text fields | None | No | Add flexible attributes if business wants retention. |
+| `f16..f20` | Custom numeric fields | None | No | Add flexible attributes if business wants retention. |
+
+## Proposed Product Extension
+
+Minimum production-safe model:
+
+```text
+AgnumProductLink
+- Id
+- ItemId
+- SndId
+- AgnumProductId
+- AgnumCode
+- AgnumEnabled
+- AgnumModifiedAt
+- LastImportedAt
+- LastExportedAt
+- SourceApiUserKeyName
+- RawHash
+- IsPrimary
+Unique: (SndId, AgnumProductId)
+Unique: (SndId, AgnumCode)
+```
+
+For custom fields, prefer a generic table first:
+
+```text
+ItemExternalAttribute
+- Id
+- ItemId
+- SourceSystem = AGNUM
+- SourceContext = sndid or api user
+- Key = group/category/subgroup/direction/branch/place/f1...
+- ValueText
+- ValueNumber
+- ValueDate
+Unique: (ItemId, SourceSystem, SourceContext, Key)
+```
+
+Later, promote heavily used fields to explicit columns only after business confirms they are operationally important.
+
+## Agnum Warehouses to MES Virtual Warehouses
+
+Agnum warehouse/store context comes from API user `sndid`, not from a request field.
+
+Rule:
+
+- Agnum `sndid` becomes a MES virtual warehouse context.
+- Physical MES locations are not the same as Agnum warehouses.
+- A virtual balance can later be distributed into one or more real MES physical warehouses/locations/bins.
+
+Known `sndid` values from test DB:
+
+| Agnum sndid | Agnum name | Likely target in MES | Exists now? | Recommendation |
+| --- | --- | --- | --- | --- |
+| 493 | Sandelys / Centrinis sandelys | MES virtual warehouse, later distributable to real physical locations | Not configured | Add virtual mapping. |
+| 496 | Pardavimai / Pagaminta produkcija-pardavimai | MES virtual warehouse, later distributable to real physical locations | Not configured | Add virtual mapping. |
+| 498 | Gamyba / Gamybos sandelys | MES virtual warehouse, later distributable to real physical locations | Not configured | Add virtual mapping. |
+| 500 | Mazavertis | Low-value inventory | Unknown | Business confirmation needed. |
+| 502 | Kuras | Fuel/transport | Unknown | Probably not core WMS stock; confirm. |
+| 507 | Ilgalaikis | Fixed assets | Unknown | Probably not core WMS stock; confirm. |
+| 509 | Visi | All warehouses | No direct MES warehouse | Do not map as operational warehouse unless Agnum confirms semantics. |
+| 1498 | Nebaigta statyba | WIP/construction | Unknown | Confirm. |
+| 12503 | Paslaugos | Services | Not stock warehouse | Likely exclude from WMS item import. |
+| 142026 | PVZ | Samples | Unknown | Confirm. |
+| 142029 | Parduotuve | Online shop/store | Unknown | Confirm. |
+
+Needed model:
+
+```text
+AgnumWarehouseMapping
+- Id
+- SndId
+- AgnumName
+- AgnumDescription
+- MesVirtualWarehouseCode
+- MesVirtualWarehouseName
+- DefaultTargetPhysicalWarehouseId (optional)
+- DefaultTargetLocationId (optional)
+- AllowedPhysicalWarehouseIds or separate child table
+- ApiKeySecretRef
+- IsImportEnabled
+- IsDistributionEnabled
+- IsExportEnabled (later)
+- IsBalanceReconciliationEnabled
+- Notes
+Unique: SndId
+```
+
+Current `Location.WarehouseId` exists and `WarehouseLayoutAggregate`/warehouse directory exists, but there is no Agnum `sndid` virtual mapping table.
+
+## Agnum Balances to Virtual Warehouse Balances
+
+Agnum balance belongs to the virtual warehouse context, not to `Item`.
+
+Needed model:
+
+```text
+AgnumBalanceImportRun
+- Id
+- StartedAt
+- FinishedAt
+- Status
+- SndId
+- ProductCount
+- BalanceCount
+- ErrorCount
+- SourceHash
+
+AgnumVirtualWarehouseBalance
+- Id
+- ImportRunId
+- SndId
+- AgnumProductId
+- ItemId
+- Sku
+- Quantity
+- Uom
+- ImportedAt
+- SourceHash
+Unique: (ImportRunId, SndId, AgnumProductId)
+```
+
+Physical distribution should consume from these records through a separate workflow/document, not by rewriting imported Agnum balances.
+
+## Agnum Categories to Warehouse Categories
+
+Agnum product classification exposes multiple dimensions:
+
+- `group`
+- `category`
+- `subgroup`
+- `direction`
+- `branch`
+
+Warehouse currently has one hierarchical `ItemCategory`:
+
+- `Code`
+- `Name`
+- `ParentCategoryId`
+
+Mapping options:
+
+1. Simple hierarchy: `group -> category -> subgroup`.
+2. Keep `direction` and `branch` as external attributes.
+3. Build a separate classifier model if these dimensions are operationally important.
+
+Recommended MVP:
+
+- Import `group/category/subgroup` into `ItemCategory` hierarchy.
+- Generate stable category codes from normalized Agnum values plus hash when needed.
+- Store original Agnum classifier values in `ItemExternalAttribute`.
+- Do not force `direction`/`branch` into `ItemCategory` until confirmed.
+
+Potential gaps:
+
+- Current category code max/normalization rules may need Lithuanian-safe slug generation.
+- Need source context so MES-created categories and Agnum-imported categories do not collide.
+
+## Agnum Suppliers to Warehouse Suppliers
+
+Current Warehouse supplier model:
+
+- `Supplier.Code`
+- `Supplier.Name`
+- `Supplier.ContactInfo`
+
+Current supplier-item mapping:
+
+- `SupplierItemMapping.SupplierId`
+- `SupplierItemMapping.SupplierSKU`
+- `SupplierItemMapping.ItemId`
+- `LeadTimeDays`
+- `MinOrderQty`
+- `PricePerUnit`
+
+Agnum product field `f2` is supplier-provided product code, but product payload does not identify the supplier.
+
+Therefore:
+
+- `f2 -> SupplierItemMapping.SupplierSKU` is only possible if we can identify supplier by another Agnum source.
+- Without supplier identity, store `f2` as `ItemExternalAttribute(key=f2)` and mark supplier mapping as unresolved.
+
+Need to inspect/confirm Agnum API supplier endpoints. Current reviewed docs mention client lookup, products, documents, but not a clear supplier/vendor master endpoint.
+
+## Import/Export Field Availability
+
+Current Excel master-data import supports:
+
+- Items: `InternalSKU`, `Name`, `Description`, `CategoryCode`, `BaseUoM`, `Weight`, `Volume`, `RequiresLotTracking`, `RequiresQC`, `Status`, `PrimaryBarcode`, `ProductConfigId`
+- Suppliers: `Code`, `Name`, `ContactInfo`
+- Supplier mappings: `SupplierCode`, `SupplierSKU`, `ItemSKU`, `LeadTimeDays`, `MinOrderQty`, `PricePerUnit`
+- Barcodes: `ItemSKU`, `Barcode`, `BarcodeType`, `IsPrimary`
+- Locations: `Code`, `Barcode`, `Type`, `ParentCode`, `IsVirtual`, `MaxWeight`, `MaxVolume`, `Status`, `ZoneType`
+
+For Agnum import this is not enough because it lacks:
+
+- `SndId`;
+- `AgnumProductId`;
+- Agnum `enabled` source state;
+- Agnum timestamps;
+- product classifier dimensions;
+- custom fields `f1..f20`;
+- virtual balance quantity by `sndid`;
+- physical distribution status/remaining quantity;
+- raw payload hash/source metadata.
+
+## Recommended Next Implementation Tasks
+
+1. Add migrations/entities for `AgnumWarehouseMapping`, `AgnumProductLink`, `ItemExternalAttribute`, `AgnumBalanceImportRun`, and `AgnumVirtualWarehouseBalance`.
+2. Add DTO mapping document/tests for `AgnumProductDto -> ItemImportCandidate`.
+3. Add read-only product import preview from Agnum by configured `sndid`.
+4. Add conflict report before writing any MES master data.
+5. Add UoM mapping table for Agnum `pcs -> UnitOfMeasure.Code`.
+6. Add category import strategy and category-code generator.
+7. Add virtual balance import/display before any export back to Agnum.
+8. Add distribution workflow from virtual balance into physical MES locations.
+9. Decide supplier source; keep `f2` as unresolved supplier SKU until supplier identity is available.

--- a/docs/agnum-integration-plan/CODEX-IMPLEMENTATION-BLUEPRINT.md
+++ b/docs/agnum-integration-plan/CODEX-IMPLEMENTATION-BLUEPRINT.md
@@ -524,8 +524,11 @@ In `Infrastructure/DependencyInjection.cs`, add:
 - `IAgnumNomenclatureImportService` → `AgnumNomenclatureImportService` scoped.
 - `IAgnumBalanceImportService` → `AgnumBalanceImportService` scoped.
 
-Bind config: `services.Configure<AgnumApiClientOptions>(config.GetSection("Agnum"))`.
-Loop `config.GetSection("Agnum:Warehouses").GetChildren()` to register per-warehouse clients.
+Bind config: `services.Configure<AgnumApiClientOptions>(config.GetSection("Agnum:Api"))`.
+Loop `config.GetSection("Agnum:Warehouses").GetChildren()` to register per-warehouse named HttpClients.
+Config key for base URL: `Agnum:Api:BaseUrl` (default `http://agnum-api:8181`).
+Register `IAgnumApiClientFactory` as **Singleton** (reads config once in constructor).
+Register `IAgnumNomenclatureImportService` and `IAgnumBalanceImportService` as **Scoped**.
 
 ---
 

--- a/docs/agnum-integration-plan/CODEX-IMPLEMENTATION-BLUEPRINT.md
+++ b/docs/agnum-integration-plan/CODEX-IMPLEMENTATION-BLUEPRINT.md
@@ -1,0 +1,627 @@
+# Codex Implementation Blueprint — Agnum Import Foundation (Slice 1)
+
+Created: 2026-05-18
+
+## Scope
+
+Slice 1 builds the read/import foundation:
+
+- `IAgnumApiClient` with X-API-KEY auth
+- Typed product and balance DTOs (defensive barcode handling)
+- `AgnumApiClient` implementation in Infrastructure
+- Five new entities + EF Core migration
+- `AgnumNomenclatureImportService` (product import with conflict detection)
+- `AgnumBalanceImportService` (virtual balance import)
+- `AgnumImportController` with read/trigger endpoints (new controller, separate from the frozen `AgnumController`)
+- Unit tests for import logic
+
+**Out of Slice 1:** Blazor pages, distribution command, 3D search, old export refactor, document export,
+MassTransit sagas. See `MVP-SCOPE.md`.
+
+---
+
+## Verified existing names
+
+These names are confirmed in the repository. Use them exactly.
+
+### Application layer — Commands
+
+| Class | Namespace | File |
+| --- | --- | --- |
+| `RecordStockMovementCommand` | `LKvitai.MES.Modules.Warehouse.Application.Commands` | `Application/Commands/RecordStockMovementCommand.cs` |
+| `ReceiveGoodsCommand` | same | `Application/Commands/ReceiveGoodsCommand.cs` |
+| `AllocateReservationCommand` | same | `Application/Commands/AllocateReservationCommand.cs` |
+
+### Application layer — Ports
+
+| Interface | Namespace | File |
+| --- | --- | --- |
+| `IStockLedgerRepository` | `LKvitai.MES.Modules.Warehouse.Application.Ports` | `Application/Ports/IStockLedgerRepository.cs` |
+| `IAvailableStockRepository` | same | `Application/Ports/IAvailableStockRepository.cs` |
+| `IEventBus` | same | `Application/Ports/IEventBus.cs` |
+
+### Infrastructure — Persistence
+
+| Class | Namespace | File |
+| --- | --- | --- |
+| `WarehouseDbContext` | `LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence` | `Infrastructure/Persistence/WarehouseDbContext.cs` |
+
+Existing `DbSet` properties relevant to Slice 1:
+
+```csharp
+public DbSet<Item> Items => Set<Item>();
+public DbSet<ItemBarcode> ItemBarcodes => Set<ItemBarcode>();
+public DbSet<ItemCategory> ItemCategories => Set<ItemCategory>();
+public DbSet<UnitOfMeasure> UnitOfMeasures => Set<UnitOfMeasure>();
+public DbSet<SupplierItemMapping> SupplierItemMappings => Set<SupplierItemMapping>();
+```
+
+### Integration — Agnum (frozen files)
+
+| Class/Interface | File | Note |
+| --- | --- | --- |
+| `IAgnumExportService` | `Integration/Agnum/IAgnumExportService.cs` | **Frozen** — old export interface |
+| `ExportMode` enum | same | **Frozen** |
+
+### Domain — Entities (frozen Agnum entities)
+
+In `Domain/Entities/MasterDataEntities.cs`:
+
+- `AgnumExportConfig` — **frozen**
+- `AgnumMapping` — **frozen**
+- `AgnumExportHistory` — **frozen**
+
+### Api — Frozen services and controller
+
+| File | Location | Note |
+| --- | --- | --- |
+| `AgnumController.cs` | `Api/Api/Controllers/` | **Frozen** |
+| `AgnumExportServices.cs` | `Api/Services/` | **Frozen** — contains `IAgnumExportOrchestrator`, `IAgnumSecretProtector` |
+| `AgnumReconciliationServices.cs` | `Api/Services/` | **Frozen** |
+
+### Packages already in `Directory.Packages.props`
+
+No `Version=` attribute allowed in any csproj.
+
+| Package | Available |
+| --- | --- |
+| `Polly` 8.2.1 | Yes |
+| `Microsoft.EntityFrameworkCore` | Yes |
+| `Npgsql.EntityFrameworkCore.PostgreSQL` | Yes |
+| `Moq` | Yes (tests) |
+| `FluentAssertions` | Yes (tests) |
+| `xunit` | Yes (tests) |
+| `Microsoft.EntityFrameworkCore.InMemory` | Yes (tests) |
+
+### Infrastructure csproj current packages
+
+`Infrastructure.csproj` currently has: `ClosedXML`, `EFCore.BulkExtensions`, `Marten`, `Npgsql.EntityFrameworkCore.PostgreSQL`, `Microsoft.EntityFrameworkCore`, `Microsoft.EntityFrameworkCore.Design`, `StackExchange.Redis`, `Serilog`, `Serilog.Sinks.Console`, `Serilog.Sinks.File`.
+
+**To add for Slice 1:** `<PackageReference Include="Polly" />` (no version — CPM).
+Check whether `Microsoft.Extensions.Http` is needed; `IHttpClientFactory` is available through
+`Microsoft.Extensions.DependencyInjection` which ASP.NET Core provides transitively via Api.
+If the Infrastructure build fails due to missing `IHttpClientFactory`, add `<PackageReference Include="Microsoft.Extensions.Http" />`.
+
+### Integration csproj current packages
+
+`Integration.csproj` has no `PackageReference` entries — only two `ProjectReference` entries
+(Contracts, SharedKernel). The new `AgnumApiClient` lives in **Infrastructure**, not Integration,
+to keep Integration free of HTTP/Polly dependencies. See layer placement below.
+
+---
+
+## Layer placement for Slice 1
+
+```
+Integration/Agnum/
+  IAgnumApiClient.cs          ← interface + AgnumProductDto + AgnumBalanceLineDto (layer 3)
+
+Domain/Entities/
+  AgnumImportEntities.cs      ← 5 new entities (layer 3, new file, NOT editing MasterDataEntities.cs)
+
+Application/Ports/
+  IAgnumNomenclatureImportService.cs   ← import service interface (layer 4)
+  IAgnumBalanceImportService.cs        ← balance import service interface (layer 4)
+
+Infrastructure/Agnum/           ← new directory
+  AgnumApiClient.cs             ← IHttpClientFactory-based impl of IAgnumApiClient (layer 5)
+  AgnumApiClientOptions.cs      ← config binding POCO
+  AgnumNomenclatureImportService.cs   ← uses WarehouseDbContext + IAgnumApiClient (layer 5)
+  AgnumBalanceImportService.cs        ← uses WarehouseDbContext + IAgnumApiClient (layer 5)
+
+Infrastructure/Persistence/
+  WarehouseDbContext.cs         ← EDIT: add 5 new DbSets + Fluent API for new tables
+  Migrations/YYYYMMDD_AddAgnumImportTables.cs  ← new migration
+
+Api/Controllers/
+  AgnumImportController.cs     ← NEW controller (do not edit AgnumController.cs)
+```
+
+Layer rule check:
+- `Integration` references only Contracts + SharedKernel. Adding only an interface + plain DTOs there is safe.
+- `Application/Ports` is already the home for port interfaces. New service ports go there.
+- `Infrastructure` references Application, Domain, Integration via the build graph. `AgnumApiClient` in Infrastructure can implement `IAgnumApiClient` from Integration.
+
+---
+
+## Files to create
+
+### 1. `Integration/Agnum/IAgnumApiClient.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Integration.Agnum`
+
+```csharp
+public interface IAgnumApiClient
+{
+    // Returns all products for the sndid bound to this client's API key.
+    // Does NOT use limit/offset — jar 1.39 pagination is buggy.
+    Task<IReadOnlyList<AgnumProductDto>> GetProductsAsync(CancellationToken ct = default);
+}
+```
+
+Also in the same file or same folder:
+
+```csharp
+public sealed class AgnumProductDto
+{
+    public int Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+    public string Pcs { get; init; } = string.Empty;
+    public decimal Balance { get; init; }       // PRK.KIEKIS — balance for this API key's sndid
+    public decimal? Netto { get; init; }
+    public decimal? Brutto { get; init; }
+    // Barcode fields: API may return either; importer must accept both
+    public string? Barcode { get; init; }
+    [JsonPropertyName("barcodes")]
+    public List<string>? Barcodes { get; init; }
+    public DateTime? ModifyDate { get; init; }
+    public DateTime? CreateDate { get; init; }
+    public string? Group { get; init; }
+    public string? Category { get; init; }
+    public string? Subgroup { get; init; }
+    public string? Direction { get; init; }
+    public string? Branch { get; init; }
+    public string? Place { get; init; }
+    public string? F1 { get; init; }
+    public string? F2 { get; init; }
+    // F3-F20 add if needed later
+}
+```
+
+No `Balance` endpoint separate call is needed for Slice 1 — balance is included in the product payload
+via `balance` field. `GetProductsAsync` returns products including their `balance` field.
+
+---
+
+### 2. `Infrastructure/Agnum/AgnumApiClientOptions.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum`
+
+```csharp
+public sealed class AgnumApiClientOptions
+{
+    public string BaseUrl { get; set; } = "http://agnum-api:8181";
+    public int TimeoutSeconds { get; set; } = 15;
+}
+
+public sealed class AgnumWarehouseKeyOptions
+{
+    public int SndId { get; set; }
+    public string ApiKey { get; set; } = string.Empty;
+}
+```
+
+Config binding path: `Agnum:BaseUrl`, `Agnum:TimeoutSeconds`, `Agnum:Warehouses:{name}:SndId`,
+`Agnum:Warehouses:{name}:ApiKey`.
+
+---
+
+### 3. `Infrastructure/Agnum/AgnumApiClient.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum`
+
+Implements `IAgnumApiClient`.
+
+- Constructor takes `IHttpClientFactory`, `AgnumWarehouseKeyOptions` (the specific key for this instance), `ILogger<AgnumApiClient>`.
+- Uses named `HttpClient` registered as `"agnum-{name}"` in DI.
+- Sets `X-API-KEY: {apiKey}` header on every request.
+- Calls `GET /api/products/search` (no pagination params).
+- Log the request at Debug level; redact the API key in all log messages.
+- On HTTP error response: log warning and return empty list (do not throw; let the import service record the error in the run status).
+- **Do not use Polly for Slice 1.** Add a TODO comment: `// TODO Slice2: add Polly retry for transient HTTP errors`.
+- Deserialize with `System.Text.Json`. Handle both `barcode` (string) and `barcodes` (array) by using `JsonPropertyName` as shown in the DTO above. Verify during deserialization: if `barcode` is non-null and `barcodes` is null, populate a synthetic single-item list for downstream use.
+
+---
+
+### 4. `Domain/Entities/AgnumImportEntities.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Domain.Entities`
+
+New file. Do not edit `MasterDataEntities.cs`.
+
+```csharp
+// Configuration: one row per Agnum warehouse (sndid) enabled for import
+public sealed class AgnumWarehouseMapping : AuditableEntity  // AuditableEntity exists in MasterDataEntities.cs
+{
+    public int Id { get; set; }
+    public int SndId { get; set; }
+    public string AgnumName { get; set; } = string.Empty;
+    public string MesVirtualWarehouseCode { get; set; } = string.Empty;
+    public string ApiKeyConfigName { get; set; } = string.Empty;  // references Agnum:Warehouses:{name}
+    public bool IsImportEnabled { get; set; }
+}
+
+// Link between MES Item and Agnum product; one row per (sndid, agnumProductId)
+public sealed class AgnumProductLink : AuditableEntity
+{
+    public int Id { get; set; }
+    public int ItemId { get; set; }
+    public int SndId { get; set; }
+    public int AgnumProductId { get; set; }
+    public string AgnumCode { get; set; } = string.Empty;
+    public bool AgnumEnabled { get; set; }
+    public DateTime? AgnumModifiedAt { get; set; }
+    public DateTime? LastImportedAt { get; set; }
+    public string? RawHash { get; set; }
+
+    public Item? Item { get; set; }
+}
+
+// Flexible key/value store for Agnum product classifiers (group, category, subgroup, direction, branch, place, f1..f20)
+public sealed class ItemExternalAttribute
+{
+    public int Id { get; set; }
+    public int ItemId { get; set; }
+    public string SourceSystem { get; set; } = "AGNUM";
+    public string SourceContext { get; set; } = string.Empty;  // sndid as string
+    public string Key { get; set; } = string.Empty;            // "group", "category", "f1", etc.
+    public string? ValueText { get; set; }
+    public decimal? ValueNumber { get; set; }
+
+    public Item? Item { get; set; }
+}
+
+// Tracks one import run for a specific sndid
+public sealed class AgnumBalanceImportRun
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public int SndId { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+    public string Status { get; set; } = "Running";   // Running, Completed, Failed
+    public int ProductCount { get; set; }
+    public int BalanceCount { get; set; }
+    public int ErrorCount { get; set; }
+    public string? ErrorSummary { get; set; }
+}
+
+// One row per (importRunId, sndId, agnumProductId)
+public sealed class AgnumVirtualWarehouseBalance
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ImportRunId { get; set; }
+    public int SndId { get; set; }
+    public int AgnumProductId { get; set; }
+    public int? ItemId { get; set; }           // null if product not yet linked to MES Item
+    public string? Sku { get; set; }
+    public decimal Quantity { get; set; }
+    public string Uom { get; set; } = string.Empty;
+    public DateTime ImportedAt { get; set; }
+    public string? SourceHash { get; set; }
+
+    public AgnumBalanceImportRun? ImportRun { get; set; }
+}
+```
+
+Table names (use in Fluent API):
+
+| Entity | Table |
+| --- | --- |
+| `AgnumWarehouseMapping` | `agnum_warehouse_mappings` |
+| `AgnumProductLink` | `agnum_product_links` |
+| `ItemExternalAttribute` | `item_external_attributes` |
+| `AgnumBalanceImportRun` | `agnum_balance_import_runs` |
+| `AgnumVirtualWarehouseBalance` | `agnum_virtual_warehouse_balances` |
+
+Unique constraints:
+
+- `AgnumProductLink`: `(SndId, AgnumProductId)` unique; `(SndId, AgnumCode)` unique.
+- `ItemExternalAttribute`: `(ItemId, SourceSystem, SourceContext, Key)` unique.
+- `AgnumVirtualWarehouseBalance`: `(ImportRunId, SndId, AgnumProductId)` unique.
+
+---
+
+### 5. `Infrastructure/Persistence/WarehouseDbContext.cs` — EDIT
+
+Add five new `DbSet` properties and Fluent API `OnModelCreating` blocks for the five new entities.
+Follow the existing pattern in the file.
+
+```csharp
+// New DbSets
+public DbSet<AgnumWarehouseMapping> AgnumWarehouseMappings => Set<AgnumWarehouseMapping>();
+public DbSet<AgnumProductLink> AgnumProductLinks => Set<AgnumProductLink>();
+public DbSet<ItemExternalAttribute> ItemExternalAttributes => Set<ItemExternalAttribute>();
+public DbSet<AgnumBalanceImportRun> AgnumBalanceImportRuns => Set<AgnumBalanceImportRun>();
+public DbSet<AgnumVirtualWarehouseBalance> AgnumVirtualWarehouseBalances => Set<AgnumVirtualWarehouseBalance>();
+```
+
+Add Fluent API blocks. Follow the pattern in the existing AgnumExportConfig block in the file.
+
+---
+
+### 6. Migration
+
+Generate with:
+```bash
+dotnet ef migrations add AddAgnumImportTables \
+  --project src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure \
+  --startup-project src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api
+```
+
+Or write the migration manually following the existing pattern in `20260211070343_AddAgnumExportTables.cs`.
+
+---
+
+### 7. `Application/Ports/IAgnumNomenclatureImportService.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Application.Ports`
+
+```csharp
+public interface IAgnumNomenclatureImportService
+{
+    Task<AgnumImportPreview> PreviewAsync(int sndId, CancellationToken ct = default);
+    Task<AgnumImportResult> ApplyAsync(int sndId, CancellationToken ct = default);
+}
+
+public sealed class AgnumImportPreview
+{
+    public int SndId { get; init; }
+    public int TotalProducts { get; init; }
+    public List<AgnumImportCandidate> ToCreate { get; init; } = new();
+    public List<AgnumImportCandidate> ToUpdate { get; init; } = new();
+    public List<AgnumImportConflict> Conflicts { get; init; } = new();
+}
+
+public sealed class AgnumImportCandidate
+{
+    public int AgnumProductId { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Pcs { get; init; } = string.Empty;
+}
+
+public sealed class AgnumImportConflict
+{
+    public int AgnumProductId { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Reason { get; init; } = string.Empty;  // "UnknownUoM", "DuplicateSku", "LinkedToDifferentItem"
+}
+
+public sealed class AgnumImportResult
+{
+    public int Created { get; init; }
+    public int Updated { get; init; }
+    public int Skipped { get; init; }
+    public List<AgnumImportConflict> Conflicts { get; init; } = new();
+}
+```
+
+---
+
+### 8. `Application/Ports/IAgnumBalanceImportService.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Application.Ports`
+
+```csharp
+public interface IAgnumBalanceImportService
+{
+    Task<Guid> StartImportAsync(int sndId, CancellationToken ct = default);
+    Task<AgnumBalanceImportRunStatus> GetRunStatusAsync(Guid runId, CancellationToken ct = default);
+}
+
+public sealed class AgnumBalanceImportRunStatus
+{
+    public Guid RunId { get; init; }
+    public int SndId { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public int ProductCount { get; init; }
+    public int BalanceCount { get; init; }
+    public int ErrorCount { get; init; }
+    public string? ErrorSummary { get; init; }
+    public DateTime StartedAt { get; init; }
+    public DateTime? FinishedAt { get; init; }
+}
+```
+
+---
+
+### 9. `Infrastructure/Agnum/AgnumNomenclatureImportService.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum`
+
+Implements `IAgnumNomenclatureImportService`.
+
+Dependencies: `IAgnumApiClient` (resolved by sndId — see DI registration note below), `WarehouseDbContext`, `ILogger<AgnumNomenclatureImportService>`.
+
+**DI note:** `IAgnumApiClient` must be resolved per sndId. Use a factory approach:
+define `IAgnumApiClientFactory` with `IAgnumApiClient GetForSndId(int sndId)` in
+`Integration/Agnum/` and inject the factory into import services. The factory resolves
+the correct named `HttpClient`.
+
+**Conflict detection logic:**
+
+| Conflict type | Condition | Reason string |
+| --- | --- | --- |
+| `UnknownUoM` | `product.Pcs` not in `UnitOfMeasures` table | `"UnknownUoM"` |
+| `DuplicateSku` | Another `Item` with same `InternalSKU` exists and no `AgnumProductLink` for this `(sndId, agnumProductId)` | `"DuplicateSku"` |
+| `LinkedToDifferentItem` | `AgnumProductLink` for `(sndId, agnumProductId)` points to a different item | `"LinkedToDifferentItem"` |
+
+**Apply logic:**
+
+- For `ToCreate`: create `Item` (set `InternalSKU = product.Code`, `Name`, `BaseUoM`, `Status`, `Weight = product.Netto`), create `AgnumProductLink`, import barcodes to `ItemBarcode`, import category hierarchy to `ItemCategory` (create levels as needed), store `group/category/subgroup/direction/branch/f1/f2` as `ItemExternalAttribute`.
+- For `ToUpdate`: update `Item` fields that differ, update `AgnumProductLink` timestamps and hash.
+- Skip conflict rows; include them in `AgnumImportResult.Conflicts`.
+
+---
+
+### 10. `Infrastructure/Agnum/AgnumBalanceImportService.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum`
+
+Implements `IAgnumBalanceImportService`.
+
+Logic for `StartImportAsync`:
+
+1. Create `AgnumBalanceImportRun` with `Status = "Running"`, `StartedAt = UtcNow`. Save.
+2. Call `IAgnumApiClient.GetProductsAsync` (via factory for the given sndId).
+3. For each product where `balance > 0` (or all, to also record zero balances): upsert `AgnumVirtualWarehouseBalance` matching latest `AgnumProductLink` for `(sndId, product.Id)` to get `ItemId` and `Sku`.
+4. Update run with counts and `Status = "Completed"` (or `"Failed"` on exception). Save.
+5. Return `run.Id`.
+
+---
+
+### 11. `Api/Controllers/AgnumImportController.cs`
+
+Namespace: `LKvitai.MES.Modules.Warehouse.Api.Controllers`
+
+**New controller — do not edit `AgnumController.cs`.**
+
+```
+POST /api/warehouse/v1/agnum/import/products?sndId={sndId}&apply=false
+  → returns AgnumImportPreview (preview) or AgnumImportResult (apply)
+  → apply=true triggers ApplyAsync
+
+POST /api/warehouse/v1/agnum/import/balances?sndId={sndId}
+  → triggers StartImportAsync, returns { runId: guid }
+
+GET  /api/warehouse/v1/agnum/import/status/{runId}
+  → returns AgnumBalanceImportRunStatus
+
+GET  /api/warehouse/v1/agnum/virtual-warehouses
+  → returns list of AgnumWarehouseMapping (sndId, name, virtualCode, isEnabled)
+
+GET  /api/warehouse/v1/agnum/nomenclature?sndId={sndId}&search={text}&page={n}
+  → returns paged list from AgnumProductLink joined to Item
+
+GET  /api/warehouse/v1/agnum/balances?sndId={sndId}
+  → returns latest AgnumVirtualWarehouseBalance rows for the most recent Completed run
+```
+
+No MediatR required for these endpoints in Slice 1. Direct service injection is fine.
+These are read/import orchestration endpoints, not domain command dispatch.
+
+---
+
+### 12. DI registration
+
+In `Infrastructure/DependencyInjection.cs`, add:
+
+- Named `HttpClient` registrations: one per configured warehouse key.
+- `AgnumApiClient` instantiation per named client.
+- `IAgnumApiClientFactory` → `AgnumApiClientFactory` singleton.
+- `IAgnumNomenclatureImportService` → `AgnumNomenclatureImportService` scoped.
+- `IAgnumBalanceImportService` → `AgnumBalanceImportService` scoped.
+
+Bind config: `services.Configure<AgnumApiClientOptions>(config.GetSection("Agnum"))`.
+Loop `config.GetSection("Agnum:Warehouses").GetChildren()` to register per-warehouse clients.
+
+---
+
+## Tests — Slice 1
+
+Location: `tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/`
+
+### Test file 1: `AgnumImportConflictDetectionTests.cs`
+
+Cover `AgnumNomenclatureImportService` conflict detection in isolation using `Moq` + `Microsoft.EntityFrameworkCore.InMemory`:
+
+- Product with unknown `pcs` → conflict `UnknownUoM`
+- Product whose code matches existing `Item.InternalSKU` but no link exists → conflict `DuplicateSku`
+- Product with existing link pointing to different item → conflict `LinkedToDifferentItem`
+- Product with valid `pcs` and no existing item → classified as `ToCreate`
+- Product with valid `pcs` and existing linked item → classified as `ToUpdate`
+
+### Test file 2: `AgnumProductDtoDeserializationTests.cs`
+
+Cover defensive barcode deserialization:
+
+- JSON with `"barcode": "12345"` (string) → single barcode available
+- JSON with `"barcodes": ["12345", "67890"]` (array) → list available
+- JSON with both fields → both parsed without error
+- JSON with neither field → no barcode, no exception
+
+### Test file 3: `AgnumBalanceImportServiceTests.cs`
+
+Cover `AgnumBalanceImportService` with mocked `IAgnumApiClient` and in-memory DbContext:
+
+- Happy path: 3 products with balances → run created, 3 balance rows inserted
+- No linked item for a product → `ItemId = null` in balance row, run still `Completed`
+- API client returns empty list → run `Completed` with zero counts
+
+---
+
+## Definition of done for Slice 1
+
+- `dotnet build src/LKvitai.MES.sln -c Release` — zero errors
+- `dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit` — all pass
+- `dotnet test tests/ArchitectureTests/...` — all pass
+- Migration generates cleanly; `dotnet ef database update` on a clean dev DB succeeds
+- `GET /api/warehouse/v1/agnum/virtual-warehouses` returns configured sndid rows
+- `POST /api/warehouse/v1/agnum/import/products?sndId=493&apply=false` returns a preview with `ToCreate`, `ToUpdate`, and `Conflicts` sections
+- `POST /api/warehouse/v1/agnum/import/balances?sndId=493` returns a run ID and the run reaches `Completed`
+- No Blazor pages, no distribution command, no Agnum document export
+
+---
+
+## Ready-to-copy Codex prompt for Slice 1
+
+```
+You are implementing Slice 1 of the Agnum import foundation for the Warehouse module.
+
+Read these files before writing any code:
+- docs/agnum-integration-plan/MVP-SCOPE.md  (scope gate, frozen files, defaults)
+- docs/agnum-integration-plan/CODEX-IMPLEMENTATION-BLUEPRINT.md  (this file — exact names, placement, tests)
+- docs/agnum-integration-plan/02-agnum-api-findings.md  (real Agnum API shape)
+- docs/agnum-integration-plan/06-master-data-mapping.md  (field mapping and conflict rules)
+- CLAUDE.md  (layer rules, forbidden patterns)
+
+Scope: implement only what is listed in CODEX-IMPLEMENTATION-BLUEPRINT.md § "Files to create".
+
+Layer rules (from CLAUDE.md):
+- IAgnumApiClient + DTOs → Integration/Agnum/ (no new NuGet refs there; BCL only)
+- New domain entities (AgnumImportEntities.cs) → Domain/Entities/ (no NuGet dependencies)
+- Application port interfaces → Application/Ports/
+- AgnumApiClient implementation, import services, DI → Infrastructure/Agnum/ (new directory)
+- AgnumImportController → Api/Controllers/ (new file)
+- Do NOT add Marten to Application. Do NOT add EF Core to Domain. Do NOT add Version= to any csproj.
+- If Infrastructure needs Polly, add: <PackageReference Include="Polly" /> (no version attribute).
+
+Frozen files — do not touch:
+- Api/Api/Controllers/AgnumController.cs
+- Api/Services/AgnumExportServices.cs
+- Api/Services/AgnumReconciliationServices.cs
+- Sagas/AgnumExportSaga.cs
+- Integration/Agnum/IAgnumExportService.cs
+- Any existing AgnumExportConfig / AgnumMapping / AgnumExportHistory entity or migration
+
+Do not create:
+- Blazor pages
+- Distribution command or workflow
+- 3D/2D product search
+- MassTransit sagas
+- Agnum document export
+- Any POST or PUT to the Agnum API
+
+Definition of done:
+- dotnet build src/LKvitai.MES.sln -c Release → zero errors
+- dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit → all pass
+- Architecture tests pass
+- GET /api/warehouse/v1/agnum/virtual-warehouses returns configured rows
+- POST /api/warehouse/v1/agnum/import/products?sndId=493&apply=false returns a valid preview
+- POST /api/warehouse/v1/agnum/import/balances?sndId=493 returns a run ID that reaches Completed status
+
+Start with the data model and entities. Then the connector. Then the import services. Then the controller. Tests last.
+If a name is not in the blueprint's verified tables, check the actual repo files before inventing it.
+```

--- a/docs/agnum-integration-plan/MVP-SCOPE.md
+++ b/docs/agnum-integration-plan/MVP-SCOPE.md
@@ -1,0 +1,75 @@
+# Agnum Integration — MVP Scope
+
+Created: 2026-05-18
+
+This file is the authoritative scope gate for the Agnum integration workstream.
+It governs what Codex implements in each slice.
+
+## Business goal
+
+The first deliverable is read-only visibility and a distribution bridge:
+
+1. MES shows the full Agnum nomenclature (product list) from each configured Agnum warehouse.
+2. MES shows how much stock exists per Agnum warehouse, with `sndid` as a virtual warehouse context.
+3. Product identity is `(sndid, agnumProductId)`. Agnum `code` is the SKU candidate.
+4. Agnum balance is never stored on `Item`. It lives in a separate virtual warehouse balance model.
+5. Users distribute those virtual balances into real MES physical warehouses and locations.
+6. After distribution, users can search products and see physical location in the existing 2D/3D viewer.
+7. Agnum document export is not part of this deliverable.
+
+## Phase status
+
+| Phase | Description | Status |
+| --- | --- | --- |
+| 0 | Business confirmations (sndid scope, UoM rules, category mapping) | **Resolved** — defaults in this file |
+| 1 | Agnum read connector (`IAgnumApiClient`, `AgnumApiClient`, DTOs) | **SLICE 1** |
+| 2 | Product/nomenclature import (`AgnumProductLink`, `ItemExternalAttribute`, conflict detection, apply) | **SLICE 1** |
+| 3 | Virtual balance import (`AgnumVirtualWarehouseBalance`, `AgnumBalanceImportRun`) | **SLICE 1** |
+| 4 | Distribution from virtual balance to physical MES location | **SLICE 2** — after Slice 1 compiles |
+| 5 | Product search + 2D/3D location visibility | **SLICE 3** — after distribution works |
+| 6 | Real warehouse operations | **NOT NEEDED** — packages A–F already implement all MES warehouse operations; no changes required |
+| 7 | Agnum document export | **BACKLOG** — governed by ADR-006; do not start until phases 1–5 are stable |
+
+## Phase 0 defaults (resolved for Slice 1)
+
+These are the working defaults for Codex. Do not re-open them unless business confirms a different rule.
+
+| Decision | Default |
+| --- | --- |
+| Active sndid for import | `493` (Sandelys), `498` (Gamyba). Add `496` only if API key is available. |
+| Product identity | `(sndid, agnumProductId)` — not `agnumProductId` alone |
+| SKU source | Agnum `code` → `Item.InternalSKU` |
+| Balance storage | Never on `Item`. Import as `AgnumVirtualWarehouseBalance` only. |
+| UoM on unknown `pcs` value | Block import of that product, surface as a conflict row. Known mappings: `vnt`, `m`, `m2`, `kg`. |
+| Category mapping | `group` → `ItemCategory` level 1, `category` → level 2, `subgroup` → level 3. `direction`/`branch` → `ItemExternalAttribute`. |
+| Pagination | No `limit`/`offset` (jar 1.39 bug). Load all products per sndid in one call. |
+| Agnum base URL config key | `Agnum:BaseUrl`, default `http://agnum-api:8181` |
+| API key config pattern | `Agnum:Warehouses:{name}:SndId` and `Agnum:Warehouses:{name}:ApiKey` |
+| POST/PUT to Agnum | **Never** in Slices 1–3 |
+
+## Files to freeze — do not modify in Slice 1
+
+These files implement the old export-first pattern. They compile and must keep compiling.
+Do not extend, refactor, or fix them in Slice 1.
+
+| File | Location | Why frozen |
+| --- | --- | --- |
+| `AgnumController.cs` | `Api/Api/Controllers/` | Old export routes; leave intact |
+| `AgnumExportServices.cs` | `Api/Services/` | Old export + `IAgnumExportOrchestrator` + `IAgnumSecretProtector` |
+| `AgnumReconciliationServices.cs` | `Api/Services/` | Old reconciliation; leave intact |
+| `AgnumExportSaga.cs` | `Sagas/` | Old MassTransit export state machine |
+| `IAgnumExportService.cs` | `Integration/Agnum/` | Old export interface; new `IAgnumApiClient` is separate |
+| `AgnumExportConfig` entity | `Domain/Entities/MasterDataEntities.cs` | Old export config entity |
+| `AgnumMapping` entity | `Domain/Entities/MasterDataEntities.cs` | Old mapping entity |
+| `AgnumExportHistory` entity | `Domain/Entities/MasterDataEntities.cs` | Old history entity |
+| Migration `20260211070343_AddAgnumExportTables` | `Infrastructure/Persistence/Migrations/` | Already applied; do not touch |
+
+## What Slice 1 must NOT include
+
+- Blazor UI pages
+- Physical distribution command or workflow
+- 3D/2D product search
+- Agnum document export of any kind
+- Refactor of the old Agnum export code
+- MassTransit sagas for import flows
+- Any POST or PUT to the Agnum API

--- a/docs/agnum-integration-plan/MVP-SCOPE.md
+++ b/docs/agnum-integration-plan/MVP-SCOPE.md
@@ -36,7 +36,7 @@ These are the working defaults for Codex. Do not re-open them unless business co
 
 | Decision | Default |
 | --- | --- |
-| Active sndid for import | `493` (Sandelys), `498` (Gamyba). Add `496` only if API key is available. |
+| Active sndid for import | `493` (Centrinis sandėlys) — main WMS warehouse. `496` (Pagaminta produkcija-pardavimai) — secondary. `498` (Gamyba) — confirm with business. Exclude all others: 502 Kuras, 507 Ilgalaikis, 509 Visi, 1498, 12503 Paslaugos, 142026 PVZ, 142029 Parduotuvė, 144513. |
 | Product identity | `(sndid, agnumProductId)` — not `agnumProductId` alone |
 | SKU source | Agnum `code` → `Item.InternalSKU` |
 | Balance storage | Never on `Item`. Import as `AgnumVirtualWarehouseBalance` only. |

--- a/docs/agnum-integration-plan/README.md
+++ b/docs/agnum-integration-plan/README.md
@@ -1,0 +1,46 @@
+# Agnum Integration Plan
+
+Created: 2026-05-18
+
+This folder collects discovery notes and implementation planning for reworking the Warehouse module around real business needs and the Agnum accounting API.
+
+The key direction change is important:
+
+- Old assumption: integration through XML/CSV-like files and periodic export.
+- New target: integration through the deployed Agnum API from `lauresta/agnum-api-deploy`.
+- Revised first priority: import Agnum nomenclature and per-`sndid` balances into MES, represent `sndid` as MES virtual warehouses, then distribute virtual balances into real MES physical locations. Agnum document export comes later.
+
+## Documents
+
+- [01-as-is-warehouse.md](01-as-is-warehouse.md) - current Warehouse module, entities, flows, Agnum-related code, and gaps.
+- [02-agnum-api-findings.md](02-agnum-api-findings.md) - findings from `lauresta/agnum-api-deploy` and how it differs from current assumptions.
+- [03-target-solution-architecture.md](03-target-solution-architecture.md) - proposed architecture for API-based integration.
+- [04-implementation-plan.md](04-implementation-plan.md) - phased implementation plan.
+- [05-open-questions.md](05-open-questions.md) - questions to confirm with business/Agnum/accounting.
+- [06-master-data-mapping.md](06-master-data-mapping.md) - Agnum product/warehouse/category/supplier mapping to current Warehouse fields and gaps.
+
+Related ADR:
+
+- [ADR-006: Warehouse-Agnum Integration Is Document-Based, Not Stock-Ledger-Event-Based](../adr/006-warehouse-agnum-document-based-integration.md)
+
+## Primary Sources Reviewed
+
+Local Warehouse code:
+
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/MasterDataEntities.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Aggregates/StockLedger.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/Events/StockMovedEvent.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumController.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/AgnumExportServices.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/AgnumReconciliationServices.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Sagas/AgnumExportSaga.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/AgnumClient.cs`
+- `docs/process/processes/P-08-agnum-integration-reconciliation/index.md`
+- `docs/phase15/features/agnum-export-job.md`
+- `docs/phase15/features/agnum-configuration-ui.md`
+
+External Agnum API repo:
+
+- Repository: `https://github.com/lauresta/agnum-api-deploy`
+- Checked commit: `c059aa3` on 2026-05-18 09:47:35 +0300
+- Key docs: `README.md`, `docs/AGNUM_API_NOTES.md`, `docs/AGNUM_WAREHOUSE_INTEGRATION_GUIDE.md`, `application.properties.example`

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
@@ -1,0 +1,191 @@
+using LKvitai.MES.Modules.Warehouse.Api.Security;
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace LKvitai.MES.Modules.Warehouse.Api.Controllers;
+
+[ApiController]
+[Route("api/warehouse/v1/agnum")]
+[Authorize(Policy = WarehousePolicies.InventoryAccountantOrManager)]
+public sealed class AgnumImportController : ControllerBase
+{
+    private readonly WarehouseDbContext _dbContext;
+    private readonly IAgnumNomenclatureImportService _nomenclatureImportService;
+    private readonly IAgnumBalanceImportService _balanceImportService;
+
+    public AgnumImportController(
+        WarehouseDbContext dbContext,
+        IAgnumNomenclatureImportService nomenclatureImportService,
+        IAgnumBalanceImportService balanceImportService)
+    {
+        _dbContext = dbContext;
+        _nomenclatureImportService = nomenclatureImportService;
+        _balanceImportService = balanceImportService;
+    }
+
+    [HttpGet("virtual-warehouses")]
+    public async Task<IActionResult> GetVirtualWarehousesAsync(CancellationToken ct = default)
+    {
+        var mappings = await _dbContext.AgnumWarehouseMappings
+            .AsNoTracking()
+            .OrderBy(x => x.SndId)
+            .Select(x => new AgnumWarehouseResponse(
+                x.SndId,
+                x.AgnumName,
+                x.MesVirtualWarehouseCode,
+                x.ApiKeyConfigName,
+                x.IsImportEnabled))
+            .ToListAsync(ct);
+
+        return Ok(mappings);
+    }
+
+    [HttpPost("import/products")]
+    public async Task<IActionResult> ImportProductsAsync(
+        [FromQuery] int sndId,
+        [FromQuery] bool apply = false,
+        CancellationToken ct = default)
+    {
+        if (sndId <= 0)
+        {
+            return BadRequest(new { Error = "sndId is required." });
+        }
+
+        if (apply)
+        {
+            var result = await _nomenclatureImportService.ApplyAsync(sndId, ct);
+            return Ok(result);
+        }
+
+        var preview = await _nomenclatureImportService.PreviewAsync(sndId, ct);
+        return Ok(preview);
+    }
+
+    [HttpPost("import/balances")]
+    public async Task<IActionResult> ImportBalancesAsync(
+        [FromQuery] int sndId,
+        CancellationToken ct = default)
+    {
+        if (sndId <= 0)
+        {
+            return BadRequest(new { Error = "sndId is required." });
+        }
+
+        var runId = await _balanceImportService.StartImportAsync(sndId, ct);
+        return Ok(new { RunId = runId });
+    }
+
+    [HttpGet("import/status/{runId:guid}")]
+    public async Task<IActionResult> GetImportStatusAsync(
+        Guid runId,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var status = await _balanceImportService.GetRunStatusAsync(runId, ct);
+            return Ok(status);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
+    }
+
+    [HttpGet("nomenclature")]
+    public async Task<IActionResult> GetNomenclatureAsync(
+        [FromQuery] int sndId,
+        [FromQuery] string? search = null,
+        [FromQuery] int page = 1,
+        [FromQuery] int pageSize = 50,
+        CancellationToken ct = default)
+    {
+        if (sndId <= 0)
+        {
+            return BadRequest(new { Error = "sndId is required." });
+        }
+
+        var query = _dbContext.AgnumProductLinks
+            .AsNoTracking()
+            .Where(x => x.SndId == sndId)
+            .Join(_dbContext.Items, l => l.ItemId, i => i.Id, (l, i) => new { Link = l, Item = i });
+
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            var lower = search.ToLower();
+            query = query.Where(x =>
+                x.Item.InternalSKU.ToLower().Contains(lower) ||
+                x.Item.Name.ToLower().Contains(lower) ||
+                x.Link.AgnumCode.ToLower().Contains(lower));
+        }
+
+        var total = await query.CountAsync(ct);
+        var items = await query
+            .OrderBy(x => x.Item.InternalSKU)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(x => new
+            {
+                x.Link.AgnumProductId,
+                x.Link.AgnumCode,
+                x.Item.InternalSKU,
+                x.Item.Name,
+                x.Item.BaseUoM,
+                x.Item.Status,
+                x.Link.AgnumEnabled,
+                x.Link.LastImportedAt
+            })
+            .ToListAsync(ct);
+
+        return Ok(new { Total = total, Page = page, PageSize = pageSize, Items = items });
+    }
+
+    [HttpGet("balances")]
+    public async Task<IActionResult> GetBalancesAsync(
+        [FromQuery] int sndId,
+        CancellationToken ct = default)
+    {
+        if (sndId <= 0)
+        {
+            return BadRequest(new { Error = "sndId is required." });
+        }
+
+        var latestRun = await _dbContext.AgnumBalanceImportRuns
+            .AsNoTracking()
+            .Where(x => x.SndId == sndId && x.Status == "Completed")
+            .OrderByDescending(x => x.FinishedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (latestRun is null)
+        {
+            return Ok(new { SndId = sndId, RunId = (Guid?)null, Balances = Array.Empty<object>() });
+        }
+
+        var balances = await _dbContext.AgnumVirtualWarehouseBalances
+            .AsNoTracking()
+            .Where(x => x.ImportRunId == latestRun.Id)
+            .OrderByDescending(x => x.Quantity)
+            .Select(x => new
+            {
+                x.AgnumProductId,
+                x.Sku,
+                x.Quantity,
+                x.Uom,
+                x.ItemId,
+                x.ImportedAt
+            })
+            .ToListAsync(ct);
+
+        return Ok(new { SndId = sndId, RunId = latestRun.Id, ImportedAt = latestRun.FinishedAt, Balances = balances });
+    }
+
+    private sealed record AgnumWarehouseResponse(
+        int SndId,
+        string AgnumName,
+        string MesVirtualWarehouseCode,
+        string ApiKeyConfigName,
+        bool IsImportEnabled);
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -62,9 +62,14 @@ builder.Services.AddMemoryCache();
 builder.Services.AddDataProtection();
 builder.Services.AddHttpClient("AgnumExportApi");
 var agnumApiBaseUrl = builder.Configuration.GetValue<string>("Agnum:Api:BaseUrl")
-    ?? builder.Configuration.GetValue<string>("AGNUM_API_BASE_URL")
-    ?? "http://agnum-api:8181";
+    ?? builder.Configuration.GetValue<string>("AGNUM_API_BASE_URL");
 var agnumApiTimeoutSeconds = builder.Configuration.GetValue<int>("Agnum:Api:TimeoutSeconds", 15);
+
+if (string.IsNullOrWhiteSpace(agnumApiBaseUrl))
+{
+    throw new InvalidOperationException(
+        "Agnum API base URL is not configured. Set Agnum:Api:BaseUrl in appsettings or Agnum__Api__BaseUrl / AGNUM_API_BASE_URL in environment.");
+}
 
 foreach (var warehouse in builder.Configuration.GetSection("Agnum:Warehouses").GetChildren())
 {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -9,6 +9,7 @@ using LKvitai.MES.Modules.Warehouse.Application.EventVersioning;
 using LKvitai.MES.Modules.Warehouse.Application.Ports;
 using LKvitai.MES.Modules.Warehouse.Application.Services;
 using LKvitai.MES.Modules.Warehouse.Infrastructure;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.BackgroundJobs;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Caching;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
@@ -60,6 +61,20 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddMemoryCache();
 builder.Services.AddDataProtection();
 builder.Services.AddHttpClient("AgnumExportApi");
+var agnumApiBaseUrl = builder.Configuration.GetValue<string>("Agnum:Api:BaseUrl", "http://agnum-api:8181");
+var agnumApiTimeoutSeconds = builder.Configuration.GetValue<int>("Agnum:Api:TimeoutSeconds", 15);
+
+foreach (var warehouse in builder.Configuration.GetSection("Agnum:Warehouses").GetChildren())
+{
+    var clientBaseUrl = agnumApiBaseUrl ?? "http://agnum-api:8181";
+    builder.Services.AddHttpClient($"Agnum-{warehouse.Key}", client =>
+    {
+        client.BaseAddress = new Uri(clientBaseUrl);
+        client.Timeout = TimeSpan.FromSeconds(agnumApiTimeoutSeconds);
+    });
+}
+
+builder.Services.Configure<AgnumApiClientOptions>(builder.Configuration.GetSection("Agnum:Api"));
 builder.Services.AddHttpClient("FedExApi");
 builder.Services.AddHttpClient("OAuthProvider");
 builder.Services.AddHttpClient("PagerDuty");

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -62,14 +62,9 @@ builder.Services.AddMemoryCache();
 builder.Services.AddDataProtection();
 builder.Services.AddHttpClient("AgnumExportApi");
 var agnumApiBaseUrl = builder.Configuration.GetValue<string>("Agnum:Api:BaseUrl")
-    ?? builder.Configuration.GetValue<string>("AGNUM_API_BASE_URL");
+    ?? builder.Configuration.GetValue<string>("AGNUM_API_BASE_URL")
+    ?? "http://agnum-api:8181";
 var agnumApiTimeoutSeconds = builder.Configuration.GetValue<int>("Agnum:Api:TimeoutSeconds", 15);
-
-if (string.IsNullOrWhiteSpace(agnumApiBaseUrl))
-{
-    throw new InvalidOperationException(
-        "Missing Agnum API base URL. Set Agnum:Api:BaseUrl in appsettings or Agnum__Api__BaseUrl / AGNUM_API_BASE_URL in environment.");
-}
 
 foreach (var warehouse in builder.Configuration.GetSection("Agnum:Warehouses").GetChildren())
 {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -61,15 +61,21 @@ builder.Services.AddHttpContextAccessor();
 builder.Services.AddMemoryCache();
 builder.Services.AddDataProtection();
 builder.Services.AddHttpClient("AgnumExportApi");
-var agnumApiBaseUrl = builder.Configuration.GetValue<string>("Agnum:Api:BaseUrl", "http://agnum-api:8181");
+var agnumApiBaseUrl = builder.Configuration.GetValue<string>("Agnum:Api:BaseUrl")
+    ?? builder.Configuration.GetValue<string>("AGNUM_API_BASE_URL");
 var agnumApiTimeoutSeconds = builder.Configuration.GetValue<int>("Agnum:Api:TimeoutSeconds", 15);
+
+if (string.IsNullOrWhiteSpace(agnumApiBaseUrl))
+{
+    throw new InvalidOperationException(
+        "Missing Agnum API base URL. Set Agnum:Api:BaseUrl in appsettings or Agnum__Api__BaseUrl / AGNUM_API_BASE_URL in environment.");
+}
 
 foreach (var warehouse in builder.Configuration.GetSection("Agnum:Warehouses").GetChildren())
 {
-    var clientBaseUrl = agnumApiBaseUrl ?? "http://agnum-api:8181";
     builder.Services.AddHttpClient($"Agnum-{warehouse.Key}", client =>
     {
-        client.BaseAddress = new Uri(clientBaseUrl);
+        client.BaseAddress = new Uri(agnumApiBaseUrl);
         client.Timeout = TimeSpan.FromSeconds(agnumApiTimeoutSeconds);
     });
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.Development.json
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.Development.json
@@ -72,6 +72,12 @@
       "WarehouseAdmin"
     ]
   },
+  "Agnum": {
+    "Api": {
+      "BaseUrl": "http://agnum-api:8181",
+      "TimeoutSeconds": 15
+    }
+  },
   "Caching": {
     "RedisConnectionString": "localhost:6379,abortConnect=false,connectRetry=3,connectTimeout=1000,syncTimeout=1000"
   },

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
@@ -72,6 +72,12 @@
       "WarehouseAdmin"
     ]
   },
+  "Agnum": {
+    "Api": {
+      "BaseUrl": "http://agnum-api:8181",
+      "TimeoutSeconds": 15
+    }
+  },
   "Caching": {
     "RedisConnectionString": "localhost:6379,abortConnect=false,connectRetry=3,connectTimeout=1000,syncTimeout=1000"
   },

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumBalanceImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumBalanceImportService.cs
@@ -1,0 +1,20 @@
+namespace LKvitai.MES.Modules.Warehouse.Application.Ports;
+
+public interface IAgnumBalanceImportService
+{
+    Task<Guid> StartImportAsync(int sndId, CancellationToken ct = default);
+    Task<AgnumBalanceImportRunStatus> GetRunStatusAsync(Guid runId, CancellationToken ct = default);
+}
+
+public sealed class AgnumBalanceImportRunStatus
+{
+    public Guid RunId { get; init; }
+    public int SndId { get; init; }
+    public string Status { get; init; } = string.Empty;
+    public int ProductCount { get; init; }
+    public int BalanceCount { get; init; }
+    public int ErrorCount { get; init; }
+    public string? ErrorSummary { get; init; }
+    public DateTime StartedAt { get; init; }
+    public DateTime? FinishedAt { get; init; }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumNomenclatureImportService.cs
@@ -1,0 +1,39 @@
+namespace LKvitai.MES.Modules.Warehouse.Application.Ports;
+
+public interface IAgnumNomenclatureImportService
+{
+    Task<AgnumImportPreview> PreviewAsync(int sndId, CancellationToken ct = default);
+    Task<AgnumImportResult> ApplyAsync(int sndId, CancellationToken ct = default);
+}
+
+public sealed class AgnumImportPreview
+{
+    public int SndId { get; init; }
+    public int TotalProducts { get; init; }
+    public List<AgnumImportCandidate> ToCreate { get; init; } = new();
+    public List<AgnumImportCandidate> ToUpdate { get; init; } = new();
+    public List<AgnumImportConflict> Conflicts { get; init; } = new();
+}
+
+public sealed class AgnumImportCandidate
+{
+    public int AgnumProductId { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string Pcs { get; init; } = string.Empty;
+}
+
+public sealed class AgnumImportConflict
+{
+    public int AgnumProductId { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Reason { get; init; } = string.Empty;
+}
+
+public sealed class AgnumImportResult
+{
+    public int Created { get; init; }
+    public int Updated { get; init; }
+    public int Skipped { get; init; }
+    public List<AgnumImportConflict> Conflicts { get; init; } = new();
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/AgnumImportEntities.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/AgnumImportEntities.cs
@@ -1,0 +1,70 @@
+using LKvitai.MES.Modules.Warehouse.Domain.Common;
+
+namespace LKvitai.MES.Modules.Warehouse.Domain.Entities;
+
+public sealed class AgnumWarehouseMapping : AuditableEntity
+{
+    public int Id { get; set; }
+    public int SndId { get; set; }
+    public string AgnumName { get; set; } = string.Empty;
+    public string MesVirtualWarehouseCode { get; set; } = string.Empty;
+    public string ApiKeyConfigName { get; set; } = string.Empty;
+    public bool IsImportEnabled { get; set; }
+}
+
+public sealed class AgnumProductLink : AuditableEntity
+{
+    public int Id { get; set; }
+    public int ItemId { get; set; }
+    public int SndId { get; set; }
+    public int AgnumProductId { get; set; }
+    public string AgnumCode { get; set; } = string.Empty;
+    public bool AgnumEnabled { get; set; }
+    public DateTime? AgnumModifiedAt { get; set; }
+    public DateTime? LastImportedAt { get; set; }
+    public string? RawHash { get; set; }
+
+    public Item? Item { get; set; }
+}
+
+public sealed class ItemExternalAttribute
+{
+    public int Id { get; set; }
+    public int ItemId { get; set; }
+    public string SourceSystem { get; set; } = "AGNUM";
+    public string SourceContext { get; set; } = string.Empty;
+    public string Key { get; set; } = string.Empty;
+    public string? ValueText { get; set; }
+    public decimal? ValueNumber { get; set; }
+
+    public Item? Item { get; set; }
+}
+
+public sealed class AgnumBalanceImportRun
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public int SndId { get; set; }
+    public DateTime StartedAt { get; set; }
+    public DateTime? FinishedAt { get; set; }
+    public string Status { get; set; } = "Running";
+    public int ProductCount { get; set; }
+    public int BalanceCount { get; set; }
+    public int ErrorCount { get; set; }
+    public string? ErrorSummary { get; set; }
+}
+
+public sealed class AgnumVirtualWarehouseBalance
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid ImportRunId { get; set; }
+    public int SndId { get; set; }
+    public int AgnumProductId { get; set; }
+    public int? ItemId { get; set; }
+    public string? Sku { get; set; }
+    public decimal Quantity { get; set; }
+    public string Uom { get; set; } = string.Empty;
+    public DateTime ImportedAt { get; set; }
+    public string? SourceHash { get; set; }
+
+    public AgnumBalanceImportRun? ImportRun { get; set; }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
@@ -1,0 +1,78 @@
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.Extensions.Logging;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumApiClient : IAgnumApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+    private readonly ILogger<AgnumApiClient> _logger;
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true
+    };
+
+    public AgnumApiClient(HttpClient httpClient, AgnumWarehouseKeyOptions options, ILogger<AgnumApiClient> logger)
+    {
+        _httpClient = httpClient;
+        _apiKey = options.ApiKey?.Trim() ?? string.Empty;
+        _logger = logger;
+    }
+
+    public async Task<IReadOnlyList<AgnumProductDto>> GetProductsAsync(CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, "api/products/search");
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+        {
+            request.Headers.Add("X-API-KEY", _apiKey);
+        }
+
+        _logger.LogDebug("Calling Agnum API GET /api/products/search with X-API-KEY {ApiKeyHash}",
+            string.IsNullOrWhiteSpace(_apiKey) ? "<none>" : "<redacted>");
+
+        try
+        {
+            using var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Agnum API returned HTTP {StatusCode} when fetching products.", response.StatusCode);
+                return Array.Empty<AgnumProductDto>();
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var products = JsonSerializer.Deserialize<IReadOnlyList<AgnumProductDto>>(content, JsonOptions);
+            if (products is null)
+            {
+                return Array.Empty<AgnumProductDto>();
+            }
+
+            foreach (var product in products)
+            {
+                if (!string.IsNullOrWhiteSpace(product.Barcode) && product.Barcodes is null)
+                {
+                    product.Barcodes = new List<string> { product.Barcode };
+                }
+                else if (!string.IsNullOrWhiteSpace(product.Barcode) && product.Barcodes is not null)
+                {
+                    if (!product.Barcodes.Contains(product.Barcode, StringComparer.Ordinal))
+                    {
+                        product.Barcodes.Add(product.Barcode);
+                    }
+                }
+            }
+
+            return products;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Agnum API request failed while fetching products.");
+            return Array.Empty<AgnumProductDto>();
+        }
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientFactory.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientFactory.cs
@@ -1,0 +1,60 @@
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Net.Http;
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumApiClientFactory : IAgnumApiClientFactory
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IReadOnlyDictionary<int, (string ClientName, AgnumWarehouseKeyOptions Options)> _clients;
+    private readonly ILogger<AgnumApiClientFactory> _logger;
+    private readonly ILoggerFactory _loggerFactory;
+
+    public AgnumApiClientFactory(
+        IHttpClientFactory httpClientFactory,
+        IOptions<AgnumApiClientOptions> clientOptions,
+        IConfiguration configuration,
+        ILogger<AgnumApiClientFactory> logger,
+        ILoggerFactory loggerFactory)
+    {
+        _httpClientFactory = httpClientFactory;
+        _logger = logger;
+        _loggerFactory = loggerFactory;
+
+        var warehouseSection = configuration.GetSection("Agnum:Warehouses");
+        var clients = new Dictionary<int, (string, AgnumWarehouseKeyOptions)>(EqualityComparer<int>.Default);
+
+        foreach (var warehouse in warehouseSection.GetChildren())
+        {
+            var options = warehouse.Get<AgnumWarehouseKeyOptions>();
+            if (options is null)
+            {
+                continue;
+            }
+
+            var name = warehouse.Key;
+            if (clients.ContainsKey(options.SndId))
+            {
+                throw new InvalidOperationException($"Duplicate Agnum warehouse configuration for sndId {options.SndId}.");
+            }
+
+            clients[options.SndId] = ($"Agnum-{name}", options);
+        }
+
+        _clients = clients;
+    }
+
+    public IAgnumApiClient GetForSndId(int sndId)
+    {
+        if (!_clients.TryGetValue(sndId, out var clientEntry))
+        {
+            throw new KeyNotFoundException($"No configured Agnum client for sndId {sndId}.");
+        }
+
+        var httpClient = _httpClientFactory.CreateClient(clientEntry.ClientName);
+        return new AgnumApiClient(httpClient, clientEntry.Options, _loggerFactory.CreateLogger<AgnumApiClient>());
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientOptions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientOptions.cs
@@ -2,7 +2,7 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
 
 public sealed class AgnumApiClientOptions
 {
-    public string BaseUrl { get; set; } = "http://agnum-api:8181";
+    public string BaseUrl { get; set; } = string.Empty;
     public int TimeoutSeconds { get; set; } = 15;
 }
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientOptions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClientOptions.cs
@@ -1,0 +1,13 @@
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumApiClientOptions
+{
+    public string BaseUrl { get; set; } = "http://agnum-api:8181";
+    public int TimeoutSeconds { get; set; } = 15;
+}
+
+public sealed class AgnumWarehouseKeyOptions
+{
+    public int SndId { get; set; }
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumBalanceImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumBalanceImportService.cs
@@ -1,0 +1,138 @@
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumBalanceImportService : IAgnumBalanceImportService
+{
+    private readonly WarehouseDbContext _dbContext;
+    private readonly IAgnumApiClientFactory _apiClientFactory;
+    private readonly ILogger<AgnumBalanceImportService> _logger;
+
+    public AgnumBalanceImportService(
+        WarehouseDbContext dbContext,
+        IAgnumApiClientFactory apiClientFactory,
+        ILogger<AgnumBalanceImportService> logger)
+    {
+        _dbContext = dbContext;
+        _apiClientFactory = apiClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<Guid> StartImportAsync(int sndId, CancellationToken ct = default)
+    {
+        var run = new AgnumBalanceImportRun
+        {
+            SndId = sndId,
+            StartedAt = DateTime.UtcNow,
+            Status = "Running"
+        };
+
+        _dbContext.AgnumBalanceImportRuns.Add(run);
+        await _dbContext.SaveChangesAsync(ct);
+
+        try
+        {
+            var client = _apiClientFactory.GetForSndId(sndId);
+            var products = await client.GetProductsAsync(ct);
+            var links = await _dbContext.AgnumProductLinks
+                .Where(x => x.SndId == sndId)
+                .Include(x => x.Item)
+                .ToDictionaryAsync(x => x.AgnumProductId, x => x, ct);
+
+            var balanceCount = 0;
+            foreach (var product in products)
+            {
+                var existing = await _dbContext.AgnumVirtualWarehouseBalances
+                    .FirstOrDefaultAsync(x => x.ImportRunId == run.Id && x.SndId == sndId && x.AgnumProductId == product.Id, ct);
+
+                var link = links.TryGetValue(product.Id, out var productLink) ? productLink : null;
+                if (existing is null)
+                {
+                    existing = new AgnumVirtualWarehouseBalance
+                    {
+                        ImportRunId = run.Id,
+                        SndId = sndId,
+                        AgnumProductId = product.Id
+                    };
+                    _dbContext.AgnumVirtualWarehouseBalances.Add(existing);
+                }
+
+                existing.ItemId = link?.ItemId;
+                existing.Sku = link?.Item?.InternalSKU;
+                existing.Quantity = product.Balance;
+                existing.Uom = product.Pcs;
+                existing.ImportedAt = DateTime.UtcNow;
+                existing.SourceHash = ComputeRawHash(product);
+
+                balanceCount++;
+            }
+
+            run.ProductCount = products.Count;
+            run.BalanceCount = balanceCount;
+            run.ErrorCount = 0;
+            run.Status = "Completed";
+            run.FinishedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync(ct);
+
+            return run.Id;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Agnum balance import failed for sndId {SndId}.", sndId);
+            run.ErrorCount = 1;
+            run.Status = "Failed";
+            run.ErrorSummary = ex.Message;
+            run.FinishedAt = DateTime.UtcNow;
+            await _dbContext.SaveChangesAsync(ct);
+            return run.Id;
+        }
+    }
+
+    public async Task<AgnumBalanceImportRunStatus> GetRunStatusAsync(Guid runId, CancellationToken ct = default)
+    {
+        var run = await _dbContext.AgnumBalanceImportRuns
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == runId, ct);
+
+        if (run is null)
+        {
+            throw new KeyNotFoundException($"Agnum balance import run '{runId}' not found.");
+        }
+
+        return new AgnumBalanceImportRunStatus
+        {
+            RunId = run.Id,
+            SndId = run.SndId,
+            Status = run.Status,
+            ProductCount = run.ProductCount,
+            BalanceCount = run.BalanceCount,
+            ErrorCount = run.ErrorCount,
+            ErrorSummary = run.ErrorSummary,
+            StartedAt = run.StartedAt,
+            FinishedAt = run.FinishedAt
+        };
+    }
+
+    private static string ComputeRawHash(AgnumProductDto product)
+    {
+        var text = string.Join("|",
+            product.Id,
+            product.Code ?? string.Empty,
+            product.Name ?? string.Empty,
+            product.Enabled,
+            product.Pcs ?? string.Empty,
+            product.Netto?.ToString("G29") ?? string.Empty,
+            product.Brutto?.ToString("G29") ?? string.Empty,
+            string.Join(";", product.Barcodes ?? Enumerable.Empty<string>()));
+
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
@@ -1,0 +1,434 @@
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportService
+{
+    private readonly WarehouseDbContext _dbContext;
+    private readonly IAgnumApiClientFactory _apiClientFactory;
+    private readonly ILogger<AgnumNomenclatureImportService> _logger;
+
+    public AgnumNomenclatureImportService(
+        WarehouseDbContext dbContext,
+        IAgnumApiClientFactory apiClientFactory,
+        ILogger<AgnumNomenclatureImportService> logger)
+    {
+        _dbContext = dbContext;
+        _apiClientFactory = apiClientFactory;
+        _logger = logger;
+    }
+
+    public async Task<AgnumImportPreview> PreviewAsync(int sndId, CancellationToken ct = default)
+    {
+        var client = _apiClientFactory.GetForSndId(sndId);
+        var products = await client.GetProductsAsync(ct);
+
+        var validUoms = await _dbContext.UnitOfMeasures
+            .Select(x => x.Code)
+            .ToListAsync(ct);
+
+        var existingLinks = await _dbContext.AgnumProductLinks
+            .Where(x => x.SndId == sndId)
+            .ToListAsync(ct);
+
+        var itemsBySku = await _dbContext.Items
+            .AsNoTracking()
+            .ToListAsync(ct);
+
+        var itemLookup = itemsBySku
+            .ToDictionary(x => x.InternalSKU, StringComparer.OrdinalIgnoreCase);
+
+        var linkByProductId = existingLinks
+            .ToDictionary(x => x.AgnumProductId, x => x);
+
+        var preview = new AgnumImportPreview
+        {
+            SndId = sndId,
+            TotalProducts = products.Count
+        };
+
+        foreach (var product in products)
+        {
+            if (string.IsNullOrWhiteSpace(product.Pcs) || !validUoms.Contains(product.Pcs, StringComparer.OrdinalIgnoreCase))
+            {
+                preview.Conflicts.Add(new AgnumImportConflict
+                {
+                    AgnumProductId = product.Id,
+                    Code = product.Code,
+                    Reason = "UnknownUoM"
+                });
+                continue;
+            }
+
+            if (linkByProductId.TryGetValue(product.Id, out var existingLink))
+            {
+                if (itemLookup.TryGetValue(product.Code, out var conflictingItem) && conflictingItem.Id != existingLink.ItemId)
+                {
+                    preview.Conflicts.Add(new AgnumImportConflict
+                    {
+                        AgnumProductId = product.Id,
+                        Code = product.Code,
+                        Reason = "LinkedToDifferentItem"
+                    });
+                }
+                else
+                {
+                    preview.ToUpdate.Add(new AgnumImportCandidate
+                    {
+                        AgnumProductId = product.Id,
+                        Code = product.Code,
+                        Name = product.Name,
+                        Pcs = product.Pcs
+                    });
+                }
+
+                continue;
+            }
+
+            if (itemLookup.ContainsKey(product.Code))
+            {
+                preview.Conflicts.Add(new AgnumImportConflict
+                {
+                    AgnumProductId = product.Id,
+                    Code = product.Code,
+                    Reason = "DuplicateSku"
+                });
+                continue;
+            }
+
+            preview.ToCreate.Add(new AgnumImportCandidate
+            {
+                AgnumProductId = product.Id,
+                Code = product.Code,
+                Name = product.Name,
+                Pcs = product.Pcs
+            });
+        }
+
+        return preview;
+    }
+
+    public async Task<AgnumImportResult> ApplyAsync(int sndId, CancellationToken ct = default)
+    {
+        var preview = await PreviewAsync(sndId, ct);
+        var products = await _apiClientFactory.GetForSndId(sndId).GetProductsAsync(ct);
+        var productById = products.ToDictionary(x => x.Id);
+        var existingLinks = await _dbContext.AgnumProductLinks
+            .Where(x => x.SndId == sndId)
+            .ToDictionaryAsync(x => x.AgnumProductId, x => x, ct);
+
+        var created = 0;
+        var updated = 0;
+
+        foreach (var candidate in preview.ToCreate)
+        {
+            if (!productById.TryGetValue(candidate.AgnumProductId, out var product))
+            {
+                continue;
+            }
+
+            await CreateProductAsync(product, sndId, ct);
+            created++;
+        }
+
+        foreach (var candidate in preview.ToUpdate)
+        {
+            if (!productById.TryGetValue(candidate.AgnumProductId, out var product))
+            {
+                continue;
+            }
+
+            if (!existingLinks.TryGetValue(product.Id, out var link))
+            {
+                continue;
+            }
+
+            await UpdateProductAsync(link, product, sndId, ct);
+            updated++;
+        }
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        return new AgnumImportResult
+        {
+            Created = created,
+            Updated = updated,
+            Skipped = preview.Conflicts.Count,
+            Conflicts = preview.Conflicts
+        };
+    }
+
+    private async Task CreateProductAsync(AgnumProductDto product, int sndId, CancellationToken ct)
+    {
+        var categoryId = await EnsureCategoryHierarchyAsync(product.Group, product.Category, product.Subgroup, ct);
+        var item = new Item
+        {
+            InternalSKU = product.Code,
+            Name = product.Name,
+            BaseUoM = product.Pcs,
+            Status = product.Enabled ? "Active" : "Discontinued",
+            Weight = product.Netto,
+            CategoryId = categoryId,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow,
+            PrimaryBarcode = product.Barcodes?.FirstOrDefault()
+        };
+
+        _dbContext.Items.Add(item);
+        await AddItemBarcodesAsync(item, product, ct);
+
+        _dbContext.AgnumProductLinks.Add(new AgnumProductLink
+        {
+            Item = item,
+            SndId = sndId,
+            AgnumProductId = product.Id,
+            AgnumCode = product.Code,
+            AgnumEnabled = product.Enabled,
+            AgnumModifiedAt = product.ModifyDate,
+            LastImportedAt = DateTime.UtcNow,
+            RawHash = ComputeRawHash(product)
+        });
+
+        await AddExternalAttributesAsync(item, product, sndId, ct);
+    }
+
+    private async Task UpdateProductAsync(AgnumProductLink link, AgnumProductDto product, int sndId, CancellationToken ct)
+    {
+        var item = await _dbContext.Items.FindAsync(new object[] { link.ItemId }, ct);
+        if (item is null)
+        {
+            _logger.LogWarning("Missing item for Agnum product link {LinkId} during update.", link.Id);
+            return;
+        }
+
+        item.Name = product.Name;
+        item.BaseUoM = product.Pcs;
+        item.Status = product.Enabled ? "Active" : "Discontinued";
+        item.Weight = product.Netto;
+        item.PrimaryBarcode = product.Barcodes?.FirstOrDefault() ?? item.PrimaryBarcode;
+        item.UpdatedAt = DateTimeOffset.UtcNow;
+
+        await AddItemBarcodesAsync(item, product, ct);
+        await ReplaceExternalAttributesAsync(item, product, sndId, ct);
+
+        link.AgnumCode = product.Code;
+        link.AgnumEnabled = product.Enabled;
+        link.AgnumModifiedAt = product.ModifyDate;
+        link.LastImportedAt = DateTime.UtcNow;
+        link.RawHash = ComputeRawHash(product);
+    }
+
+    private async Task AddItemBarcodesAsync(Item item, AgnumProductDto product, CancellationToken ct)
+    {
+        var barcodes = product.Barcodes ?? new List<string>();
+        var distinctBarcodes = barcodes
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        if (distinctBarcodes.Count == 0)
+        {
+            return;
+        }
+
+        var existingBarcodes = await _dbContext.ItemBarcodes
+            .Where(x => distinctBarcodes.Contains(x.Barcode))
+            .Select(x => x.Barcode)
+            .ToListAsync(ct);
+
+        foreach (var barcode in distinctBarcodes.Except(existingBarcodes, StringComparer.OrdinalIgnoreCase))
+        {
+            _dbContext.ItemBarcodes.Add(new ItemBarcode
+            {
+                Item = item,
+                Barcode = barcode,
+                BarcodeType = "Other",
+                IsPrimary = false
+            });
+        }
+    }
+
+    private async Task AddExternalAttributesAsync(Item item, AgnumProductDto product, int sndId, CancellationToken ct)
+    {
+        var attributes = BuildAttributes(product, sndId);
+        foreach (var attribute in attributes)
+        {
+            _dbContext.ItemExternalAttributes.Add(attribute);
+        }
+
+        await Task.CompletedTask;
+    }
+
+    private async Task ReplaceExternalAttributesAsync(Item item, AgnumProductDto product, int sndId, CancellationToken ct)
+    {
+        var sourceContext = sndId.ToString();
+        var existingAttributes = _dbContext.ItemExternalAttributes
+            .Where(x => x.ItemId == item.Id && x.SourceSystem == "AGNUM" && x.SourceContext == sourceContext);
+
+        _dbContext.ItemExternalAttributes.RemoveRange(existingAttributes);
+        await AddExternalAttributesAsync(item, product, sndId, ct);
+    }
+
+    private IEnumerable<ItemExternalAttribute> BuildAttributes(AgnumProductDto product, int sndId)
+    {
+        var sourceContext = sndId.ToString();
+        var attributes = new List<ItemExternalAttribute?>
+        {
+            CreateAttribute(sourceContext, "group", product.Group),
+            CreateAttribute(sourceContext, "category", product.Category),
+            CreateAttribute(sourceContext, "subgroup", product.Subgroup),
+            CreateAttribute(sourceContext, "direction", product.Direction),
+            CreateAttribute(sourceContext, "branch", product.Branch),
+            CreateAttribute(sourceContext, "place", product.Place),
+            CreateAttribute(sourceContext, "f1", product.F1),
+            CreateAttribute(sourceContext, "f2", product.F2)
+        };
+
+        return attributes.Where(x => x is not null)!;
+    }
+
+    private static ItemExternalAttribute? CreateAttribute(string sourceContext, string key, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var attribute = new ItemExternalAttribute
+        {
+            SourceContext = sourceContext,
+            Key = key,
+            ValueText = value.Trim()
+        };
+
+        if (decimal.TryParse(value.Trim(), out var numericValue))
+        {
+            attribute.ValueNumber = numericValue;
+            attribute.ValueText = null;
+        }
+
+        return attribute;
+    }
+
+    private async Task<int> EnsureCategoryHierarchyAsync(string? group, string? category, string? subgroup, CancellationToken ct)
+    {
+        int? parentId = null;
+
+        if (!string.IsNullOrWhiteSpace(group))
+        {
+            parentId = await GetOrCreateCategoryAsync(group.Trim(), null, ct);
+        }
+
+        if (!string.IsNullOrWhiteSpace(category))
+        {
+            parentId = await GetOrCreateCategoryAsync(category.Trim(), parentId, ct);
+        }
+
+        if (!string.IsNullOrWhiteSpace(subgroup))
+        {
+            parentId = await GetOrCreateCategoryAsync(subgroup.Trim(), parentId, ct);
+        }
+
+        if (parentId.HasValue)
+        {
+            return parentId.Value;
+        }
+
+        return await GetOrCreateCategoryAsync("Agnum", null, ct);
+    }
+
+    private async Task<int> GetOrCreateCategoryAsync(string name, int? parentCategoryId, CancellationToken ct)
+    {
+        var normalizedCode = NormalizeCategoryCode(name);
+        if (parentCategoryId.HasValue)
+        {
+            var parent = await _dbContext.ItemCategories.FindAsync(new object[] { parentCategoryId.Value }, ct);
+            if (parent is null)
+            {
+                parentCategoryId = null;
+            }
+            else
+            {
+                normalizedCode = NormalizeCategoryCode(parent.Code + "-" + name);
+            }
+        }
+
+        var existing = await _dbContext.ItemCategories
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Code == normalizedCode, ct);
+
+        if (existing is not null)
+        {
+            return existing.Id;
+        }
+
+        var category = new ItemCategory
+        {
+            Code = normalizedCode,
+            Name = name,
+            ParentCategoryId = parentCategoryId
+        };
+
+        _dbContext.ItemCategories.Add(category);
+        await _dbContext.SaveChangesAsync(ct);
+        return category.Id;
+    }
+
+    private static string NormalizeCategoryCode(string value)
+    {
+        var normalized = value.Trim().ToUpperInvariant();
+        var builder = new System.Text.StringBuilder();
+
+        foreach (var c in normalized)
+        {
+            if (char.IsLetterOrDigit(c) || c == '-' || c == '_')
+            {
+                builder.Append(c);
+            }
+            else if (char.IsWhiteSpace(c))
+            {
+                builder.Append('-');
+            }
+        }
+
+        var code = builder.ToString();
+        if (code.Length > 50)
+        {
+            code = code[..50];
+        }
+
+        return code;
+    }
+
+    private static string ComputeRawHash(AgnumProductDto product)
+    {
+        var text = string.Join("|",
+            product.Id,
+            product.Code ?? string.Empty,
+            product.Name ?? string.Empty,
+            product.Enabled,
+            product.Pcs ?? string.Empty,
+            product.Netto?.ToString("G29") ?? string.Empty,
+            product.Brutto?.ToString("G29") ?? string.Empty,
+            string.Join(";", product.Barcodes ?? Enumerable.Empty<string>()),
+            product.Group ?? string.Empty,
+            product.Category ?? string.Empty,
+            product.Subgroup ?? string.Empty,
+            product.Direction ?? string.Empty,
+            product.Branch ?? string.Empty,
+            product.Place ?? string.Empty,
+            product.F1 ?? string.Empty,
+            product.F2 ?? string.Empty);
+
+        using var sha = System.Security.Cryptography.SHA256.Create();
+        var bytes = System.Text.Encoding.UTF8.GetBytes(text);
+        var hash = sha.ComputeHash(bytes);
+        return Convert.ToHexString(hash);
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/DependencyInjection.cs
@@ -11,6 +11,8 @@ using LKvitai.MES.Modules.Warehouse.Infrastructure.Locking;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Projections;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Visualization;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace LKvitai.MES.Modules.Warehouse.Infrastructure;
@@ -62,6 +64,11 @@ public static class DependencyInjection
         services.AddSingleton<IIdempotencyCleanupService, IdempotencyCleanupService>();
         services.AddSingleton<IEventUpcaster, StockMovedV1ToStockMovedEventUpcaster>();
         services.AddSingleton<IEventSchemaVersionRegistry, EventSchemaVersionRegistry>();
+
+        // Agnum import services
+        services.AddSingleton<IAgnumApiClientFactory, AgnumApiClientFactory>();
+        services.AddScoped<IAgnumNomenclatureImportService, AgnumNomenclatureImportService>();
+        services.AddScoped<IAgnumBalanceImportService, AgnumBalanceImportService>();
 
         // Consistency checks
         services.AddScoped<IConsistencyCheck, StuckReservationCheck>();

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/LKvitai.MES.Modules.Warehouse.Infrastructure.csproj
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/LKvitai.MES.Modules.Warehouse.Infrastructure.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <PackageReference Include="Microsoft.Extensions.Http" />
     <PackageReference Include="StackExchange.Redis" />
     <PackageReference Include="Serilog" />
     <PackageReference Include="Serilog.Sinks.Console" />
@@ -25,6 +27,7 @@
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Domain\LKvitai.MES.Modules.Warehouse.Domain.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Contracts\LKvitai.MES.Modules.Warehouse.Contracts.csproj" />
     <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Application\LKvitai.MES.Modules.Warehouse.Application.csproj" />
+    <ProjectReference Include="..\LKvitai.MES.Modules.Warehouse.Integration\LKvitai.MES.Modules.Warehouse.Integration.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
@@ -60,6 +60,11 @@ public class WarehouseDbContext : DbContext
     public DbSet<AgnumExportConfig> AgnumExportConfigs => Set<AgnumExportConfig>();
     public DbSet<AgnumMapping> AgnumMappings => Set<AgnumMapping>();
     public DbSet<AgnumExportHistory> AgnumExportHistories => Set<AgnumExportHistory>();
+    public DbSet<AgnumWarehouseMapping> AgnumWarehouseMappings => Set<AgnumWarehouseMapping>();
+    public DbSet<AgnumProductLink> AgnumProductLinks => Set<AgnumProductLink>();
+    public DbSet<ItemExternalAttribute> ItemExternalAttributes => Set<ItemExternalAttribute>();
+    public DbSet<AgnumBalanceImportRun> AgnumBalanceImportRuns => Set<AgnumBalanceImportRun>();
+    public DbSet<AgnumVirtualWarehouseBalance> AgnumVirtualWarehouseBalances => Set<AgnumVirtualWarehouseBalance>();
     public DbSet<TransactionExport> TransactionExports => Set<TransactionExport>();
     public DbSet<SupplierItemMapping> SupplierItemMappings => Set<SupplierItemMapping>();
     public DbSet<Location> Locations => Set<Location>();
@@ -285,6 +290,79 @@ public class WarehouseDbContext : DbContext
                 .HasFilter("\"IsPrimary\" = true");
             entity.HasOne(e => e.Item).WithMany(e => e.Barcodes).HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Cascade);
             entity.ToTable(t => t.HasCheckConstraint("ck_item_barcodes_type", "\"BarcodeType\" IN ('EAN13','Code128','QR','UPC','Other')"));
+        });
+
+        modelBuilder.Entity<AgnumWarehouseMapping>(entity =>
+        {
+            entity.ToTable("agnum_warehouse_mappings");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.SndId).IsRequired();
+            entity.Property(e => e.AgnumName).HasMaxLength(200).IsRequired();
+            entity.Property(e => e.MesVirtualWarehouseCode).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.ApiKeyConfigName).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.IsImportEnabled).IsRequired();
+            entity.HasIndex(e => e.SndId).IsUnique();
+        });
+
+        modelBuilder.Entity<AgnumProductLink>(entity =>
+        {
+            entity.ToTable("agnum_product_links");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.ItemId).IsRequired();
+            entity.Property(e => e.SndId).IsRequired();
+            entity.Property(e => e.AgnumProductId).IsRequired();
+            entity.Property(e => e.AgnumCode).HasMaxLength(100).IsRequired();
+            entity.HasIndex(e => new { e.SndId, e.AgnumProductId }).IsUnique();
+            entity.HasIndex(e => e.ItemId);
+            entity.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<ItemExternalAttribute>(entity =>
+        {
+            entity.ToTable("item_external_attributes");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.ItemId).IsRequired();
+            entity.Property(e => e.SourceSystem).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.SourceContext).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.Key).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.ValueText).HasColumnType("text");
+            entity.Property(e => e.ValueNumber).HasPrecision(18, 4);
+            entity.HasIndex(e => e.ItemId);
+            entity.HasIndex(e => new { e.ItemId, e.SourceSystem, e.SourceContext, e.Key }).IsUnique();
+            entity.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Cascade);
+        });
+
+        modelBuilder.Entity<AgnumBalanceImportRun>(entity =>
+        {
+            entity.ToTable("agnum_balance_import_runs");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.SndId).IsRequired();
+            entity.Property(e => e.StartedAt).IsRequired();
+            entity.Property(e => e.FinishedAt);
+            entity.Property(e => e.Status).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.ProductCount).IsRequired();
+            entity.Property(e => e.BalanceCount).IsRequired();
+            entity.Property(e => e.ErrorCount).IsRequired();
+            entity.Property(e => e.ErrorSummary).HasMaxLength(500);
+        });
+
+        modelBuilder.Entity<AgnumVirtualWarehouseBalance>(entity =>
+        {
+            entity.ToTable("agnum_virtual_warehouse_balances");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.ImportRunId).IsRequired();
+            entity.Property(e => e.SndId).IsRequired();
+            entity.Property(e => e.AgnumProductId).IsRequired();
+            entity.Property(e => e.ItemId);
+            entity.Property(e => e.Sku).HasMaxLength(100);
+            entity.Property(e => e.Quantity).HasPrecision(18, 4).IsRequired();
+            entity.Property(e => e.Uom).HasMaxLength(10).IsRequired();
+            entity.Property(e => e.ImportedAt).IsRequired();
+            entity.Property(e => e.SourceHash).HasMaxLength(128);
+            entity.HasIndex(e => e.ImportRunId);
+            entity.HasIndex(e => new { e.SndId, e.AgnumProductId });
+            entity.HasOne(e => e.ImportRun).WithMany().HasForeignKey(e => e.ImportRunId).OnDelete(DeleteBehavior.Cascade);
+            entity.HasOne<Item>().WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Supplier>(entity =>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
@@ -1,0 +1,39 @@
+using System.Text.Json.Serialization;
+
+namespace LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+
+public interface IAgnumApiClient
+{
+    Task<IReadOnlyList<AgnumProductDto>> GetProductsAsync(CancellationToken ct = default);
+}
+
+public sealed class AgnumProductDto
+{
+    public int Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public bool Enabled { get; init; }
+    public string Pcs { get; init; } = string.Empty;
+    public decimal Balance { get; init; }
+    public decimal? Netto { get; init; }
+    public decimal? Brutto { get; init; }
+    public string? Barcode { get; init; }
+
+    [JsonPropertyName("barcodes")]
+    public List<string>? Barcodes { get; set; }
+
+    [JsonPropertyName("modify_date")]
+    public DateTime? ModifyDate { get; init; }
+
+    [JsonPropertyName("create_date")]
+    public DateTime? CreateDate { get; init; }
+
+    public string? Group { get; init; }
+    public string? Category { get; init; }
+    public string? Subgroup { get; init; }
+    public string? Direction { get; init; }
+    public string? Branch { get; init; }
+    public string? Place { get; init; }
+    public string? F1 { get; init; }
+    public string? F2 { get; init; }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClientFactory.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClientFactory.cs
@@ -1,0 +1,6 @@
+namespace LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+
+public interface IAgnumApiClientFactory
+{
+    IAgnumApiClient GetForSndId(int sndId);
+}

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumBalanceImportServiceTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumBalanceImportServiceTests.cs
@@ -1,0 +1,119 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AgnumBalanceImportServiceTests
+{
+    [Fact]
+    public async Task StartImportAsync_WhenProductsAreReturned_ShouldCreateRunAndBalances()
+    {
+        await using var db = CreateDbContext();
+        var item = new Item { InternalSKU = "SKU-001", Name = "Item One", BaseUoM = "vnt", CategoryId = await GetOrCreateCategoryIdAsync(db) };
+        db.Items.Add(item);
+        await db.SaveChangesAsync();
+
+        db.AgnumProductLinks.Add(new AgnumProductLink
+        {
+            ItemId = item.Id,
+            SndId = 493,
+            AgnumProductId = 1,
+            AgnumCode = "SKU-001",
+            AgnumEnabled = true,
+            LastImportedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var product = new AgnumProductDto
+        {
+            Id = 1,
+            Code = "SKU-001",
+            Name = "Item One",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 20
+        };
+
+        var service = CreateService(db, product);
+
+        var runId = await service.StartImportAsync(493);
+
+        var run = await db.AgnumBalanceImportRuns.FirstOrDefaultAsync(x => x.Id == runId);
+        run.Should().NotBeNull();
+        run!.Status.Should().Be("Completed");
+        run.ProductCount.Should().Be(1);
+        run.BalanceCount.Should().Be(1);
+
+        var balance = await db.AgnumVirtualWarehouseBalances.FirstOrDefaultAsync(x => x.ImportRunId == runId);
+        balance.Should().NotBeNull();
+        balance!.ItemId.Should().Be(item.Id);
+        balance.Quantity.Should().Be(20);
+        balance.AgnumProductId.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task StartImportAsync_WhenNoLinkExists_ShouldStillCreateBalanceWithNullItemId()
+    {
+        await using var db = CreateDbContext();
+        var product = new AgnumProductDto
+        {
+            Id = 2,
+            Code = "SKU-002",
+            Name = "Unlinked Item",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 5
+        };
+
+        var service = CreateService(db, product);
+
+        var runId = await service.StartImportAsync(493);
+
+        var balance = await db.AgnumVirtualWarehouseBalances.FirstOrDefaultAsync(x => x.ImportRunId == runId);
+        balance.Should().NotBeNull();
+        balance!.ItemId.Should().BeNull();
+        balance.Quantity.Should().Be(5);
+    }
+
+    private static AgnumBalanceImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)
+    {
+        var clientMock = new Mock<IAgnumApiClient>();
+        clientMock.Setup(x => x.GetProductsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(products.ToList());
+
+        var factoryMock = new Mock<IAgnumApiClientFactory>();
+        factoryMock.Setup(x => x.GetForSndId(It.IsAny<int>())).Returns(clientMock.Object);
+
+        return new AgnumBalanceImportService(db, factoryMock.Object, new LoggerFactory().CreateLogger<AgnumBalanceImportService>());
+    }
+
+    private static WarehouseDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<WarehouseDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new WarehouseDbContext(options);
+    }
+
+    private static async Task<int> GetOrCreateCategoryIdAsync(WarehouseDbContext db)
+    {
+        if (await db.ItemCategories.AnyAsync())
+        {
+            return await db.ItemCategories.Select(x => x.Id).FirstAsync();
+        }
+
+        var category = new ItemCategory { Code = "DEFAULT", Name = "Default" };
+        db.ItemCategories.Add(category);
+        await db.SaveChangesAsync();
+        return category.Id;
+    }
+}

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
@@ -1,0 +1,211 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AgnumImportConflictDetectionTests
+{
+    [Fact]
+    public async Task PreviewAsync_WhenPcsIsUnknown_ShouldReturnUnknownUoM()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var product = new AgnumProductDto
+        {
+            Id = 1,
+            Code = "SKU-UNKNOWN",
+            Name = "Unknown UoM",
+            Pcs = "unknown",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, product);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.Conflicts.Should().ContainSingle();
+        preview.Conflicts[0].Reason.Should().Be("UnknownUoM");
+    }
+
+    [Fact]
+    public async Task PreviewAsync_WhenDuplicateItemExistsWithoutLink_ShouldReturnDuplicateSku()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        db.Items.Add(new Item { InternalSKU = "SKU-001", Name = "Existing Item", BaseUoM = "vnt", CategoryId = await GetOrCreateCategoryIdAsync(db) });
+        await db.SaveChangesAsync();
+
+        var product = new AgnumProductDto
+        {
+            Id = 2,
+            Code = "SKU-001",
+            Name = "Duplicate SKU",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, product);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.Conflicts.Should().ContainSingle();
+        preview.Conflicts[0].Reason.Should().Be("DuplicateSku");
+    }
+
+    [Fact]
+    public async Task PreviewAsync_WhenLinkPointsToDifferentItem_ShouldReturnLinkedToDifferentItem()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var linkedItem = new Item { InternalSKU = "ITEM-ONE", Name = "Linked Item", BaseUoM = "vnt", CategoryId = await GetOrCreateCategoryIdAsync(db) };
+        var conflictingItem = new Item { InternalSKU = "SKU-002", Name = "Conflicting Item", BaseUoM = "vnt", CategoryId = await GetOrCreateCategoryIdAsync(db) };
+        db.Items.AddRange(linkedItem, conflictingItem);
+        await db.SaveChangesAsync();
+
+        db.AgnumProductLinks.Add(new AgnumProductLink
+        {
+            ItemId = linkedItem.Id,
+            SndId = 493,
+            AgnumProductId = 3,
+            AgnumCode = "SKU-001",
+            AgnumEnabled = true,
+            LastImportedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var product = new AgnumProductDto
+        {
+            Id = 3,
+            Code = "SKU-002",
+            Name = "Linked to wrong item",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, product);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.Conflicts.Should().ContainSingle();
+        preview.Conflicts[0].Reason.Should().Be("LinkedToDifferentItem");
+    }
+
+    [Fact]
+    public async Task PreviewAsync_WhenProductHasValidPcsAndNoExistingLink_ShouldReturnToCreate()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var product = new AgnumProductDto
+        {
+            Id = 4,
+            Code = "SKU-NEW",
+            Name = "New Product",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, product);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.ToCreate.Should().ContainSingle(x => x.AgnumProductId == 4 && x.Code == "SKU-NEW");
+    }
+
+    [Fact]
+    public async Task PreviewAsync_WhenExistingLinkExists_ShouldReturnToUpdate()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var existingItem = new Item { InternalSKU = "SKU-EXIST", Name = "Existing Item", BaseUoM = "vnt", CategoryId = await GetOrCreateCategoryIdAsync(db) };
+        db.Items.Add(existingItem);
+        await db.SaveChangesAsync();
+
+        db.AgnumProductLinks.Add(new AgnumProductLink
+        {
+            ItemId = existingItem.Id,
+            SndId = 493,
+            AgnumProductId = 5,
+            AgnumCode = "SKU-EXIST",
+            AgnumEnabled = true,
+            LastImportedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+
+        var product = new AgnumProductDto
+        {
+            Id = 5,
+            Code = "SKU-EXIST",
+            Name = "Existing Product",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, product);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.ToUpdate.Should().ContainSingle(x => x.AgnumProductId == 5);
+    }
+
+    private static AgnumNomenclatureImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)
+    {
+        var clientMock = new Mock<IAgnumApiClient>();
+        clientMock.Setup(x => x.GetProductsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(products.ToList());
+
+        var factoryMock = new Mock<IAgnumApiClientFactory>();
+        factoryMock.Setup(x => x.GetForSndId(It.IsAny<int>())).Returns(clientMock.Object);
+
+        return new AgnumNomenclatureImportService(db, factoryMock.Object, new LoggerFactory().CreateLogger<AgnumNomenclatureImportService>());
+    }
+
+    private static WarehouseDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<WarehouseDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new WarehouseDbContext(options);
+    }
+
+    private static async Task<int> GetOrCreateCategoryIdAsync(WarehouseDbContext db)
+    {
+        if (await db.ItemCategories.AnyAsync())
+        {
+            return await db.ItemCategories.Select(x => x.Id).FirstAsync();
+        }
+
+        var category = new ItemCategory { Code = "DEFAULT", Name = "Default" };
+        db.ItemCategories.Add(category);
+        await db.SaveChangesAsync();
+        return category.Id;
+    }
+
+    private static async Task SeedUnitOfMeasuresAsync(WarehouseDbContext db, params string[] codes)
+    {
+        foreach (var code in codes)
+        {
+            db.UnitOfMeasures.Add(new UnitOfMeasure { Code = code, Name = code, Type = "Piece" });
+        }
+
+        await db.SaveChangesAsync();
+    }
+}

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumProductDtoDeserializationTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumProductDtoDeserializationTests.cs
@@ -1,0 +1,63 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using System.Text.Json;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AgnumProductDtoDeserializationTests
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        AllowTrailingCommas = true
+    };
+
+    [Fact]
+    public void Deserialize_ProductWithSingleBarcodeString_ShouldPopulateBarcodes()
+    {
+        var json = "{\"id\":1,\"code\":\"SKU-001\",\"name\":\"Test\",\"pcs\":\"vnt\",\"enabled\":true,\"balance\":10,\"barcode\":\"12345\"}";
+
+        var result = JsonSerializer.Deserialize<AgnumProductDto>(json, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Barcode.Should().Be("12345");
+        result.Barcodes.Should().BeNull();
+    }
+
+    [Fact]
+    public void Deserialize_ProductWithBarcodesArray_ShouldPopulateBarcodesList()
+    {
+        var json = "{\"id\":1,\"code\":\"SKU-001\",\"name\":\"Test\",\"pcs\":\"vnt\",\"enabled\":true,\"balance\":10,\"barcodes\":[\"12345\",\"67890\"]}";
+
+        var result = JsonSerializer.Deserialize<AgnumProductDto>(json, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Barcode.Should().BeNull();
+        result.Barcodes.Should().ContainInOrder("12345", "67890");
+    }
+
+    [Fact]
+    public void Deserialize_ProductWithBothBarcodeFields_ShouldPopulateBothWithoutError()
+    {
+        var json = "{\"id\":1,\"code\":\"SKU-001\",\"name\":\"Test\",\"pcs\":\"vnt\",\"enabled\":true,\"balance\":10,\"barcode\":\"12345\",\"barcodes\":[\"67890\"]}";
+
+        var result = JsonSerializer.Deserialize<AgnumProductDto>(json, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Barcode.Should().Be("12345");
+        result.Barcodes.Should().ContainInOrder("67890");
+    }
+
+    [Fact]
+    public void Deserialize_ProductWithNoBarcodeFields_ShouldNotFail()
+    {
+        var json = "{\"id\":1,\"code\":\"SKU-001\",\"name\":\"Test\",\"pcs\":\"vnt\",\"enabled\":true,\"balance\":10}";
+
+        var result = JsonSerializer.Deserialize<AgnumProductDto>(json, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.Barcode.Should().BeNull();
+        result.Barcodes.Should().BeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- Agnum read connector (IAgnumApiClient, AgnumApiClient) with X-API-KEY auth, per-sndid named HttpClient, defensive barcode handling
- 5 new domain entities: AgnumWarehouseMapping, AgnumProductLink, ItemExternalAttribute, AgnumBalanceImportRun, AgnumVirtualWarehouseBalance
- Nomenclature import service: conflict detection (UnknownUoM/DuplicateSku/LinkedToDifferentItem), category hierarchy, barcodes, external attributes
- Balance import service: virtual warehouse balance per sndid with run tracking
- AgnumImportController (new, frozen AgnumController not touched): 6 endpoints
- 3 unit test files: DTO deserialization, conflict detection (5 scenarios), balance import lifecycle
- Docs: MVP-SCOPE.md, CODEX-IMPLEMENTATION-BLUEPRINT.md, ADR-006, agnum-integration-plan/01-06

## Confirmed sndid scope

493 Centrinis sandelys (main), 496 Pagaminta produkcija-pardavimai (secondary). All others excluded.

## Not in this PR (next slices)

EF Core migration, seed data, Hangfire job, distribution command, Blazor pages, Agnum document export.

## Test plan

- dotnet restore && dotnet build — zero errors
- dotnet test Unit — all pass
- Architecture tests pass

Made with [Cursor](https://cursor.com)