### PR TITLE
Fix Agnum nomenclature import: supplier/UoM reference graph, category hierarchy, and DTO metadata

### DIFF
--- a/docs/agnum-integration-plan/07-agnum-import-service-fix-blueprint.md
+++ b/docs/agnum-integration-plan/07-agnum-import-service-fix-blueprint.md
@@ -1,0 +1,163 @@
+# Agnum Nomenclature Import Fix Blueprint
+
+## Goal
+
+Fix the Agnum nomenclature import so it can:
+- fully import product fields from Agnum,
+- create and maintain the local FK reference data needed for import,
+- import suppliers from Agnum as a supplier reference catalog,
+- create missing UoM records during import,
+- build category hierarchy without committing halfway through a live import,
+- preserve a clean import path for a wiped inventory/catalog database.
+
+## Scope
+
+This blueprint covers changes to:
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs`
+- `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs`
+- unit tests in `tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/`
+
+It also includes the required cleanup SQL for a fully clean import database.
+
+## Background
+
+Current import behavior is partially broken:
+- Agnum API fallback was fixed, so product retrieval works.
+- `ItemExternalAttribute` FK is now linked correctly.
+- Import still rejects or breaks on missing UoM and does not import suppliers.
+- `GetOrCreateCategoryAsync()` still `SaveChangesAsync()` inside helper logic, which can fail when previous uncaptured items are present.
+
+## Implementation Plan
+
+### 1. Extend Agnum DTO
+
+Update `AgnumProductDto` in `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs` to include:
+- Supplier-related fields: `SupplierCode`, `SupplierName`, or the actual Agnum payload names.
+- Any additional Agnum metadata that must be imported, including UoM type if available.
+
+### 2. Stop rejecting unknown UoM in preview
+
+In `AgnumNomenclatureImportService.PreviewAsync()`:
+- remove `UnknownUoM` as an import blocker if the service can create UoM records.
+- preserve conflict detection for duplicate SKU and linked-to-different-item.
+
+### 3. Add UoM creation helper
+
+Add a helper method in `AgnumNomenclatureImportService`:
+- `Task<UnitOfMeasure> EnsureUnitOfMeasureAsync(string code, string? type, CancellationToken ct)`
+- Normalize codes to the same format used by the DB.
+- If the code exists, return the existing record.
+- If it does not exist, create a new `UnitOfMeasure` record and attach it to the context.
+- Default `Type` sensibly when Agnum does not provide it: `Piece` for typical piece units, otherwise infer from common codes.
+
+### 4. Add supplier creation helper
+
+Add a supplier helper:
+- `Task<Supplier> EnsureSupplierAsync(string code, string? name, CancellationToken ct)`
+- If the supplier exists, return it.
+- If not, create a new `Supplier` record.
+- Optionally create `SupplierItemMapping` for `Item` + supplier SKU if that mapping is needed by downstream flows.
+
+### 5. Refactor category creation
+
+Change `GetOrCreateCategoryAsync()` to:
+- return `ItemCategory` instead of `int`
+- remove `await _dbContext.SaveChangesAsync(ct)` from inside the helper
+- add the category to the DbContext and return it
+- continue to normalize category codes consistently
+
+Change `EnsureCategoryHierarchyAsync()` so it builds a chain of `ItemCategory` objects and returns the leaf category.
+
+### 6. Update `CreateProductAsync()` to use navigation properties
+
+Refactor `CreateProductAsync()` so it:
+1. loads/creates category via `EnsureCategoryHierarchyAsync()`
+2. loads/creates UoM via `EnsureUnitOfMeasureAsync(product.Pcs, maybeType, ct)`
+3. loads/creates supplier via `EnsureSupplierAsync(...)`
+4. creates `Item` and sets:
+   - `InternalSKU`
+   - `Name`
+   - `Status`
+   - `Weight` / `Volume`
+   - `BaseUoM = product.Pcs`
+   - `BaseUnit = unitOfMeasure`
+   - `Category = category`
+   - `Supplier = supplier` or `SupplierId` if needed
+5. adds the item to `_dbContext.Items`
+6. adds item barcodes
+7. adds `AgnumProductLink` with `Item = item`
+8. adds external attributes with `attribute.Item = item`
+
+### 7. Keep save timing controlled
+
+Ensure the import does not call `SaveChangesAsync()` inside `GetOrCreateCategoryAsync()` or other helper methods that are used while previous `Item` entities are still pending.
+
+Preferred pattern:
+- accumulate changes for one product in the current DbContext transaction,
+- optionally `SaveChangesAsync()` after each product if batch isolation is desired,
+- or save once per import run if the code path is safe.
+
+### 8. Add missing supplier import into the Agnum product flow
+
+If the Agnum payload includes supplier information for a product, import it and link it to the created item.
+
+Potential mapping logic:
+- `product.SupplierCode` → `Supplier.Code`
+- `product.SupplierName` → `Supplier.Name`
+- `SupplierItemMapping.SupplierId` + `SupplierSKU` if Agnum provides a supplier SKU for the item.
+
+### 9. Validation and tests
+
+Add or update tests for:
+- UoM creation when `product.Pcs` is missing from `unit_of_measures`
+- supplier creation from Agnum fields
+- `CreateProductAsync()` creating category, UoM, supplier, item, barcodes, and link records
+- ensuring `GetOrCreateCategoryAsync()` does not commit mid-import
+- ensuring external attributes are linked with `attribute.Item = item`
+
+### 10. Clean database before import
+
+Add a SQL cleanup snippet in the doc or run manually before import.
+
+Full wipe for import domain:
+
+```sql
+BEGIN;
+
+TRUNCATE TABLE public.item_uom_conversions RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.agnum_product_links RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.item_external_attributes RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.item_barcodes RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.item_photos RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.on_hand_value RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.items RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.item_categories RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.supplier_item_mappings RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.suppliers RESTART IDENTITY CASCADE;
+TRUNCATE TABLE public.unit_of_measures RESTART IDENTITY CASCADE;
+
+COMMIT;
+```
+
+If you need to keep a base UoM catalog, remove the `unit_of_measures` truncate and reinsert base rows separately.
+
+## Implementation prompt for another AI
+
+Use this prompt if you want another AI to make the code changes directly:
+
+> Update the Agnum nomenclature import service in `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs` and the Agnum DTO in `src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs` with the following behavior:
+>
+> 1. Extend `AgnumProductDto` with supplier fields and, if available from Agnum, UoM type metadata.
+> 2. In `PreviewAsync()`, stop blocking import for UoM codes that are not present in `unit_of_measures` if the service can create them.
+> 3. Add `EnsureUnitOfMeasureAsync(string code, string? type, CancellationToken ct)` to create missing UoM records during import.
+> 4. Add `EnsureSupplierAsync(string code, string? name, CancellationToken ct)` to create missing suppliers and return the supplier entity.
+> 5. Refactor category creation so `GetOrCreateCategoryAsync()` returns `ItemCategory`, does not call `SaveChangesAsync()` inside the helper, and builds category hierarchy safely.
+> 6. In `CreateProductAsync()`, create/find category, UoM, and supplier, then build the `Item` with navigation properties: `Category`, `BaseUnit`, `Supplier` or supplier mapping. Attach `ItemBarcode`, `AgnumProductLink`, and `ItemExternalAttribute` correctly.
+> 7. Ensure external attributes are linked via `attribute.Item = item` before adding them to the DbContext.
+> 8. Add tests for UoM creation, supplier creation, safe category creation, and the full import flow.
+>
+> Keep the solution consistent with existing EF Core model conventions and avoid committing the DbContext mid-import.
+
+---
+
+File path: `docs/agnum-integration-plan/07-agnum-import-service-fix-blueprint.md`

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
@@ -28,10 +28,6 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
         var client = _apiClientFactory.GetForSndId(sndId);
         var products = await client.GetProductsAsync(ct);
 
-        var validUoms = await _dbContext.UnitOfMeasures
-            .Select(x => x.Code)
-            .ToListAsync(ct);
-
         var existingLinks = await _dbContext.AgnumProductLinks
             .Where(x => x.SndId == sndId)
             .ToListAsync(ct);
@@ -54,13 +50,13 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
         foreach (var product in products)
         {
-            if (string.IsNullOrWhiteSpace(product.Pcs) || !validUoms.Contains(product.Pcs, StringComparer.OrdinalIgnoreCase))
+            if (string.IsNullOrWhiteSpace(product.Pcs))
             {
                 preview.Conflicts.Add(new AgnumImportConflict
                 {
                     AgnumProductId = product.Id,
                     Code = product.Code,
-                    Reason = "UnknownUoM"
+                    Reason = "MissingUoM"
                 });
                 continue;
             }
@@ -165,22 +161,26 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
     private async Task CreateProductAsync(AgnumProductDto product, int sndId, CancellationToken ct)
     {
-        var categoryId = await EnsureCategoryHierarchyAsync(product.Group, product.Category, product.Subgroup, ct);
+        var category = await EnsureCategoryHierarchyAsync(product.Group, product.Category, product.Subgroup, ct);
+        var unitOfMeasure = await EnsureUnitOfMeasureAsync(product.Pcs, product.UnitOfMeasureType, ct);
+        var supplier = await EnsureSupplierAsync(product.SupplierCode, product.SupplierName, ct);
         var item = new Item
         {
             InternalSKU = product.Code,
             Name = product.Name,
-            BaseUoM = product.Pcs,
+            BaseUoM = unitOfMeasure.Code,
+            BaseUnit = unitOfMeasure,
             Status = product.Enabled ? "Active" : "Discontinued",
             Weight = product.Netto,
-            CategoryId = categoryId,
+            Category = category,
             CreatedAt = DateTimeOffset.UtcNow,
             UpdatedAt = DateTimeOffset.UtcNow,
-            PrimaryBarcode = product.Barcodes?.FirstOrDefault()
+            PrimaryBarcode = GetProductBarcodes(product).FirstOrDefault()
         };
 
         _dbContext.Items.Add(item);
         await AddItemBarcodesAsync(item, product, ct);
+        await EnsureSupplierItemMappingAsync(item, supplier, product, ct);
 
         _dbContext.AgnumProductLinks.Add(new AgnumProductLink
         {
@@ -206,14 +206,21 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
             return;
         }
 
+        var category = await EnsureCategoryHierarchyAsync(product.Group, product.Category, product.Subgroup, ct);
+        var unitOfMeasure = await EnsureUnitOfMeasureAsync(product.Pcs, product.UnitOfMeasureType, ct);
+        var supplier = await EnsureSupplierAsync(product.SupplierCode, product.SupplierName, ct);
+
         item.Name = product.Name;
-        item.BaseUoM = product.Pcs;
+        item.BaseUoM = unitOfMeasure.Code;
+        item.BaseUnit = unitOfMeasure;
+        item.Category = category;
         item.Status = product.Enabled ? "Active" : "Discontinued";
         item.Weight = product.Netto;
-        item.PrimaryBarcode = product.Barcodes?.FirstOrDefault() ?? item.PrimaryBarcode;
+        item.PrimaryBarcode = GetProductBarcodes(product).FirstOrDefault() ?? item.PrimaryBarcode;
         item.UpdatedAt = DateTimeOffset.UtcNow;
 
         await AddItemBarcodesAsync(item, product, ct);
+        await EnsureSupplierItemMappingAsync(item, supplier, product, ct);
         await ReplaceExternalAttributesAsync(item, product, sndId, ct);
 
         link.AgnumCode = product.Code;
@@ -225,12 +232,7 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
     private async Task AddItemBarcodesAsync(Item item, AgnumProductDto product, CancellationToken ct)
     {
-        var barcodes = product.Barcodes ?? new List<string>();
-        var distinctBarcodes = barcodes
-            .Where(x => !string.IsNullOrWhiteSpace(x))
-            .Select(x => x.Trim())
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .ToList();
+        var distinctBarcodes = GetProductBarcodes(product);
 
         if (distinctBarcodes.Count == 0)
         {
@@ -288,7 +290,11 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
             CreateAttribute(sourceContext, "branch", product.Branch),
             CreateAttribute(sourceContext, "place", product.Place),
             CreateAttribute(sourceContext, "f1", product.F1),
-            CreateAttribute(sourceContext, "f2", product.F2)
+            CreateAttribute(sourceContext, "f2", product.F2),
+            CreateAttribute(sourceContext, "supplierCode", product.SupplierCode),
+            CreateAttribute(sourceContext, "supplierName", product.SupplierName),
+            CreateAttribute(sourceContext, "supplierSku", product.SupplierSku),
+            CreateAttribute(sourceContext, "uomType", product.UnitOfMeasureType)
         };
 
         return attributes.Where(x => x is not null)!;
@@ -317,68 +323,203 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
         return attribute;
     }
 
-    private async Task<int> EnsureCategoryHierarchyAsync(string? group, string? category, string? subgroup, CancellationToken ct)
+    private async Task<ItemCategory> EnsureCategoryHierarchyAsync(string? group, string? category, string? subgroup, CancellationToken ct)
     {
-        int? parentId = null;
+        ItemCategory? parent = null;
 
         if (!string.IsNullOrWhiteSpace(group))
         {
-            parentId = await GetOrCreateCategoryAsync(group.Trim(), null, ct);
+            parent = await GetOrCreateCategoryAsync(group.Trim(), null, ct);
         }
 
         if (!string.IsNullOrWhiteSpace(category))
         {
-            parentId = await GetOrCreateCategoryAsync(category.Trim(), parentId, ct);
+            parent = await GetOrCreateCategoryAsync(category.Trim(), parent, ct);
         }
 
         if (!string.IsNullOrWhiteSpace(subgroup))
         {
-            parentId = await GetOrCreateCategoryAsync(subgroup.Trim(), parentId, ct);
+            parent = await GetOrCreateCategoryAsync(subgroup.Trim(), parent, ct);
         }
 
-        if (parentId.HasValue)
+        if (parent is not null)
         {
-            return parentId.Value;
+            return parent;
         }
 
         return await GetOrCreateCategoryAsync("Agnum", null, ct);
     }
 
-    private async Task<int> GetOrCreateCategoryAsync(string name, int? parentCategoryId, CancellationToken ct)
+    private async Task<ItemCategory> GetOrCreateCategoryAsync(string name, ItemCategory? parentCategory, CancellationToken ct)
     {
         var normalizedCode = NormalizeCategoryCode(name);
-        if (parentCategoryId.HasValue)
+        var normalizedCodeUpper = normalizedCode.ToUpperInvariant();
+        if (parentCategory is not null)
         {
-            var parent = await _dbContext.ItemCategories.FindAsync(new object[] { parentCategoryId.Value }, ct);
-            if (parent is null)
-            {
-                parentCategoryId = null;
-            }
-            else
-            {
-                normalizedCode = NormalizeCategoryCode(parent.Code + "-" + name);
-            }
+            normalizedCode = NormalizeCategoryCode(parentCategory.Code + "-" + name);
+            normalizedCodeUpper = normalizedCode.ToUpperInvariant();
+        }
+
+        var tracked = _dbContext.ItemCategories.Local
+            .FirstOrDefault(x => string.Equals(x.Code, normalizedCode, StringComparison.OrdinalIgnoreCase));
+        if (tracked is not null)
+        {
+            return tracked;
         }
 
         var existing = await _dbContext.ItemCategories
-            .AsNoTracking()
-            .FirstOrDefaultAsync(x => x.Code == normalizedCode, ct);
+            .FirstOrDefaultAsync(x => x.Code.ToUpper() == normalizedCodeUpper, ct);
 
         if (existing is not null)
         {
-            return existing.Id;
+            return existing;
         }
 
         var category = new ItemCategory
         {
             Code = normalizedCode,
             Name = name,
-            ParentCategoryId = parentCategoryId
+            ParentCategory = parentCategory
         };
 
         _dbContext.ItemCategories.Add(category);
-        await _dbContext.SaveChangesAsync(ct);
-        return category.Id;
+        return category;
+    }
+
+    private async Task<UnitOfMeasure> EnsureUnitOfMeasureAsync(string code, string? type, CancellationToken ct)
+    {
+        var normalizedCode = NormalizeUnitOfMeasureCode(code);
+        var normalizedCodeUpper = normalizedCode.ToUpperInvariant();
+
+        var tracked = _dbContext.UnitOfMeasures.Local
+            .FirstOrDefault(x => string.Equals(x.Code, normalizedCode, StringComparison.OrdinalIgnoreCase));
+        if (tracked is not null)
+        {
+            return tracked;
+        }
+
+        var existing = await _dbContext.UnitOfMeasures
+            .FirstOrDefaultAsync(x => x.Code.ToUpper() == normalizedCodeUpper, ct);
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        var unitOfMeasure = new UnitOfMeasure
+        {
+            Code = normalizedCode,
+            Name = normalizedCode,
+            Type = NormalizeUnitOfMeasureType(type, normalizedCode)
+        };
+
+        _dbContext.UnitOfMeasures.Add(unitOfMeasure);
+        return unitOfMeasure;
+    }
+
+    private async Task<Supplier?> EnsureSupplierAsync(string? code, string? name, CancellationToken ct)
+    {
+        var normalizedCode = NormalizeSupplierCode(code);
+        if (normalizedCode is null)
+        {
+            normalizedCode = NormalizeSupplierCode(name);
+        }
+
+        if (normalizedCode is null)
+        {
+            return null;
+        }
+
+        var supplierName = string.IsNullOrWhiteSpace(name) ? normalizedCode : name.Trim();
+        var normalizedCodeUpper = normalizedCode.ToUpperInvariant();
+        var tracked = _dbContext.Suppliers.Local
+            .FirstOrDefault(x => string.Equals(x.Code, normalizedCode, StringComparison.OrdinalIgnoreCase));
+        if (tracked is not null)
+        {
+            if (string.IsNullOrWhiteSpace(tracked.Name) || tracked.Name == tracked.Code)
+            {
+                tracked.Name = supplierName;
+            }
+
+            return tracked;
+        }
+
+        var existing = await _dbContext.Suppliers
+            .FirstOrDefaultAsync(x => x.Code.ToUpper() == normalizedCodeUpper, ct);
+        if (existing is not null)
+        {
+            if (string.IsNullOrWhiteSpace(existing.Name) || existing.Name == existing.Code)
+            {
+                existing.Name = supplierName;
+            }
+
+            return existing;
+        }
+
+        var supplier = new Supplier
+        {
+            Code = normalizedCode,
+            Name = supplierName,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        };
+
+        _dbContext.Suppliers.Add(supplier);
+        return supplier;
+    }
+
+    private async Task EnsureSupplierItemMappingAsync(Item item, Supplier? supplier, AgnumProductDto product, CancellationToken ct)
+    {
+        if (supplier is null)
+        {
+            return;
+        }
+
+        var supplierSku = (product.SupplierSku ?? product.F2 ?? product.Code).Trim();
+        if (string.IsNullOrWhiteSpace(supplierSku))
+        {
+            return;
+        }
+
+        var tracked = _dbContext.SupplierItemMappings.Local.FirstOrDefault(x =>
+            string.Equals(x.SupplierSKU, supplierSku, StringComparison.OrdinalIgnoreCase)
+            && (ReferenceEquals(x.Supplier, supplier) || x.SupplierId != 0 && x.SupplierId == supplier.Id));
+
+        if (tracked is not null)
+        {
+            if (tracked.Item is null && tracked.ItemId == 0)
+            {
+                tracked.Item = item;
+            }
+
+            return;
+        }
+
+        if (supplier.Id != 0)
+        {
+            var existing = await _dbContext.SupplierItemMappings
+                .FirstOrDefaultAsync(x => x.SupplierId == supplier.Id && x.SupplierSKU == supplierSku, ct);
+            if (existing is not null)
+            {
+                if (existing.ItemId == item.Id)
+                {
+                    return;
+                }
+
+                _logger.LogWarning(
+                    "Supplier SKU {SupplierSku} for supplier {SupplierCode} is already mapped to item {ItemId}.",
+                    supplierSku,
+                    supplier.Code,
+                    existing.ItemId);
+                return;
+            }
+        }
+
+        _dbContext.SupplierItemMappings.Add(new SupplierItemMapping
+        {
+            Supplier = supplier,
+            Item = item,
+            SupplierSKU = supplierSku
+        });
     }
 
     private static string NormalizeCategoryCode(string value)
@@ -407,6 +548,67 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
         return code;
     }
 
+    private static string NormalizeUnitOfMeasureCode(string value)
+    {
+        var code = value.Trim();
+        return code.Length > 10 ? code[..10] : code;
+    }
+
+    private static string NormalizeUnitOfMeasureType(string? type, string code)
+    {
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            var normalizedType = type.Trim();
+            if (normalizedType.Equals("Weight", StringComparison.OrdinalIgnoreCase)
+                || normalizedType.Equals("Volume", StringComparison.OrdinalIgnoreCase)
+                || normalizedType.Equals("Piece", StringComparison.OrdinalIgnoreCase)
+                || normalizedType.Equals("Length", StringComparison.OrdinalIgnoreCase))
+            {
+                return char.ToUpperInvariant(normalizedType[0]) + normalizedType[1..].ToLowerInvariant();
+            }
+        }
+
+        var normalizedCode = code.Trim().ToLowerInvariant();
+        return normalizedCode switch
+        {
+            "kg" or "g" or "gr" or "t" => "Weight",
+            "l" or "ltr" or "m3" => "Volume",
+            "m" or "m2" or "cm" or "mm" => "Length",
+            _ => "Piece"
+        };
+    }
+
+    private static string? NormalizeSupplierCode(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return null;
+        }
+
+        var normalized = NormalizeCategoryCode(value);
+        return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static List<string> GetProductBarcodes(AgnumProductDto product)
+    {
+        var barcodes = new List<string>();
+        if (product.Barcodes is not null)
+        {
+            barcodes.AddRange(product.Barcodes);
+        }
+
+        if (!string.IsNullOrWhiteSpace(product.Barcode))
+        {
+            barcodes.Add(product.Barcode);
+        }
+
+        return barcodes
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x.Trim())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private static string ComputeRawHash(AgnumProductDto product)
     {
         var text = string.Join("|",
@@ -425,7 +627,11 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
             product.Branch ?? string.Empty,
             product.Place ?? string.Empty,
             product.F1 ?? string.Empty,
-            product.F2 ?? string.Empty);
+            product.F2 ?? string.Empty,
+            product.SupplierCode ?? string.Empty,
+            product.SupplierName ?? string.Empty,
+            product.SupplierSku ?? string.Empty,
+            product.UnitOfMeasureType ?? string.Empty);
 
         using var sha = System.Security.Cryptography.SHA256.Create();
         var bytes = System.Text.Encoding.UTF8.GetBytes(text);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
@@ -36,4 +36,16 @@ public sealed class AgnumProductDto
     public string? Place { get; init; }
     public string? F1 { get; init; }
     public string? F2 { get; init; }
+
+    [JsonPropertyName("supplier_code")]
+    public string? SupplierCode { get; init; }
+
+    [JsonPropertyName("supplier_name")]
+    public string? SupplierName { get; init; }
+
+    [JsonPropertyName("supplier_sku")]
+    public string? SupplierSku { get; init; }
+
+    [JsonPropertyName("uom_type")]
+    public string? UnitOfMeasureType { get; init; }
 }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
@@ -15,7 +15,7 @@ namespace LKvitai.MES.Tests.Warehouse.Unit;
 public class AgnumImportConflictDetectionTests
 {
     [Fact]
-    public async Task PreviewAsync_WhenPcsIsUnknown_ShouldReturnUnknownUoM()
+    public async Task PreviewAsync_WhenPcsIsUnknown_ShouldReturnToCreate()
     {
         await using var db = CreateDbContext();
         await SeedUnitOfMeasuresAsync(db, "vnt");
@@ -34,8 +34,8 @@ public class AgnumImportConflictDetectionTests
 
         var preview = await service.PreviewAsync(493);
 
-        preview.Conflicts.Should().ContainSingle();
-        preview.Conflicts[0].Reason.Should().Be("UnknownUoM");
+        preview.Conflicts.Should().BeEmpty();
+        preview.ToCreate.Should().ContainSingle(x => x.AgnumProductId == 1 && x.Pcs == "unknown");
     }
 
     [Fact]
@@ -164,6 +164,102 @@ public class AgnumImportConflictDetectionTests
         var preview = await service.PreviewAsync(493);
 
         preview.ToUpdate.Should().ContainSingle(x => x.AgnumProductId == 5);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenProductHasMissingReferences_ShouldCreateReferenceGraph()
+    {
+        await using var db = CreateDbContext();
+
+        var product = new AgnumProductDto
+        {
+            Id = 6,
+            Code = "SKU-FULL",
+            Name = "Full Import Product",
+            Pcs = "m2",
+            UnitOfMeasureType = "Length",
+            Enabled = true,
+            Balance = 1,
+            Netto = 1.25m,
+            Barcode = "111",
+            Barcodes = new List<string> { "222" },
+            Group = "Fabric",
+            Category = "Cotton",
+            Subgroup = "Printed",
+            SupplierCode = "sup-001",
+            SupplierName = "Supplier One",
+            SupplierSku = "SUP-SKU-001"
+        };
+
+        var service = CreateService(db, product);
+
+        var result = await service.ApplyAsync(493);
+
+        result.Created.Should().Be(1);
+        result.Skipped.Should().Be(0);
+
+        var item = await db.Items.SingleAsync(x => x.InternalSKU == "SKU-FULL");
+        item.BaseUoM.Should().Be("m2");
+        item.Weight.Should().Be(1.25m);
+        item.PrimaryBarcode.Should().Be("222");
+
+        var unitOfMeasure = await db.UnitOfMeasures.SingleAsync(x => x.Code == "m2");
+        unitOfMeasure.Type.Should().Be("Length");
+
+        var leafCategory = await db.ItemCategories.SingleAsync(x => x.Code == "FABRIC-COTTON-PRINTED");
+        item.CategoryId.Should().Be(leafCategory.Id);
+
+        var supplier = await db.Suppliers.SingleAsync(x => x.Code == "SUP-001");
+        supplier.Name.Should().Be("Supplier One");
+
+        var mapping = await db.SupplierItemMappings.SingleAsync();
+        mapping.SupplierId.Should().Be(supplier.Id);
+        mapping.ItemId.Should().Be(item.Id);
+        mapping.SupplierSKU.Should().Be("SUP-SKU-001");
+
+        (await db.AgnumProductLinks.SingleAsync()).ItemId.Should().Be(item.Id);
+        (await db.ItemExternalAttributes.CountAsync(x => x.ItemId == item.Id)).Should().BeGreaterThan(0);
+        (await db.ItemBarcodes.CountAsync(x => x.ItemId == item.Id)).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task ApplyAsync_WhenProductsShareNewCategoryHierarchy_ShouldReuseTrackedCategories()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var first = new AgnumProductDto
+        {
+            Id = 7,
+            Code = "SKU-CAT-1",
+            Name = "First",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1,
+            Group = "Group",
+            Category = "Category",
+            Subgroup = "Subgroup"
+        };
+        var second = new AgnumProductDto
+        {
+            Id = 8,
+            Code = "SKU-CAT-2",
+            Name = "Second",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1,
+            Group = "Group",
+            Category = "Category",
+            Subgroup = "Subgroup"
+        };
+
+        var service = CreateService(db, first, second);
+
+        var result = await service.ApplyAsync(493);
+
+        result.Created.Should().Be(2);
+        (await db.ItemCategories.CountAsync()).Should().Be(3);
+        (await db.ItemCategories.CountAsync(x => x.Code == "GROUP-CATEGORY-SUBGROUP")).Should().Be(1);
     }
 
     private static AgnumNomenclatureImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumProductDtoDeserializationTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumProductDtoDeserializationTests.cs
@@ -60,4 +60,18 @@ public class AgnumProductDtoDeserializationTests
         result!.Barcode.Should().BeNull();
         result.Barcodes.Should().BeNull();
     }
+
+    [Fact]
+    public void Deserialize_ProductWithSupplierAndUomMetadata_ShouldPopulateImportFields()
+    {
+        var json = "{\"id\":1,\"code\":\"SKU-001\",\"name\":\"Test\",\"pcs\":\"vnt\",\"enabled\":true,\"balance\":10,\"supplier_code\":\"SUP-001\",\"supplier_name\":\"Supplier One\",\"supplier_sku\":\"SUP-SKU-001\",\"uom_type\":\"Piece\"}";
+
+        var result = JsonSerializer.Deserialize<AgnumProductDto>(json, JsonOptions);
+
+        result.Should().NotBeNull();
+        result!.SupplierCode.Should().Be("SUP-001");
+        result.SupplierName.Should().Be("Supplier One");
+        result.SupplierSku.Should().Be("SUP-SKU-001");
+        result.UnitOfMeasureType.Should().Be("Piece");
+    }
 }


### PR DESCRIPTION
## Summary

This PR completes the Agnum nomenclature import fix by:
- importing missing UnitOfMeasure and Supplier reference data
- creating SupplierItemMapping for Agnum supplier SKUs
- using Category and BaseUnit navigation properties on Item
- avoiding SaveChangesAsync inside category helper logic
- adding supplier/UoM metadata to external attributes
- verifying with Warehouse unit tests

## Notes

- branch: agnum-import-empty-search-fallback
- test: /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Projections/LKvitai.MES.Modules.Warehouse.Projections.csproj : warning NU1904: Package 'Marten' 7.0.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-vmw2-qwm8-x84c
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj : warning NU1902: Package 'OpenTelemetry.Exporter.Jaeger' 1.5.1 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-38h3-2333-qx47
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/LKvitai.MES.Modules.Warehouse.Api.csproj : warning NU1902: Package 'SixLabors.ImageSharp' 3.1.8 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-rxmq-m78w-7wmc
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/LKvitai.MES.Modules.Warehouse.Infrastructure.csproj : warning NU1904: Package 'Marten' 7.0.0 has a known critical severity vulnerability, https://github.com/advisories/GHSA-vmw2-qwm8-x84c
  LKvitai.MES.BuildingBlocks.Cqrs.Abstractions -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions/bin/Release/net8.0/LKvitai.MES.BuildingBlocks.Cqrs.Abstractions.dll
  LKvitai.MES.BuildingBlocks.ObjectStorage -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.ObjectStorage/bin/Release/net8.0/LKvitai.MES.BuildingBlocks.ObjectStorage.dll
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/Messages/PickStockMessages.cs(5,1): warning CS1587: XML comment is not placed on a valid language element [/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/LKvitai.MES.Modules.Warehouse.Contracts.csproj]
  LKvitai.MES.Modules.Warehouse.Contracts -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Contracts/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Contracts.dll
  LKvitai.MES.BuildingBlocks.PortalAuth -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.PortalAuth/bin/Release/net8.0/LKvitai.MES.BuildingBlocks.PortalAuth.dll
  LKvitai.MES.BuildingBlocks.WebUI -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/bin/Release/net8.0/LKvitai.MES.BuildingBlocks.WebUI.dll
  LKvitai.MES.BuildingBlocks.SharedKernel -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.SharedKernel/bin/Release/net8.0/LKvitai.MES.BuildingBlocks.SharedKernel.dll
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/LabelPrinting/ILabelPrintingService.cs(7,31): warning CS1570: XML comment has badly formed XML -- 'An identifier was expected.' [/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/LKvitai.MES.Modules.Warehouse.Integration.csproj]
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/LabelPrinting/ILabelPrintingService.cs(7,31): warning CS1570: XML comment has badly formed XML -- 'The character(s) '5' cannot be used at this location.' [/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/LKvitai.MES.Modules.Warehouse.Integration.csproj]
  LKvitai.MES.Modules.Warehouse.Domain -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Domain.dll
  LKvitai.MES.Modules.Warehouse.Integration -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Integration.dll
  LKvitai.MES.Modules.Warehouse.Projections -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Projections/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Projections.dll
/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Projections/IProjectionRebuildService.cs(26,14): warning CS1573: Parameter 'resetProgress' has no matching param tag in the XML comment for 'IProjectionRebuildService.RebuildProjectionAsync(string, bool, bool, CancellationToken)' (but other parameters do) [/Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/LKvitai.MES.Modules.Warehouse.Application.csproj]
  LKvitai.MES.Modules.Warehouse.Application -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Application.dll
  LKvitai.MES.Modules.Warehouse.Sagas -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Sagas/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Sagas.dll
  LKvitai.MES.Modules.Warehouse.Infrastructure -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Infrastructure.dll
  LKvitai.MES.Modules.Warehouse.WebUI -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.WebUI.dll
  LKvitai.MES.Modules.Warehouse.Api -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/bin/Release/net8.0/LKvitai.MES.Modules.Warehouse.Api.dll
  LKvitai.MES.Tests.Warehouse.Unit -> /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/bin/Release/net8.0/LKvitai.MES.Tests.Warehouse.Unit.dll
Test run for /Users/bykovas/Sources/clients/lauresta/lkvitai-mes/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/bin/Release/net8.0/LKvitai.MES.Tests.Warehouse.Unit.dll (.NETCoreApp,Version=v8.0)
VSTest version 17.11.1 (arm64)

Starting test execution, please wait...
A total of 1 test files matched the specified pattern.

Passed!  - Failed:     0, Passed:   734, Skipped:     0, Total:   734, Duration: 7 s - LKvitai.MES.Tests.Warehouse.Unit.dll (net8.0)