### PR TITLE
Fix Agnum empty-product search fallback

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
@@ -1,6 +1,7 @@
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
 using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
 using Microsoft.Extensions.Logging;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
@@ -9,6 +10,8 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
 
 public sealed class AgnumApiClient : IAgnumApiClient
 {
+    private const string FallbackProductsSearchQuery = "api/products/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id";
+
     private readonly HttpClient _httpClient;
     private readonly string _apiKey;
     private readonly ILogger<AgnumApiClient> _logger;
@@ -27,13 +30,27 @@ public sealed class AgnumApiClient : IAgnumApiClient
 
     public async Task<IReadOnlyList<AgnumProductDto>> GetProductsAsync(CancellationToken ct = default)
     {
-        using var request = new HttpRequestMessage(HttpMethod.Get, "api/products/search");
+        var products = await FetchProductsAsync("api/products/search", ct);
+        if (products is not null)
+        {
+            return products;
+        }
+
+        _logger.LogDebug("Agnum API returned BadRequest for empty search; retrying with fallback query to fetch all products.");
+        products = await FetchProductsAsync(FallbackProductsSearchQuery, ct);
+        return products ?? Array.Empty<AgnumProductDto>();
+    }
+
+    private async Task<IReadOnlyList<AgnumProductDto>?> FetchProductsAsync(string requestUri, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
         if (!string.IsNullOrWhiteSpace(_apiKey))
         {
             request.Headers.Add("X-API-KEY", _apiKey);
         }
 
-        _logger.LogDebug("Calling Agnum API GET /api/products/search with X-API-KEY {ApiKeyHash}",
+        _logger.LogDebug("Calling Agnum API GET {RequestUri} with X-API-KEY {ApiKeyHash}",
+            requestUri,
             string.IsNullOrWhiteSpace(_apiKey) ? "<none>" : "<redacted>");
 
         try
@@ -41,8 +58,13 @@ public sealed class AgnumApiClient : IAgnumApiClient
             using var response = await _httpClient.SendAsync(request, ct);
             if (!response.IsSuccessStatusCode)
             {
-                _logger.LogWarning("Agnum API returned HTTP {StatusCode} when fetching products.", response.StatusCode);
-                return Array.Empty<AgnumProductDto>();
+                if (response.StatusCode == HttpStatusCode.BadRequest)
+                {
+                    return null;
+                }
+
+                _logger.LogWarning("Agnum API returned HTTP {StatusCode} when fetching products from {RequestUri}.", response.StatusCode, requestUri);
+                return null;
             }
 
             var content = await response.Content.ReadAsStringAsync(ct);
@@ -72,7 +94,7 @@ public sealed class AgnumApiClient : IAgnumApiClient
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Agnum API request failed while fetching products.");
-            return Array.Empty<AgnumProductDto>();
+            return null;
         }
     }
 }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumApiClientTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumApiClientTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+using LKvitai.MES.Modules.Warehouse.Integration.Agnum;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AgnumApiClientTests
+{
+    [Fact]
+    public async Task GetProductsAsync_WhenEmptySearchReturnsBadRequest_ShouldRetryWithFallbackQuery()
+    {
+        var products = new[]
+        {
+            new AgnumProductDto
+            {
+                Id = 1,
+                Code = "SKU-001",
+                Name = "Test Product",
+                Pcs = "vnt",
+                Enabled = true,
+                Balance = 10m
+            }
+        };
+
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            new HttpResponseMessage(HttpStatusCode.BadRequest),
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(products), Encoding.UTF8, "application/json")
+            }
+        });
+
+        var handler = new SequentialHttpMessageHandler(responses);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new System.Uri("https://agnum.example/")
+        };
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddFilter((_, _) => false));
+        var client = new AgnumApiClient(httpClient, new AgnumWarehouseKeyOptions { ApiKey = "secret" }, loggerFactory.CreateLogger<AgnumApiClient>());
+        var result = await client.GetProductsAsync(CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].Code.Should().Be("SKU-001");
+        handler.Requests.Should().HaveCount(2);
+        handler.Requests[1].RequestUri!.PathAndQuery.Should().Be("/api/products/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id");
+    }
+
+    private sealed class SequentialHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Queue<HttpResponseMessage> _responses;
+
+        public SequentialHttpMessageHandler(Queue<HttpResponseMessage> responses)
+        {
+            _responses = responses;
+            Requests = new List<HttpRequestMessage>();
+        }
+
+        public List<HttpRequestMessage> Requests { get; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Requests.Add(request);
+            return Task.FromResult(_responses.Dequeue());
+        }
+    }
+}


### PR DESCRIPTION
Retry Agnum /api/products/search with an explicit fallback query when the empty search request returns 400 BadRequest, and add a regression test.