### PR TITLE
[codex] Fix Agnum imports and partner sync

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/MasterDataEntities.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/MasterDataEntities.cs
@@ -94,6 +94,7 @@ public sealed class ItemBarcode
 public sealed class Supplier : AuditableEntity
 {
     public int Id { get; set; }
+    public int? AgnumClientId { get; set; }
     public string Code { get; set; } = string.Empty;
     public string Name { get; set; } = string.Empty;
     public string? ContactInfo { get; set; }
@@ -146,6 +147,7 @@ public sealed class Address
 public sealed class Customer : AuditableEntity
 {
     public Guid Id { get; set; } = Guid.NewGuid();
+    public int? AgnumClientId { get; set; }
     public string CustomerCode { get; set; } = string.Empty;
     [Encrypted]
     public string Name { get; set; } = string.Empty;

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumApiClient.cs
@@ -12,6 +12,7 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
 public sealed class AgnumApiClient : IAgnumApiClient
 {
     private const string FallbackProductsSearchQuery = "api/products/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id";
+    private const string FallbackClientsSearchQuery = "api/clients/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id";
 
     private readonly HttpClient _httpClient;
     private readonly string _apiKey;
@@ -41,6 +42,9 @@ public sealed class AgnumApiClient : IAgnumApiClient
         products = await FetchProductsAsync(FallbackProductsSearchQuery, ct);
         return products ?? Array.Empty<AgnumProductDto>();
     }
+
+    public Task<IReadOnlyList<AgnumClientDto>> GetClientsAsync(CancellationToken ct = default)
+        => FetchClientsAsync(FallbackClientsSearchQuery, ct);
 
     private async Task<IReadOnlyList<AgnumProductDto>?> FetchProductsAsync(string requestUri, CancellationToken ct)
     {
@@ -107,6 +111,54 @@ public sealed class AgnumApiClient : IAgnumApiClient
         {
             _logger.LogWarning(ex, "Agnum API request failed while fetching products.");
             return null;
+        }
+    }
+
+    private async Task<IReadOnlyList<AgnumClientDto>> FetchClientsAsync(string requestUri, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        if (!string.IsNullOrWhiteSpace(_apiKey))
+        {
+            request.Headers.Add("X-API-KEY", _apiKey);
+        }
+
+        _logger.LogDebug("Calling Agnum API GET {RequestUri} with X-API-KEY {ApiKeyHash}",
+            requestUri,
+            string.IsNullOrWhiteSpace(_apiKey) ? "<none>" : "<redacted>");
+
+        try
+        {
+            var stopwatch = Stopwatch.StartNew();
+            using var response = await _httpClient.SendAsync(request, ct);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Agnum API returned HTTP {StatusCode} when fetching clients from {RequestUri}.", response.StatusCode, requestUri);
+                return Array.Empty<AgnumClientDto>();
+            }
+
+            var content = await response.Content.ReadAsStringAsync(ct);
+            var clients = JsonSerializer.Deserialize<IReadOnlyList<AgnumClientDto>>(content, JsonOptions);
+            if (clients is null)
+            {
+                _logger.LogInformation(
+                    "Agnum API GET {RequestUri} returned no clients in {ElapsedMs} ms.",
+                    requestUri,
+                    stopwatch.ElapsedMilliseconds);
+                return Array.Empty<AgnumClientDto>();
+            }
+
+            _logger.LogInformation(
+                "Agnum API GET {RequestUri} returned {ClientCount} clients in {ElapsedMs} ms.",
+                requestUri,
+                clients.Count,
+                stopwatch.ElapsedMilliseconds);
+
+            return clients;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Agnum API request failed while fetching clients.");
+            return Array.Empty<AgnumClientDto>();
         }
     }
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
@@ -137,7 +137,9 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
     public async Task<AgnumImportResult> ApplyAsync(int sndId, CancellationToken ct = default)
     {
-        var products = await _apiClientFactory.GetForSndId(sndId).GetProductsAsync(ct);
+        var client = _apiClientFactory.GetForSndId(sndId);
+        var products = await client.GetProductsAsync(ct);
+        var clients = await client.GetClientsAsync(ct);
         var preview = await BuildPreviewAsync(sndId, products, ct);
         var productById = products.ToDictionary(x => x.Id);
         var existingLinks = await _dbContext.AgnumProductLinks
@@ -146,6 +148,8 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
         var created = 0;
         var updated = 0;
+
+        await EnsurePartnersAsync(clients, ct);
 
         foreach (var candidate in preview.ToCreate)
         {
@@ -493,6 +497,211 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
         return supplier;
     }
 
+    private async Task EnsurePartnersAsync(IReadOnlyList<AgnumClientDto> clients, CancellationToken ct)
+    {
+        await EnsureSuppliersAsync(clients.Where(IsSupplier).ToList(), ct);
+        await EnsureCustomersAsync(clients.Where(IsBuyer).ToList(), ct);
+    }
+
+    private async Task EnsureSuppliersAsync(IReadOnlyList<AgnumClientDto> suppliers, CancellationToken ct)
+    {
+        if (suppliers.Count == 0)
+        {
+            return;
+        }
+
+        var normalizedCodes = suppliers
+            .Select(x => NormalizeSupplierCode(x.Code))
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var agnumClientIds = suppliers
+            .Where(x => x.Id > 0)
+            .Select(x => x.Id)
+            .Distinct()
+            .ToList();
+
+        var normalizedCodeUpperSet = normalizedCodes
+            .Select(x => x.ToUpperInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+        var existingSuppliers = await _dbContext.Suppliers
+            .Where(x => normalizedCodeUpperSet.Contains(x.Code.ToUpper()) || x.AgnumClientId != null && agnumClientIds.Contains(x.AgnumClientId.Value))
+            .ToListAsync(ct);
+        var existingSuppliersByCode = existingSuppliers
+            .ToDictionary(x => x.Code, StringComparer.OrdinalIgnoreCase);
+        var existingSuppliersByAgnumId = existingSuppliers
+            .Where(x => x.AgnumClientId is not null)
+            .ToDictionary(x => x.AgnumClientId!.Value);
+
+        var imported = 0;
+        foreach (var supplierClient in suppliers)
+        {
+            var normalizedCode = NormalizeSupplierCode(supplierClient.Code);
+            if (normalizedCode is null)
+            {
+                continue;
+            }
+
+            var supplierName = string.IsNullOrWhiteSpace(supplierClient.Name)
+                ? normalizedCode
+                : supplierClient.Name.Trim();
+            var contactInfo = BuildSupplierContactInfo(supplierClient);
+
+            var tracked = _dbContext.Suppliers.Local.FirstOrDefault(x =>
+                x.AgnumClientId == supplierClient.Id
+                || string.Equals(x.Code, normalizedCode, StringComparison.OrdinalIgnoreCase));
+            if (tracked is not null)
+            {
+                tracked.AgnumClientId = supplierClient.Id;
+                tracked.Name = supplierName;
+                tracked.ContactInfo = contactInfo;
+                tracked.UpdatedAt = DateTimeOffset.UtcNow;
+                imported++;
+                continue;
+            }
+
+            if ((supplierClient.Id > 0 && existingSuppliersByAgnumId.TryGetValue(supplierClient.Id, out var existing))
+                || existingSuppliersByCode.TryGetValue(normalizedCode, out existing))
+            {
+                existing.AgnumClientId = supplierClient.Id;
+                existing.Code = normalizedCode;
+                existing.Name = supplierName;
+                existing.ContactInfo = contactInfo;
+                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                imported++;
+                continue;
+            }
+
+            var supplier = new Supplier
+            {
+                AgnumClientId = supplierClient.Id,
+                Code = normalizedCode,
+                Name = supplierName,
+                ContactInfo = contactInfo,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+
+            _dbContext.Suppliers.Add(supplier);
+            existingSuppliersByCode[normalizedCode] = supplier;
+            if (supplierClient.Id > 0)
+            {
+                existingSuppliersByAgnumId[supplierClient.Id] = supplier;
+            }
+
+            imported++;
+        }
+
+        _logger.LogInformation("Prepared {SupplierCount} Agnum suppliers for import.", imported);
+    }
+
+    private async Task EnsureCustomersAsync(IReadOnlyList<AgnumClientDto> customers, CancellationToken ct)
+    {
+        if (customers.Count == 0)
+        {
+            return;
+        }
+
+        var normalizedCodes = customers
+            .Select(x => NormalizeCustomerCode(x.Code))
+            .Where(x => x is not null)
+            .Select(x => x!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+        var agnumClientIds = customers
+            .Where(x => x.Id > 0)
+            .Select(x => x.Id)
+            .Distinct()
+            .ToList();
+
+        var normalizedCodeUpperSet = normalizedCodes
+            .Select(x => x.ToUpperInvariant())
+            .ToHashSet(StringComparer.Ordinal);
+
+        var existingCustomers = await _dbContext.Customers
+            .IgnoreQueryFilters()
+            .Where(x => normalizedCodeUpperSet.Contains(x.CustomerCode.ToUpper()) || x.AgnumClientId != null && agnumClientIds.Contains(x.AgnumClientId.Value))
+            .ToListAsync(ct);
+        var existingCustomersByCode = existingCustomers
+            .ToDictionary(x => x.CustomerCode, StringComparer.OrdinalIgnoreCase);
+        var existingCustomersByAgnumId = existingCustomers
+            .Where(x => x.AgnumClientId is not null)
+            .ToDictionary(x => x.AgnumClientId!.Value);
+
+        var imported = 0;
+        foreach (var client in customers)
+        {
+            var normalizedCode = NormalizeCustomerCode(client.Code);
+            if (normalizedCode is null)
+            {
+                continue;
+            }
+
+            var customerName = string.IsNullOrWhiteSpace(client.Name)
+                ? normalizedCode
+                : client.Name.Trim();
+            var customerEmail = client.Email?.Trim() ?? string.Empty;
+            var billingAddress = BuildCustomerAddress(client);
+
+            var tracked = _dbContext.Customers.Local.FirstOrDefault(x =>
+                x.AgnumClientId == client.Id
+                || string.Equals(x.CustomerCode, normalizedCode, StringComparison.OrdinalIgnoreCase));
+            if (tracked is not null)
+            {
+                tracked.AgnumClientId = client.Id;
+                tracked.Name = customerName;
+                tracked.Email = customerEmail;
+                tracked.BillingAddress = billingAddress;
+                tracked.Status = CustomerStatus.Active;
+                tracked.IsDeleted = false;
+                tracked.UpdatedAt = DateTimeOffset.UtcNow;
+                imported++;
+                continue;
+            }
+
+            if ((client.Id > 0 && existingCustomersByAgnumId.TryGetValue(client.Id, out var existing))
+                || existingCustomersByCode.TryGetValue(normalizedCode, out existing))
+            {
+                existing.AgnumClientId = client.Id;
+                existing.CustomerCode = normalizedCode;
+                existing.Name = customerName;
+                existing.Email = customerEmail;
+                existing.BillingAddress = billingAddress;
+                existing.Status = CustomerStatus.Active;
+                existing.IsDeleted = false;
+                existing.UpdatedAt = DateTimeOffset.UtcNow;
+                imported++;
+                continue;
+            }
+
+            var customer = new Customer
+            {
+                AgnumClientId = client.Id,
+                CustomerCode = normalizedCode,
+                Name = customerName,
+                Email = customerEmail,
+                BillingAddress = billingAddress,
+                Status = CustomerStatus.Active,
+                PaymentTerms = PaymentTerms.Net30,
+                CreatedAt = DateTimeOffset.UtcNow,
+                UpdatedAt = DateTimeOffset.UtcNow
+            };
+
+            _dbContext.Customers.Add(customer);
+            existingCustomersByCode[normalizedCode] = customer;
+            if (client.Id > 0)
+            {
+                existingCustomersByAgnumId[client.Id] = customer;
+            }
+
+            imported++;
+        }
+
+        _logger.LogInformation("Prepared {CustomerCount} Agnum customers for import.", imported);
+    }
+
     private async Task EnsureSupplierItemMappingAsync(Item item, Supplier? supplier, AgnumProductDto product, CancellationToken ct)
     {
         if (supplier is null)
@@ -613,6 +822,48 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
         var normalized = NormalizeCategoryCode(value);
         return string.IsNullOrWhiteSpace(normalized) ? null : normalized;
+    }
+
+    private static string? NormalizeCustomerCode(string? value)
+        => NormalizeSupplierCode(value);
+
+    private static bool IsSupplier(AgnumClientDto client)
+    {
+        return client.ClientRoles?.Any(x => string.Equals(x, "SUPPLIER", StringComparison.OrdinalIgnoreCase)) == true
+            || client.PozymNumbers?.Contains(1) == true;
+    }
+
+    private static bool IsBuyer(AgnumClientDto client)
+    {
+        return client.ClientRoles?.Any(x => string.Equals(x, "BUYER", StringComparison.OrdinalIgnoreCase)) == true
+            || client.PozymNumbers?.Contains(2) == true;
+    }
+
+    private static Address BuildCustomerAddress(AgnumClientDto client)
+    {
+        var address = string.IsNullOrWhiteSpace(client.RegisteredAddress)
+            ? client.OfficeAddress
+            : client.RegisteredAddress;
+
+        return new Address
+        {
+            Street = address?.Trim() ?? string.Empty
+        };
+    }
+
+    private static string? BuildSupplierContactInfo(AgnumClientDto supplier)
+    {
+        var parts = new[]
+        {
+            string.IsNullOrWhiteSpace(supplier.CompanyCode) ? null : $"CompanyCode={supplier.CompanyCode.Trim()}",
+            string.IsNullOrWhiteSpace(supplier.VatCode) ? null : $"VatCode={supplier.VatCode.Trim()}",
+            string.IsNullOrWhiteSpace(supplier.Email) ? null : $"Email={supplier.Email.Trim()}",
+            string.IsNullOrWhiteSpace(supplier.RegisteredAddress) ? null : $"RegisteredAddress={supplier.RegisteredAddress.Trim()}",
+            string.IsNullOrWhiteSpace(supplier.OfficeAddress) ? null : $"OfficeAddress={supplier.OfficeAddress.Trim()}"
+        };
+
+        var contactInfo = string.Join("; ", parts.Where(x => x is not null));
+        return string.IsNullOrWhiteSpace(contactInfo) ? null : contactInfo;
     }
 
     private static decimal? NormalizePositiveDecimal(decimal? value)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
@@ -215,7 +215,7 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
             AgnumProductId = product.Id,
             AgnumCode = product.Code,
             AgnumEnabled = product.Enabled,
-            AgnumModifiedAt = product.ModifyDate,
+            AgnumModifiedAt = NormalizeUtcDateTime(product.ModifyDate),
             LastImportedAt = DateTime.UtcNow,
             RawHash = ComputeRawHash(product)
         });
@@ -251,7 +251,7 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
 
         link.AgnumCode = product.Code;
         link.AgnumEnabled = product.Enabled;
-        link.AgnumModifiedAt = product.ModifyDate;
+        link.AgnumModifiedAt = NormalizeUtcDateTime(product.ModifyDate);
         link.LastImportedAt = DateTime.UtcNow;
         link.RawHash = ComputeRawHash(product);
     }
@@ -623,6 +623,21 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
     private static string NormalizeSkuCode(string? value)
     {
         return value?.Trim() ?? string.Empty;
+    }
+
+    private static DateTime? NormalizeUtcDateTime(DateTime? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        return value.Value.Kind switch
+        {
+            DateTimeKind.Utc => value.Value,
+            DateTimeKind.Local => value.Value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value.Value, DateTimeKind.Utc)
+        };
     }
 
     private static List<string> GetProductBarcodes(AgnumProductDto product)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumNomenclatureImportService.cs
@@ -49,6 +49,14 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
         var linkByProductId = existingLinks
             .ToDictionary(x => x.AgnumProductId, x => x);
 
+        var duplicateAgnumCodes = products
+            .Select(x => NormalizeSkuCode(x.Code))
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .GroupBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .Where(x => x.Count() > 1)
+            .Select(x => x.Key)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
         var preview = new AgnumImportPreview
         {
             SndId = sndId,
@@ -64,6 +72,17 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
                     AgnumProductId = product.Id,
                     Code = product.Code,
                     Reason = "MissingUoM"
+                });
+                continue;
+            }
+
+            if (duplicateAgnumCodes.Contains(NormalizeSkuCode(product.Code)))
+            {
+                preview.Conflicts.Add(new AgnumImportConflict
+                {
+                    AgnumProductId = product.Id,
+                    Code = product.Code,
+                    Reason = "DuplicateAgnumCode"
                 });
                 continue;
             }
@@ -599,6 +618,11 @@ public sealed class AgnumNomenclatureImportService : IAgnumNomenclatureImportSer
     private static decimal? NormalizePositiveDecimal(decimal? value)
     {
         return value > 0 ? value : null;
+    }
+
+    private static string NormalizeSkuCode(string? value)
+    {
+        return value?.Trim() ?? string.Empty;
     }
 
     private static List<string> GetProductBarcodes(AgnumProductDto product)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260519163000_AddAgnumClientIdsToPartners.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260519163000_AddAgnumClientIdsToPartners.cs
@@ -1,0 +1,66 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddAgnumClientIdsToPartners : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AgnumClientId",
+                schema: "public",
+                table: "suppliers",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "AgnumClientId",
+                schema: "public",
+                table: "customers",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_suppliers_AgnumClientId",
+                schema: "public",
+                table: "suppliers",
+                column: "AgnumClientId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_customers_AgnumClientId",
+                schema: "public",
+                table: "customers",
+                column: "AgnumClientId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_suppliers_AgnumClientId",
+                schema: "public",
+                table: "suppliers");
+
+            migrationBuilder.DropIndex(
+                name: "IX_customers_AgnumClientId",
+                schema: "public",
+                table: "customers");
+
+            migrationBuilder.DropColumn(
+                name: "AgnumClientId",
+                schema: "public",
+                table: "suppliers");
+
+            migrationBuilder.DropColumn(
+                name: "AgnumClientId",
+                schema: "public",
+                table: "customers");
+        }
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
@@ -804,6 +804,9 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                     b.Property<string>("CreatedBy")
                         .HasColumnType("text");
 
+                    b.Property<int?>("AgnumClientId")
+                        .HasColumnType("integer");
+
                     b.Property<decimal?>("CreditLimit")
                         .HasPrecision(18, 2)
                         .HasColumnType("numeric(18,2)");
@@ -849,6 +852,9 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         .HasColumnType("text");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AgnumClientId")
+                        .IsUnique();
 
                     b.HasIndex("CustomerCode")
                         .IsUnique();
@@ -1595,6 +1601,9 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
 
                     NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
 
+                    b.Property<int?>("AgnumClientId")
+                        .HasColumnType("integer");
+
                     b.Property<string>("Code")
                         .IsRequired()
                         .HasMaxLength(50)
@@ -1609,6 +1618,9 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         .HasColumnType("integer");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("AgnumClientId")
+                        .IsUnique();
 
                     b.HasIndex("Code")
                         .IsUnique();

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
@@ -371,10 +371,12 @@ public class WarehouseDbContext : DbContext
         {
             entity.ToTable("suppliers");
             entity.HasKey(e => e.Id);
+            entity.Property(e => e.AgnumClientId);
             entity.Property(e => e.Code).HasMaxLength(50).IsRequired();
             entity.Property(e => e.Name).HasMaxLength(200).IsRequired();
             entity.Property(e => e.ContactInfo).HasColumnType("text");
             entity.HasIndex(e => e.Code).IsUnique();
+            entity.HasIndex(e => e.AgnumClientId).IsUnique();
         });
 
         modelBuilder.Entity<Customer>(entity =>
@@ -385,6 +387,7 @@ public class WarehouseDbContext : DbContext
                 .HasMaxLength(50)
                 .IsRequired()
                 .HasDefaultValueSql("'CUST-' || LPAD(nextval('customer_code_seq')::text, 4, '0')");
+            entity.Property(e => e.AgnumClientId);
             entity.Property(e => e.Name).HasColumnType("text").HasConversion(PiiEncryption.StringConverter).IsRequired();
             entity.Property(e => e.Email).HasColumnType("text").HasConversion(PiiEncryption.StringConverter).IsRequired();
             entity.Property(e => e.Phone).HasMaxLength(50);
@@ -393,6 +396,7 @@ public class WarehouseDbContext : DbContext
             entity.Property(e => e.CreditLimit).HasPrecision(18, 2);
             entity.Property(e => e.IsDeleted).HasDefaultValue(false);
             entity.HasIndex(e => e.CustomerCode).IsUnique();
+            entity.HasIndex(e => e.AgnumClientId).IsUnique();
             entity.HasIndex(e => e.Name);
             entity.HasIndex(e => e.Status);
             entity.HasQueryFilter(e => !e.IsDeleted);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Integration/Agnum/IAgnumApiClient.cs
@@ -5,6 +5,7 @@ namespace LKvitai.MES.Modules.Warehouse.Integration.Agnum;
 public interface IAgnumApiClient
 {
     Task<IReadOnlyList<AgnumProductDto>> GetProductsAsync(CancellationToken ct = default);
+    Task<IReadOnlyList<AgnumClientDto>> GetClientsAsync(CancellationToken ct = default);
 }
 
 public sealed class AgnumProductDto
@@ -48,4 +49,31 @@ public sealed class AgnumProductDto
 
     [JsonPropertyName("uom_type")]
     public string? UnitOfMeasureType { get; init; }
+}
+
+public sealed class AgnumClientDto
+{
+    public int Id { get; init; }
+    public string Code { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+
+    [JsonPropertyName("company_code")]
+    public string? CompanyCode { get; init; }
+
+    [JsonPropertyName("vat_code")]
+    public string? VatCode { get; init; }
+
+    public string? Email { get; init; }
+
+    [JsonPropertyName("registeredAddress")]
+    public string? RegisteredAddress { get; init; }
+
+    [JsonPropertyName("officeAddress")]
+    public string? OfficeAddress { get; init; }
+
+    [JsonPropertyName("client_role")]
+    public List<string>? ClientRoles { get; init; }
+
+    [JsonPropertyName("pozym_numbers")]
+    public List<int>? PozymNumbers { get; init; }
 }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumApiClientTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumApiClientTests.cs
@@ -56,6 +56,58 @@ public class AgnumApiClientTests
         handler.Requests[1].RequestUri!.PathAndQuery.Should().Be("/api/products/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id");
     }
 
+    [Fact]
+    public async Task GetClientsAsync_ShouldReturnAgnumClients()
+    {
+        var clients = new[]
+        {
+            new AgnumClientDto
+            {
+                Id = 1,
+                Code = "BUYER",
+                Name = "Buyer",
+                PozymNumbers = new List<int> { 2 }
+            },
+            new AgnumClientDto
+            {
+                Id = 2,
+                Code = "SUP-POZYM",
+                Name = "Supplier by marker",
+                PozymNumbers = new List<int> { 1 }
+            },
+            new AgnumClientDto
+            {
+                Id = 3,
+                Code = "SUP-ROLE",
+                Name = "Supplier by role",
+                ClientRoles = new List<string> { "SUPPLIER" }
+            }
+        };
+
+        var responses = new Queue<HttpResponseMessage>(new[]
+        {
+            new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(JsonSerializer.Serialize(clients), Encoding.UTF8, "application/json")
+            }
+        });
+
+        var handler = new SequentialHttpMessageHandler(responses);
+        var httpClient = new HttpClient(handler)
+        {
+            BaseAddress = new System.Uri("https://agnum.example/")
+        };
+
+        using var loggerFactory = LoggerFactory.Create(builder => builder.AddFilter((_, _) => false));
+        var client = new AgnumApiClient(httpClient, new AgnumWarehouseKeyOptions { ApiKey = "secret" }, loggerFactory.CreateLogger<AgnumApiClient>());
+
+        var result = await client.GetClientsAsync(CancellationToken.None);
+
+        result.Select(x => x.Code).Should().Equal("BUYER", "SUP-POZYM", "SUP-ROLE");
+        handler.Requests.Should().ContainSingle();
+        handler.Requests[0].RequestUri!.PathAndQuery.Should().Be("/api/clients/search?code=___NO_SUCH_CODE___&filter_type=ne&order=id");
+    }
+
     private sealed class SequentialHttpMessageHandler : HttpMessageHandler
     {
         private readonly Queue<HttpResponseMessage> _responses;

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
@@ -282,6 +282,9 @@ public class AgnumImportConflictDetectionTests
         clientMock
             .Setup(x => x.GetProductsAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<AgnumProductDto> { product });
+        clientMock
+            .Setup(x => x.GetClientsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<AgnumClientDto>());
 
         var factoryMock = new Mock<IAgnumApiClientFactory>();
         factoryMock.Setup(x => x.GetForSndId(It.IsAny<int>())).Returns(clientMock.Object);
@@ -383,10 +386,79 @@ public class AgnumImportConflictDetectionTests
         link.AgnumModifiedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
     }
 
+    [Fact]
+    public async Task ApplyAsync_WhenAgnumPartnerClientsExist_ShouldImportSupplierAndCustomerCatalogs()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var product = new AgnumProductDto
+        {
+            Id = 14,
+            Code = "SKU-SUPPLIER-CATALOG",
+            Name = "Supplier catalog product",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+        var supplier = new AgnumClientDto
+        {
+            Id = 57,
+            Code = "PL7209-100-63-81",
+            Name = "Samex P.P.H.U.",
+            CompanyCode = "PL7209-100-63-81",
+            VatCode = "PL72091006381",
+            PozymNumbers = new List<int> { 1 }
+        };
+        var customer = new AgnumClientDto
+        {
+            Id = 6,
+            Code = "110305282",
+            Name = "Omnitel AB",
+            Email = "test@example.com",
+            RegisteredAddress = "T.Ševčenkos g.25, Vilnius",
+            PozymNumbers = new List<int> { 2 }
+        };
+        var both = new AgnumClientDto
+        {
+            Id = 99,
+            Code = "BOTH",
+            Name = "Both Roles",
+            ClientRoles = new List<string> { "BUYER", "SUPPLIER" }
+        };
+
+        var service = CreateService(db, new[] { product }, new[] { supplier, customer, both });
+
+        await service.ApplyAsync(493);
+
+        var importedSupplier = await db.Suppliers.SingleAsync(x => x.Code == "PL7209-100-63-81");
+        importedSupplier.AgnumClientId.Should().Be(57);
+        importedSupplier.Code.Should().Be("PL7209-100-63-81");
+        importedSupplier.Name.Should().Be("Samex P.P.H.U.");
+        importedSupplier.ContactInfo.Should().Contain("CompanyCode=PL7209-100-63-81");
+        (await db.Suppliers.CountAsync()).Should().Be(2);
+
+        var importedCustomer = await db.Customers.SingleAsync(x => x.CustomerCode == "110305282");
+        importedCustomer.AgnumClientId.Should().Be(6);
+        importedCustomer.Name.Should().Be("Omnitel AB");
+        importedCustomer.Email.Should().Be("test@example.com");
+        importedCustomer.BillingAddress.Street.Should().Be("T.Ševčenkos g.25, Vilnius");
+        (await db.Customers.CountAsync()).Should().Be(2);
+
+        (await db.SupplierItemMappings.CountAsync()).Should().Be(0);
+    }
+
     private static AgnumNomenclatureImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)
+        => CreateService(db, products, Array.Empty<AgnumClientDto>());
+
+    private static AgnumNomenclatureImportService CreateService(
+        WarehouseDbContext db,
+        IReadOnlyList<AgnumProductDto> products,
+        IReadOnlyList<AgnumClientDto> suppliers)
     {
         var clientMock = new Mock<IAgnumApiClient>();
         clientMock.Setup(x => x.GetProductsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(products.ToList());
+        clientMock.Setup(x => x.GetClientsAsync(It.IsAny<CancellationToken>())).ReturnsAsync(suppliers.ToList());
 
         var factoryMock = new Mock<IAgnumApiClientFactory>();
         factoryMock.Setup(x => x.GetForSndId(It.IsAny<int>())).Returns(clientMock.Object);

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
@@ -323,6 +323,40 @@ public class AgnumImportConflictDetectionTests
         item.Weight.Should().BeNull();
     }
 
+    [Fact]
+    public async Task PreviewAsync_WhenAgnumPayloadContainsDuplicateCodes_ShouldReturnDuplicateAgnumCodeConflicts()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var first = new AgnumProductDto
+        {
+            Id = 11,
+            Code = "SKU-DUP",
+            Name = "Duplicate first",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+        var second = new AgnumProductDto
+        {
+            Id = 12,
+            Code = " sku-dup ",
+            Name = "Duplicate second",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1
+        };
+
+        var service = CreateService(db, first, second);
+
+        var preview = await service.PreviewAsync(493);
+
+        preview.ToCreate.Should().BeEmpty();
+        preview.Conflicts.Should().HaveCount(2);
+        preview.Conflicts.Should().OnlyContain(x => x.Reason == "DuplicateAgnumCode");
+    }
+
     private static AgnumNomenclatureImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)
     {
         var clientMock = new Mock<IAgnumApiClient>();

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumImportConflictDetectionTests.cs
@@ -357,6 +357,32 @@ public class AgnumImportConflictDetectionTests
         preview.Conflicts.Should().OnlyContain(x => x.Reason == "DuplicateAgnumCode");
     }
 
+    [Fact]
+    public async Task ApplyAsync_WhenModifyDateHasUnspecifiedKind_ShouldStoreUtcAgnumModifiedAt()
+    {
+        await using var db = CreateDbContext();
+        await SeedUnitOfMeasuresAsync(db, "vnt");
+
+        var product = new AgnumProductDto
+        {
+            Id = 13,
+            Code = "SKU-DATE",
+            Name = "Date product",
+            Pcs = "vnt",
+            Enabled = true,
+            Balance = 1,
+            ModifyDate = new DateTime(2026, 5, 19, 10, 30, 0, DateTimeKind.Unspecified)
+        };
+
+        var service = CreateService(db, product);
+
+        await service.ApplyAsync(493);
+
+        var link = await db.AgnumProductLinks.SingleAsync(x => x.AgnumProductId == product.Id);
+        link.AgnumModifiedAt.Should().NotBeNull();
+        link.AgnumModifiedAt!.Value.Kind.Should().Be(DateTimeKind.Utc);
+    }
+
     private static AgnumNomenclatureImportService CreateService(WarehouseDbContext db, params AgnumProductDto[] products)
     {
         var clientMock = new Mock<IAgnumApiClient>();


### PR DESCRIPTION
## Summary
- skip duplicate Agnum product codes and normalize non-positive weights / modified dates
- import Agnum partner clients into Warehouse suppliers and customers
- store AgnumClientId on both supplier and customer records for stable matching

## Real test DB result
- suppliers: 159 rows, 159 with AgnumClientId
- customers: 1304 rows, 1304 with AgnumClientId
- supplier item mappings remain empty because Agnum product f2 is supplier SKU, not supplier id

## Tests
- dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/LKvitai.MES.Tests.Warehouse.Unit.csproj --filter "FullyQualifiedName~Agnum" --no-restore -m:1