### PR TITLE
feat(agnum): Slice 1.5 — EF migration, Hangfire job, deploy wiring

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -27,6 +27,9 @@ jobs:
       ITEMIMAGES__MODEL_PATH: ${{ vars.ITEMIMAGES__MODEL_PATH }}
       CLIP_MODEL_DIR: ${{ vars.CLIP_MODEL_DIR }}
       LKVITAI_MSACCESS_DB_CONNECTION: ${{ secrets.LKVITAI_MSACCESS_DB_CONNECTION }}
+      Agnum__Api__BaseUrl: ${{ vars.Agnum__Api__BaseUrl }}
+      Agnum__Warehouses__sandelys__ApiKey: ${{ secrets.AGNUM__WAREHOUSES__SANDELYS__APIKEY }}
+      Agnum__Warehouses__pardavimai__ApiKey: ${{ secrets.AGNUM__WAREHOUSES__PARDAVIMAI__APIKEY }}
 
     steps:
       - name: Fail fast if required env vars are missing or invalid

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [ "main" ]
 
+env:
+  Agnum__Api__BaseUrl: ${{ vars.Agnum__Api__BaseUrl }}
+  Agnum__Warehouses__sandelys__ApiKey: ${{ secrets.AGNUM__WAREHOUSES__SANDELYS__APIKEY }}
+  Agnum__Warehouses__pardavimai__ApiKey: ${{ secrets.AGNUM__WAREHOUSES__PARDAVIMAI__APIKEY }}
+
 jobs:
   docker-gated-integration-tests:
     runs-on: ubuntu-latest

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -21,6 +21,9 @@ services:
       ITEMIMAGES__MAXUPLOADMB: "${ITEMIMAGES__MAXUPLOADMB:-5}"
       ITEMIMAGES__CACHEMAXAGESECONDS: "${ITEMIMAGES__CACHEMAXAGESECONDS:-86400}"
       ITEMIMAGES__MODEL_PATH: "${ITEMIMAGES__MODEL_PATH:-/models/item-image-model.onnx}"
+      Agnum__Api__BaseUrl: "${Agnum__Api__BaseUrl:-http://agnum-api:8181}"
+      Agnum__Warehouses__sandelys__ApiKey: "${Agnum__Warehouses__sandelys__ApiKey}"
+      Agnum__Warehouses__pardavimai__ApiKey: "${Agnum__Warehouses__pardavimai__ApiKey}"
     volumes:
       - ${LOGS_DIR:-/opt/lkvitai-mes/logs}:/app/logs
       - ${CLIP_MODEL_DIR:-/opt/lkvitai-mes/models}:/models:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
       ConnectionStrings__WarehouseDb: "Host=pg;Port=5432;Database=lkvitai_warehouse_test;Username=postgres;Password=postgres;Minimum Pool Size=10;Maximum Pool Size=100;Connection Lifetime=300;Connection Idle Lifetime=60;Timeout=30"
       Caching__RedisConnectionString: "redis:6379,abortConnect=false,connectRetry=3,connectTimeout=1000,syncTimeout=1000"
       SkipSchemaValidation: "true"
+      Agnum__Api__BaseUrl: "${Agnum__Api__BaseUrl:-http://agnum-api:8181}"
+      Agnum__Warehouses__sandelys__ApiKey: "${Agnum__Warehouses__sandelys__ApiKey}"
+      Agnum__Warehouses__pardavimai__ApiKey: "${Agnum__Warehouses__pardavimai__ApiKey}"
     depends_on:
       - pg
       - redis
@@ -53,6 +56,9 @@ services:
       ConnectionStrings__WarehouseDb: "Host=pg;Port=5432;Database=lkvitai_warehouse_test;Username=postgres;Password=postgres;Minimum Pool Size=10;Maximum Pool Size=100;Connection Lifetime=300;Connection Idle Lifetime=60;Timeout=30"
       Caching__RedisConnectionString: "redis:6379,abortConnect=false,connectRetry=3,connectTimeout=1000,syncTimeout=1000"
       SkipSchemaValidation: "true"
+      Agnum__Api__BaseUrl: "${Agnum__Api__BaseUrl:-http://agnum-api:8181}"
+      Agnum__Warehouses__sandelys__ApiKey: "${Agnum__Warehouses__sandelys__ApiKey}"
+      Agnum__Warehouses__pardavimai__ApiKey: "${Agnum__Warehouses__pardavimai__ApiKey}"
     depends_on:
       - pg
       - redis
@@ -74,6 +80,9 @@ services:
       ConnectionStrings__WarehouseDb: "Host=pg;Port=5432;Database=lkvitai_warehouse_test;Username=postgres;Password=postgres;Minimum Pool Size=10;Maximum Pool Size=100;Connection Lifetime=300;Connection Idle Lifetime=60;Timeout=30"
       Caching__RedisConnectionString: "redis:6379,abortConnect=false,connectRetry=3,connectTimeout=1000,syncTimeout=1000"
       SkipSchemaValidation: "true"
+      Agnum__Api__BaseUrl: "${Agnum__Api__BaseUrl:-http://agnum-api:8181}"
+      Agnum__Warehouses__sandelys__ApiKey: "${Agnum__Warehouses__sandelys__ApiKey}"
+      Agnum__Warehouses__pardavimai__ApiKey: "${Agnum__Warehouses__pardavimai__ApiKey}"
     depends_on:
       - pg
       - redis

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/BackgroundJobs/AgnumImportRecurringJob.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/BackgroundJobs/AgnumImportRecurringJob.cs
@@ -1,0 +1,73 @@
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace LKvitai.MES.Modules.Warehouse.Api.BackgroundJobs;
+
+public sealed class AgnumImportRecurringJob
+{
+    public const string JobId = "agnum-daily-import";
+
+    private readonly WarehouseDbContext _dbContext;
+    private readonly IAgnumNomenclatureImportService _nomenclatureImportService;
+    private readonly IAgnumBalanceImportService _balanceImportService;
+    private readonly ILogger<AgnumImportRecurringJob> _logger;
+
+    public AgnumImportRecurringJob(
+        WarehouseDbContext dbContext,
+        IAgnumNomenclatureImportService nomenclatureImportService,
+        IAgnumBalanceImportService balanceImportService,
+        ILogger<AgnumImportRecurringJob> logger)
+    {
+        _dbContext = dbContext;
+        _nomenclatureImportService = nomenclatureImportService;
+        _balanceImportService = balanceImportService;
+        _logger = logger;
+    }
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        var mappings = await _dbContext.AgnumWarehouseMappings
+            .AsNoTracking()
+            .Where(x => x.IsImportEnabled)
+            .OrderBy(x => x.SndId)
+            .ToListAsync(cancellationToken);
+
+        _logger.LogInformation("Starting Agnum daily import for {Count} enabled warehouses.", mappings.Count);
+
+        var succeeded = 0;
+        var failed = 0;
+
+        foreach (var mapping in mappings)
+        {
+            try
+            {
+                var productResult = await _nomenclatureImportService.ApplyAsync(mapping.SndId, cancellationToken);
+                var balanceRunId = await _balanceImportService.StartImportAsync(mapping.SndId, cancellationToken);
+
+                succeeded++;
+                _logger.LogInformation(
+                    "Agnum import completed for sndId {SndId}. Created={Created} Updated={Updated} Skipped={Skipped} Conflicts={Conflicts} BalanceRunId={BalanceRunId}",
+                    mapping.SndId,
+                    productResult.Created,
+                    productResult.Updated,
+                    productResult.Skipped,
+                    productResult.Conflicts.Count,
+                    balanceRunId);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                failed++;
+                _logger.LogError(
+                    ex,
+                    "Agnum import failed for sndId {SndId}; continuing with the next configured warehouse.",
+                    mapping.SndId);
+            }
+        }
+
+        _logger.LogInformation(
+            "Agnum daily import finished. Succeeded={Succeeded} Failed={Failed}",
+            succeeded,
+            failed);
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Program.cs
@@ -1,4 +1,5 @@
 using LKvitai.MES.Modules.Warehouse.Api.Configuration;
+using LKvitai.MES.Modules.Warehouse.Api.BackgroundJobs;
 using LKvitai.MES.BuildingBlocks.ObjectStorage;
 using LKvitai.MES.Modules.Warehouse.Api.ErrorHandling;
 using LKvitai.MES.Modules.Warehouse.Api.Middleware;
@@ -227,6 +228,7 @@ builder.Services.AddScoped<IAvailableStockQuantityResolver, MartenAvailableStock
 builder.Services.AddScoped<IAgnumSecretProtector, AgnumDataProtector>();
 builder.Services.AddScoped<IAgnumExportOrchestrator, AgnumExportOrchestrator>();
 builder.Services.AddScoped<AgnumExportRecurringJob>();
+builder.Services.AddScoped<AgnumImportRecurringJob>();
 builder.Services.AddSingleton<IAgnumReconciliationReportStore, InMemoryAgnumReconciliationReportStore>();
 builder.Services.AddScoped<IAgnumReconciliationService, AgnumReconciliationService>();
 builder.Services.AddSingleton<LabelTemplateEngine>();
@@ -419,6 +421,21 @@ RecurringJob.AddOrUpdate<AgnumExportRecurringJob>(
     AgnumRecurringJobs.DailyExportJobId,
     job => job.ExecuteAsync("SCHEDULED", null, 0),
     "0 23 * * *",
+    new RecurringJobOptions
+    {
+        TimeZone = TimeZoneInfo.Utc
+    });
+
+var agnumImportCron = builder.Configuration.GetValue<string>("Agnum:Import:DailyCron");
+if (string.IsNullOrWhiteSpace(agnumImportCron))
+{
+    agnumImportCron = "0 6 * * *";
+}
+
+RecurringJob.AddOrUpdate<AgnumImportRecurringJob>(
+    AgnumImportRecurringJob.JobId,
+    job => job.ExecuteAsync(CancellationToken.None),
+    agnumImportCron,
     new RecurringJobOptions
     {
         TimeZone = TimeZoneInfo.Utc

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.Development.json
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.Development.json
@@ -76,6 +76,19 @@
     "Api": {
       "BaseUrl": "http://agnum-api:8181",
       "TimeoutSeconds": 15
+    },
+    "Import": {
+      "DailyCron": "0 6 * * *"
+    },
+    "Warehouses": {
+      "sandelys": {
+        "SndId": 493,
+        "ApiKey": ""
+      },
+      "pardavimai": {
+        "SndId": 496,
+        "ApiKey": ""
+      }
     }
   },
   "Caching": {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/appsettings.json
@@ -76,6 +76,19 @@
     "Api": {
       "BaseUrl": "http://agnum-api:8181",
       "TimeoutSeconds": 15
+    },
+    "Import": {
+      "DailyCron": "0 6 * * *"
+    },
+    "Warehouses": {
+      "sandelys": {
+        "SndId": 493,
+        "ApiKey": ""
+      },
+      "pardavimai": {
+        "SndId": 496,
+        "ApiKey": ""
+      }
     }
   },
   "Caching": {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260518115100_AddAgnumImportTables.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260518115100_AddAgnumImportTables.cs
@@ -1,0 +1,254 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    [Migration("20260518115100_AddAgnumImportTables")]
+    public partial class AddAgnumImportTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agnum_balance_import_runs",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    SndId = table.Column<int>(type: "integer", nullable: false),
+                    StartedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    FinishedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    Status = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    ProductCount = table.Column<int>(type: "integer", nullable: false),
+                    BalanceCount = table.Column<int>(type: "integer", nullable: false),
+                    ErrorCount = table.Column<int>(type: "integer", nullable: false),
+                    ErrorSummary = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agnum_balance_import_runs", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "agnum_warehouse_mappings",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SndId = table.Column<int>(type: "integer", nullable: false),
+                    AgnumName = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    MesVirtualWarehouseCode = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ApiKeyConfigName = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    IsImportEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agnum_warehouse_mappings", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "agnum_product_links",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ItemId = table.Column<int>(type: "integer", nullable: false),
+                    SndId = table.Column<int>(type: "integer", nullable: false),
+                    AgnumProductId = table.Column<int>(type: "integer", nullable: false),
+                    AgnumCode = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    AgnumEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    AgnumModifiedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    LastImportedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    RawHash = table.Column<string>(type: "text", nullable: true),
+                    CreatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    UpdatedAt = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    CreatedBy = table.Column<string>(type: "text", nullable: true),
+                    UpdatedBy = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agnum_product_links", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_agnum_product_links_items_ItemId",
+                        column: x => x.ItemId,
+                        principalSchema: "public",
+                        principalTable: "items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "agnum_virtual_warehouse_balances",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    ImportRunId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SndId = table.Column<int>(type: "integer", nullable: false),
+                    AgnumProductId = table.Column<int>(type: "integer", nullable: false),
+                    ItemId = table.Column<int>(type: "integer", nullable: true),
+                    Sku = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    Quantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    Uom = table.Column<string>(type: "character varying(10)", maxLength: 10, nullable: false),
+                    ImportedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    SourceHash = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agnum_virtual_warehouse_balances", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_agnum_virtual_warehouse_balances_agnum_balance_import_ru~",
+                        column: x => x.ImportRunId,
+                        principalSchema: "public",
+                        principalTable: "agnum_balance_import_runs",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                    table.ForeignKey(
+                        name: "FK_agnum_virtual_warehouse_balances_items_ItemId",
+                        column: x => x.ItemId,
+                        principalSchema: "public",
+                        principalTable: "items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "item_external_attributes",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    ItemId = table.Column<int>(type: "integer", nullable: false),
+                    SourceSystem = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    SourceContext = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    Key = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    ValueText = table.Column<string>(type: "text", nullable: true),
+                    ValueNumber = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_item_external_attributes", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_item_external_attributes_items_ItemId",
+                        column: x => x.ItemId,
+                        principalSchema: "public",
+                        principalTable: "items",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.InsertData(
+                schema: "public",
+                table: "agnum_warehouse_mappings",
+                columns: new[] { "Id", "AgnumName", "ApiKeyConfigName", "CreatedAt", "CreatedBy", "IsImportEnabled", "MesVirtualWarehouseCode", "SndId", "UpdatedAt", "UpdatedBy" },
+                values: new object[,]
+                {
+                    { 1, "Sandėlys", "sandelys", new DateTimeOffset(new DateTime(2026, 2, 13, 0, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero), "system", true, "AGNUM-493", 493, null, null },
+                    { 2, "Pardavimai", "pardavimai", new DateTimeOffset(new DateTime(2026, 2, 13, 0, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero), "system", true, "AGNUM-496", 496, null, null }
+                });
+
+            migrationBuilder.Sql(
+                "SELECT setval(pg_get_serial_sequence('public.agnum_warehouse_mappings', 'Id'), 2, true);");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_product_links_ItemId",
+                schema: "public",
+                table: "agnum_product_links",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_product_links_SndId_AgnumCode",
+                schema: "public",
+                table: "agnum_product_links",
+                columns: new[] { "SndId", "AgnumCode" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_product_links_SndId_AgnumProductId",
+                schema: "public",
+                table: "agnum_product_links",
+                columns: new[] { "SndId", "AgnumProductId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_virtual_warehouse_balances_ImportRunId",
+                schema: "public",
+                table: "agnum_virtual_warehouse_balances",
+                column: "ImportRunId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_virtual_warehouse_balances_ImportRunId_SndId_Agnum~",
+                schema: "public",
+                table: "agnum_virtual_warehouse_balances",
+                columns: new[] { "ImportRunId", "SndId", "AgnumProductId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_virtual_warehouse_balances_ItemId",
+                schema: "public",
+                table: "agnum_virtual_warehouse_balances",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_virtual_warehouse_balances_SndId_AgnumProductId",
+                schema: "public",
+                table: "agnum_virtual_warehouse_balances",
+                columns: new[] { "SndId", "AgnumProductId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_warehouse_mappings_SndId",
+                schema: "public",
+                table: "agnum_warehouse_mappings",
+                column: "SndId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_item_external_attributes_ItemId",
+                schema: "public",
+                table: "item_external_attributes",
+                column: "ItemId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_item_external_attributes_ItemId_SourceSystem_SourceContext_Key",
+                schema: "public",
+                table: "item_external_attributes",
+                columns: new[] { "ItemId", "SourceSystem", "SourceContext", "Key" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agnum_product_links",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "agnum_virtual_warehouse_balances",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "agnum_warehouse_mappings",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "item_external_attributes",
+                schema: "public");
+
+            migrationBuilder.DropTable(
+                name: "agnum_balance_import_runs",
+                schema: "public");
+        }
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
@@ -197,6 +197,44 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         });
                 });
 
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumBalanceImportRun", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("BalanceCount")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("ErrorCount")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("ErrorSummary")
+                        .HasMaxLength(500)
+                        .HasColumnType("character varying(500)");
+
+                    b.Property<DateTime?>("FinishedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("ProductCount")
+                        .HasColumnType("integer");
+
+                    b.Property<int>("SndId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("StartedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("Status")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("agnum_balance_import_runs", "public");
+                });
+
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumExportConfig", b =>
                 {
                     b.Property<Guid>("Id")
@@ -323,6 +361,190 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         .IsUnique();
 
                     b.ToTable("agnum_mappings", "public");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumProductLink", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("AgnumCode")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<bool>("AgnumEnabled")
+                        .HasColumnType("boolean");
+
+                    b.Property<DateTime?>("AgnumModifiedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<int>("AgnumProductId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CreatedBy")
+                        .HasColumnType("text");
+
+                    b.Property<int>("ItemId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime?>("LastImportedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("RawHash")
+                        .HasColumnType("text");
+
+                    b.Property<int>("SndId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("UpdatedBy")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ItemId");
+
+                    b.HasIndex("SndId", "AgnumCode")
+                        .IsUnique();
+
+                    b.HasIndex("SndId", "AgnumProductId")
+                        .IsUnique();
+
+                    b.ToTable("agnum_product_links", "public");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumVirtualWarehouseBalance", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("AgnumProductId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("ImportedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<Guid>("ImportRunId")
+                        .HasColumnType("uuid");
+
+                    b.Property<int?>("ItemId")
+                        .HasColumnType("integer");
+
+                    b.Property<decimal>("Quantity")
+                        .HasPrecision(18, 4)
+                        .HasColumnType("numeric(18,4)");
+
+                    b.Property<string>("Sku")
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("SndId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("SourceHash")
+                        .HasMaxLength(128)
+                        .HasColumnType("character varying(128)");
+
+                    b.Property<string>("Uom")
+                        .IsRequired()
+                        .HasMaxLength(10)
+                        .HasColumnType("character varying(10)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ImportRunId");
+
+                    b.HasIndex("ImportRunId", "SndId", "AgnumProductId")
+                        .IsUnique();
+
+                    b.HasIndex("ItemId");
+
+                    b.HasIndex("SndId", "AgnumProductId");
+
+                    b.ToTable("agnum_virtual_warehouse_balances", "public");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumWarehouseMapping", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("AgnumName")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("ApiKeyConfigName")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<DateTimeOffset>("CreatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("CreatedBy")
+                        .HasColumnType("text");
+
+                    b.Property<bool>("IsImportEnabled")
+                        .HasColumnType("boolean");
+
+                    b.Property<string>("MesVirtualWarehouseCode")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<int>("SndId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTimeOffset?>("UpdatedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("UpdatedBy")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SndId")
+                        .IsUnique();
+
+                    b.ToTable("agnum_warehouse_mappings", "public");
+
+                    b.HasData(
+                        new
+                        {
+                            Id = 1,
+                            AgnumName = "Sandėlys",
+                            ApiKeyConfigName = "sandelys",
+                            CreatedAt = new DateTimeOffset(new DateTime(2026, 2, 13, 0, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero),
+                            CreatedBy = "system",
+                            IsImportEnabled = true,
+                            MesVirtualWarehouseCode = "AGNUM-493",
+                            SndId = 493
+                        },
+                        new
+                        {
+                            Id = 2,
+                            AgnumName = "Pardavimai",
+                            ApiKeyConfigName = "pardavimai",
+                            CreatedAt = new DateTimeOffset(new DateTime(2026, 2, 13, 0, 0, 0, 0, DateTimeKind.Unspecified), TimeSpan.Zero),
+                            CreatedBy = "system",
+                            IsImportEnabled = true,
+                            MesVirtualWarehouseCode = "AGNUM-496",
+                            SndId = 496
+                        });
                 });
 
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.ApiKey", b =>
@@ -1394,6 +1616,49 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                     b.HasIndex("ParentCategoryId");
 
                     b.ToTable("item_categories", "public");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.ItemExternalAttribute", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<int>("ItemId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Key")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceContext")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<string>("SourceSystem")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<decimal?>("ValueNumber")
+                        .HasPrecision(18, 4)
+                        .HasColumnType("numeric(18,4)");
+
+                    b.Property<string>("ValueText")
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("ItemId");
+
+                    b.HasIndex("ItemId", "SourceSystem", "SourceContext", "Key")
+                        .IsUnique();
+
+                    b.ToTable("item_external_attributes", "public");
                 });
 
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.ItemPhoto", b =>
@@ -3628,6 +3893,44 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         .IsRequired();
 
                     b.Navigation("Config");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumProductLink", b =>
+                {
+                    b.HasOne("LKvitai.MES.Modules.Warehouse.Domain.Entities.Item", "Item")
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("Item");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumVirtualWarehouseBalance", b =>
+                {
+                    b.HasOne("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumBalanceImportRun", "ImportRun")
+                        .WithMany()
+                        .HasForeignKey("ImportRunId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.HasOne("LKvitai.MES.Modules.Warehouse.Domain.Entities.Item", null)
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Restrict);
+
+                    b.Navigation("ImportRun");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.ItemExternalAttribute", b =>
+                {
+                    b.HasOne("LKvitai.MES.Modules.Warehouse.Domain.Entities.Item", "Item")
+                        .WithMany()
+                        .HasForeignKey("ItemId")
+                        .OnDelete(DeleteBehavior.Cascade)
+                        .IsRequired();
+
+                    b.Navigation("Item");
                 });
 
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.Customer", b =>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
@@ -313,6 +313,7 @@ public class WarehouseDbContext : DbContext
             entity.Property(e => e.AgnumProductId).IsRequired();
             entity.Property(e => e.AgnumCode).HasMaxLength(100).IsRequired();
             entity.HasIndex(e => new { e.SndId, e.AgnumProductId }).IsUnique();
+            entity.HasIndex(e => new { e.SndId, e.AgnumCode }).IsUnique();
             entity.HasIndex(e => e.ItemId);
             entity.HasOne(e => e.Item).WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
         });
@@ -360,6 +361,7 @@ public class WarehouseDbContext : DbContext
             entity.Property(e => e.ImportedAt).IsRequired();
             entity.Property(e => e.SourceHash).HasMaxLength(128);
             entity.HasIndex(e => e.ImportRunId);
+            entity.HasIndex(e => new { e.ImportRunId, e.SndId, e.AgnumProductId }).IsUnique();
             entity.HasIndex(e => new { e.SndId, e.AgnumProductId });
             entity.HasOne(e => e.ImportRun).WithMany().HasForeignKey(e => e.ImportRunId).OnDelete(DeleteBehavior.Cascade);
             entity.HasOne<Item>().WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
@@ -1446,6 +1448,30 @@ public class WarehouseDbContext : DbContext
             new RolePermission { RoleId = 3, PermissionId = 5 },
             new RolePermission { RoleId = 4, PermissionId = 7 },
             new RolePermission { RoleId = 4, PermissionId = 8 });
+
+        modelBuilder.Entity<AgnumWarehouseMapping>().HasData(
+            new AgnumWarehouseMapping
+            {
+                Id = 1,
+                SndId = 493,
+                AgnumName = "Sandėlys",
+                MesVirtualWarehouseCode = "AGNUM-493",
+                ApiKeyConfigName = "sandelys",
+                IsImportEnabled = true,
+                CreatedAt = systemCreatedAt,
+                CreatedBy = "system"
+            },
+            new AgnumWarehouseMapping
+            {
+                Id = 2,
+                SndId = 496,
+                AgnumName = "Pardavimai",
+                MesVirtualWarehouseCode = "AGNUM-496",
+                ApiKeyConfigName = "pardavimai",
+                IsImportEnabled = true,
+                CreatedAt = systemCreatedAt,
+                CreatedBy = "system"
+            });
 
         modelBuilder.Entity<SerialNumber>(entity =>
         {


### PR DESCRIPTION
## Summary

- **EF migration** `20260518115100_AddAgnumImportTables` — creates 5 tables: `agnum_warehouse_mappings`, `agnum_product_links`, `item_external_attributes`, `agnum_balance_import_runs`, `agnum_virtual_warehouse_balances`; seeds sndId 493 (Sandėlys) and 496 (Pardavimai)
- **EF snapshot** updated — `WarehouseDbContextModelSnapshot.cs` includes all 5 new entities + relationships + seed data (prevents duplicate migration on next `dotnet ef migrations add`)
- **`AgnumImportRecurringJob`** — Hangfire job `agnum-daily-import`; iterates enabled warehouse mappings, calls nomenclature + balance import, continues on per-warehouse failure; cron configurable via `Agnum:Import:DailyCron` (default `0 6 * * *`)
- **Deploy wiring** — Agnum API key secrets and base URL added to `deploy-test.yml`, `deploy.yml`, `docker-compose.test.yml`, `docker-compose.yml`

## Before merging

Add these to GitHub **environment `test`** secrets/vars:

| Type | Name | Value |
|------|------|-------|
| Secret | `AGNUM__WAREHOUSES__SANDELYS__APIKEY` | API key for sndId 493 |
| Secret | `AGNUM__WAREHOUSES__PARDAVIMAI__APIKEY` | API key for sndId 496 |
| Variable | `Agnum__Api__BaseUrl` | Agnum API URL (e.g. `http://agnum-api:8181`) |

Also ensure the Agnum API (`agnum-api` container on test server) has both users configured in `/opt/agnum/application.properties` with `rights=READ_ALL`.

## Test plan

- [ ] GitHub secrets added for environment `test`
- [ ] Agnum API configured with sandelys (493) + pardavimai (496) users
- [ ] Deploy to test succeeds — migration applies cleanly
- [ ] `POST /api/agnum/nomenclature/apply?sndId=493` returns import result
- [ ] `GET /api/agnum/balances?sndId=493` returns virtual balances
- [ ] Hangfire dashboard shows `agnum-daily-import` job scheduled


Made with [Cursor](https://cursor.com)