### PR TITLE
Fix Agnum import failures and ItemUoM query translation

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/ItemUomConversionsController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/ItemUomConversionsController.cs
@@ -31,15 +31,17 @@ public sealed class ItemUomConversionsController : ControllerBase
         var query = from conversion in _dbContext.ItemUoMConversions.AsNoTracking()
                     join item in _dbContext.Items.AsNoTracking() on conversion.ItemId equals item.Id into itemGroup
                     from item in itemGroup.DefaultIfEmpty()
-                    select new ConversionProjection(
+                    select new
+                    {
                         conversion.Id,
                         conversion.ItemId,
-                        item != null ? item.InternalSKU : string.Empty,
-                        item != null ? item.Name : string.Empty,
+                        ItemSku = item != null ? item.InternalSKU : string.Empty,
+                        ItemName = item != null ? item.Name : string.Empty,
                         conversion.FromUoM,
                         conversion.ToUoM,
                         conversion.Factor,
-                        conversion.RoundingRule);
+                        conversion.RoundingRule
+                    };
 
         if (!string.IsNullOrWhiteSpace(search))
         {
@@ -47,15 +49,15 @@ public sealed class ItemUomConversionsController : ControllerBase
             query = query.Where(x =>
                 x.ItemSku.ToLower().Contains(normalized) ||
                 x.ItemName.ToLower().Contains(normalized) ||
-                x.FromUom.ToLower().Contains(normalized) ||
-                x.ToUom.ToLower().Contains(normalized));
+                x.FromUoM.ToLower().Contains(normalized) ||
+                x.ToUoM.ToLower().Contains(normalized));
         }
 
         var totalCount = await query.CountAsync(cancellationToken);
         var items = await query
             .OrderBy(x => x.ItemSku)
-            .ThenBy(x => x.FromUom)
-            .ThenBy(x => x.ToUom)
+            .ThenBy(x => x.FromUoM)
+            .ThenBy(x => x.ToUoM)
             .Skip((pageNumber - 1) * pageSize)
             .Take(pageSize)
             .Select(x => new ItemUomConversionDto(
@@ -63,24 +65,14 @@ public sealed class ItemUomConversionsController : ControllerBase
                 x.ItemId,
                 x.ItemSku,
                 x.ItemName,
-                x.FromUom,
-                x.ToUom,
+                x.FromUoM,
+                x.ToUoM,
                 x.Factor,
                 x.RoundingRule))
             .ToListAsync(cancellationToken);
 
         return Ok(new PagedResponse<ItemUomConversionDto>(items, totalCount, pageNumber, pageSize));
     }
-
-    private sealed record ConversionProjection(
-        int Id,
-        int ItemId,
-        string ItemSku,
-        string ItemName,
-        string FromUom,
-        string ToUom,
-        decimal Factor,
-        string RoundingRule);
 
     public sealed record ItemUomConversionDto(
         int Id,


### PR DESCRIPTION
## Summary

Fixes the Agnum recurring import failure caused by zero `netto` values from Agnum violating the MES `ck_items_weight` constraint. Also keeps the existing ItemUoM conversions controller query translation fix in this branch.

## Root Cause

Agnum returns many products with `netto = 0` (`sandelys`: 5151 / 7470, `pardavimai`: 811 / 2682 on test). MES allows `items.Weight` only when it is `NULL` or greater than zero, so importing `0` directly caused `DbUpdateException` and both warehouse imports failed.

## Changes

- map non-positive Agnum `netto` values to `NULL` before writing `Item.Weight`
- avoid fetching Agnum products twice during nomenclature apply
- remove per-product balance lookup during a new balance import run
- add progress/timing logs around Agnum import phases and API product fetches
- add unit coverage for zero/negative `netto` and single-fetch apply behavior
- preserve the ItemUoM conversions controller query translation fix already on the branch

## Validation

- `dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/LKvitai.MES.Tests.Warehouse.Unit.csproj --filter "FullyQualifiedName~Agnum" --no-restore -m:1`
- Passed: 30, Failed: 0

## Test Env Check

Confirmed on `lkvitai-test.vpn.lauresta.com` that the failing data is real Agnum data, not a single malformed row:

- `sandelys`: 7470 products, 5151 with `netto = 0`
- `pardavimai`: 2682 products, 811 with `netto = 0`