### PR TITLE
feat(agnum): Slice 2 — distribute Agnum virtual balance to physical MES location

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
@@ -1,7 +1,10 @@
+using LKvitai.MES.BuildingBlocks.SharedKernel;
 using LKvitai.MES.Modules.Warehouse.Api.Security;
+using LKvitai.MES.Modules.Warehouse.Application.Commands;
 using LKvitai.MES.Modules.Warehouse.Application.Ports;
 using LKvitai.MES.Modules.Warehouse.Domain.Entities;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -16,15 +19,21 @@ public sealed class AgnumImportController : ControllerBase
     private readonly WarehouseDbContext _dbContext;
     private readonly IAgnumNomenclatureImportService _nomenclatureImportService;
     private readonly IAgnumBalanceImportService _balanceImportService;
+    private readonly IAgnumDistributionService _distributionService;
+    private readonly IMediator _mediator;
 
     public AgnumImportController(
         WarehouseDbContext dbContext,
         IAgnumNomenclatureImportService nomenclatureImportService,
-        IAgnumBalanceImportService balanceImportService)
+        IAgnumBalanceImportService balanceImportService,
+        IAgnumDistributionService distributionService,
+        IMediator mediator)
     {
         _dbContext = dbContext;
         _nomenclatureImportService = nomenclatureImportService;
         _balanceImportService = balanceImportService;
+        _distributionService = distributionService;
+        _mediator = mediator;
     }
 
     [HttpGet("virtual-warehouses")]
@@ -164,12 +173,21 @@ public sealed class AgnumImportController : ControllerBase
             return Ok(new { SndId = sndId, RunId = (Guid?)null, Balances = Array.Empty<object>() });
         }
 
-        var balances = await _dbContext.AgnumVirtualWarehouseBalances
+        var distributedByBalance = await _dbContext.AgnumBalanceDistributions
+            .AsNoTracking()
+            .Where(d => d.SndId == sndId)
+            .GroupBy(d => d.VirtualBalanceId)
+            .Select(g => new { VirtualBalanceId = g.Key, Total = g.Sum(x => x.Quantity) })
+            .ToListAsync(ct);
+        var distributedLookup = distributedByBalance.ToDictionary(x => x.VirtualBalanceId, x => x.Total);
+
+        var balanceRows = await _dbContext.AgnumVirtualWarehouseBalances
             .AsNoTracking()
             .Where(x => x.ImportRunId == latestRun.Id)
             .OrderByDescending(x => x.Quantity)
             .Select(x => new
             {
+                x.Id,
                 x.AgnumProductId,
                 x.Sku,
                 x.Quantity,
@@ -179,7 +197,70 @@ public sealed class AgnumImportController : ControllerBase
             })
             .ToListAsync(ct);
 
+        var balances = balanceRows
+            .Select(x =>
+            {
+                var distributedQty = distributedLookup.GetValueOrDefault(x.Id);
+                return new AgnumVirtualBalanceRow(
+                    x.Id,
+                    x.AgnumProductId,
+                    x.Sku,
+                    x.Quantity,
+                    distributedQty,
+                    x.Quantity - distributedQty,
+                    x.Uom,
+                    x.ItemId,
+                    x.ImportedAt);
+            })
+            .ToList();
+
         return Ok(new { SndId = sndId, RunId = latestRun.Id, ImportedAt = latestRun.FinishedAt, Balances = balances });
+    }
+
+    [HttpPost("balances/{id:guid}/distribute")]
+    public async Task<IActionResult> DistributeBalanceAsync(
+        Guid id,
+        [FromBody] DistributeAgnumBalanceRequest request,
+        CancellationToken ct = default)
+    {
+        var result = await _mediator.Send(new DistributeAgnumBalanceCommand
+        {
+            CorrelationId = Guid.NewGuid(),
+            CausationId = Guid.NewGuid(),
+            VirtualBalanceId = id,
+            LocationCode = request.LocationCode,
+            WarehouseId = request.WarehouseId,
+            Quantity = request.Quantity,
+            OperatorId = request.OperatorId
+        }, ct);
+
+        if (result.IsSuccess)
+        {
+            return Ok(new { });
+        }
+
+        if (result.ErrorCode == DomainErrorCodes.NotFound)
+        {
+            return NotFound(new { Error = result.ErrorDetail ?? result.Error });
+        }
+
+        return BadRequest(new { Error = result.ErrorDetail ?? result.Error });
+    }
+
+    [HttpGet("balances/{id:guid}/distributions")]
+    public async Task<IActionResult> GetBalanceDistributionsAsync(
+        Guid id,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var summary = await _distributionService.GetVirtualBalanceSummaryAsync(id, ct);
+            return Ok(summary.Distributions);
+        }
+        catch (KeyNotFoundException)
+        {
+            return NotFound();
+        }
     }
 
     private sealed record AgnumWarehouseResponse(
@@ -188,4 +269,21 @@ public sealed class AgnumImportController : ControllerBase
         string MesVirtualWarehouseCode,
         string ApiKeyConfigName,
         bool IsImportEnabled);
+
+    private sealed record AgnumVirtualBalanceRow(
+        Guid Id,
+        int AgnumProductId,
+        string? Sku,
+        decimal Quantity,
+        decimal DistributedQty,
+        decimal RemainingQty,
+        string Uom,
+        int? ItemId,
+        DateTime ImportedAt);
+
+    public sealed record DistributeAgnumBalanceRequest(
+        string LocationCode,
+        string WarehouseId,
+        decimal Quantity,
+        Guid OperatorId);
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/LocationsController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/LocationsController.cs
@@ -34,6 +34,7 @@ public sealed class LocationsController : ControllerBase
         [FromQuery] string? search,
         [FromQuery] string? status,
         [FromQuery] Guid? warehouseId,
+        [FromQuery] string? type,
         [FromQuery] bool includeVirtual = true,
         [FromQuery] int pageNumber = 1,
         [FromQuery] int pageSize = 50,
@@ -68,6 +69,18 @@ public sealed class LocationsController : ControllerBase
         {
             var normalizedStatus = status.Trim();
             query = query.Where(x => x.Status == normalizedStatus);
+        }
+
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            var requestedTypes = type
+                .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .ToArray();
+
+            if (requestedTypes.Length > 0)
+            {
+                query = query.Where(x => requestedTypes.Contains(x.Type));
+            }
         }
 
         var totalCount = await query.CountAsync(cancellationToken);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/DistributeAgnumBalanceCommandHandler.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/DistributeAgnumBalanceCommandHandler.cs
@@ -1,0 +1,114 @@
+using LKvitai.MES.BuildingBlocks.SharedKernel;
+using LKvitai.MES.Modules.Warehouse.Application.Commands;
+using LKvitai.MES.Modules.Warehouse.Domain;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace LKvitai.MES.Modules.Warehouse.Api.Services;
+
+public sealed class DistributeAgnumBalanceCommandHandler
+    : IRequestHandler<DistributeAgnumBalanceCommand, Result>
+{
+    private readonly WarehouseDbContext _dbContext;
+    private readonly IMediator _mediator;
+    private readonly ILogger<DistributeAgnumBalanceCommandHandler> _logger;
+
+    public DistributeAgnumBalanceCommandHandler(
+        WarehouseDbContext dbContext,
+        IMediator mediator,
+        ILogger<DistributeAgnumBalanceCommandHandler> logger)
+    {
+        _dbContext = dbContext;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<Result> Handle(DistributeAgnumBalanceCommand command, CancellationToken ct)
+    {
+        var virtualBalance = await _dbContext.AgnumVirtualWarehouseBalances
+            .FirstOrDefaultAsync(x => x.Id == command.VirtualBalanceId, ct);
+
+        if (virtualBalance is null)
+        {
+            return Result.Fail(DomainErrorCodes.NotFound, $"Agnum virtual balance '{command.VirtualBalanceId}' was not found.");
+        }
+
+        if (string.IsNullOrWhiteSpace(virtualBalance.Sku))
+        {
+            return Result.Fail(DomainErrorCodes.ValidationError, "Agnum product must be linked to a MES item before distribution.");
+        }
+
+        if (string.IsNullOrWhiteSpace(command.LocationCode))
+        {
+            return Result.Fail(DomainErrorCodes.ValidationError, "Location code is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(command.WarehouseId))
+        {
+            return Result.Fail(DomainErrorCodes.ValidationError, "Warehouse id is required.");
+        }
+
+        var alreadyDistributed = await _dbContext.AgnumBalanceDistributions
+            .Where(x => x.VirtualBalanceId == command.VirtualBalanceId)
+            .SumAsync(x => (decimal?)x.Quantity, ct) ?? 0m;
+
+        var remaining = virtualBalance.Quantity - alreadyDistributed;
+        if (command.Quantity <= 0m || command.Quantity > remaining)
+        {
+            return Result.Fail(
+                DomainErrorCodes.ValidationError,
+                $"Quantity must be greater than 0 and no more than remaining quantity {remaining:0.####}.");
+        }
+
+        var stockMovementCommandId = Guid.NewGuid();
+        var stockMovementResult = await _mediator.Send(new RecordStockMovementCommand
+        {
+            CommandId = stockMovementCommandId,
+            CorrelationId = command.CommandId,
+            CausationId = command.CommandId,
+            WarehouseId = command.WarehouseId.Trim(),
+            SKU = virtualBalance.Sku.Trim(),
+            Quantity = command.Quantity,
+            FromLocation = "AGNUM",
+            ToLocation = command.LocationCode.Trim(),
+            MovementType = MovementType.Receipt,
+            OperatorId = command.OperatorId,
+            Reason = $"Agnum distribution sndid={virtualBalance.SndId}"
+        }, ct);
+
+        if (!stockMovementResult.IsSuccess)
+        {
+            return stockMovementResult;
+        }
+
+        _dbContext.AgnumBalanceDistributions.Add(new AgnumBalanceDistribution
+        {
+            Id = Guid.NewGuid(),
+            VirtualBalanceId = virtualBalance.Id,
+            SndId = virtualBalance.SndId,
+            AgnumProductId = virtualBalance.AgnumProductId,
+            Sku = virtualBalance.Sku.Trim(),
+            LocationCode = command.LocationCode.Trim(),
+            WarehouseId = command.WarehouseId.Trim(),
+            Quantity = command.Quantity,
+            StockMovementCommandId = stockMovementCommandId,
+            DistributedAt = DateTime.UtcNow,
+            DistributedBy = command.OperatorId.ToString()
+        });
+
+        await _dbContext.SaveChangesAsync(ct);
+
+        _logger.LogInformation(
+            "Agnum balance {VirtualBalanceId} distributed: {Quantity} {Sku} to {WarehouseId}/{LocationCode}",
+            virtualBalance.Id,
+            command.Quantity,
+            virtualBalance.Sku,
+            command.WarehouseId,
+            command.LocationCode);
+
+        return Result.Ok();
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Commands/DistributeAgnumBalanceCommand.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Commands/DistributeAgnumBalanceCommand.cs
@@ -1,0 +1,15 @@
+using LKvitai.MES.BuildingBlocks.SharedKernel;
+
+namespace LKvitai.MES.Modules.Warehouse.Application.Commands;
+
+public record DistributeAgnumBalanceCommand : ICommand
+{
+    public Guid CommandId { get; init; } = Guid.NewGuid();
+    public Guid CorrelationId { get; init; }
+    public Guid CausationId { get; init; }
+    public Guid VirtualBalanceId { get; init; }
+    public string LocationCode { get; init; } = string.Empty;
+    public string WarehouseId { get; init; } = string.Empty;
+    public decimal Quantity { get; init; }
+    public Guid OperatorId { get; init; }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumDistributionService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Application/Ports/IAgnumDistributionService.cs
@@ -1,0 +1,26 @@
+namespace LKvitai.MES.Modules.Warehouse.Application.Ports;
+
+public interface IAgnumDistributionService
+{
+    Task<DistributionSummary> GetVirtualBalanceSummaryAsync(Guid virtualBalanceId, CancellationToken ct = default);
+}
+
+public record DistributionSummary(
+    Guid VirtualBalanceId,
+    decimal TotalQty,
+    decimal DistributedQty,
+    decimal RemainingQty,
+    IReadOnlyList<AgnumBalanceDistributionDto> Distributions);
+
+public record AgnumBalanceDistributionDto(
+    Guid Id,
+    Guid VirtualBalanceId,
+    int SndId,
+    int AgnumProductId,
+    string Sku,
+    string LocationCode,
+    string WarehouseId,
+    decimal Quantity,
+    Guid StockMovementCommandId,
+    DateTime DistributedAt,
+    string DistributedBy);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/AgnumImportEntities.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/AgnumImportEntities.cs
@@ -68,3 +68,20 @@ public sealed class AgnumVirtualWarehouseBalance
 
     public AgnumBalanceImportRun? ImportRun { get; set; }
 }
+
+public sealed class AgnumBalanceDistribution
+{
+    public Guid Id { get; set; }
+    public Guid VirtualBalanceId { get; set; }
+    public int SndId { get; set; }
+    public int AgnumProductId { get; set; }
+    public string Sku { get; set; } = string.Empty;
+    public string LocationCode { get; set; } = string.Empty;
+    public string WarehouseId { get; set; } = string.Empty;
+    public decimal Quantity { get; set; }
+    public Guid StockMovementCommandId { get; set; }
+    public DateTime DistributedAt { get; set; }
+    public string DistributedBy { get; set; } = string.Empty;
+
+    public AgnumVirtualWarehouseBalance VirtualBalance { get; set; } = null!;
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumDistributionService.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Agnum/AgnumDistributionService.cs
@@ -1,0 +1,53 @@
+using LKvitai.MES.Modules.Warehouse.Application.Ports;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Agnum;
+
+public sealed class AgnumDistributionService : IAgnumDistributionService
+{
+    private readonly WarehouseDbContext _dbContext;
+
+    public AgnumDistributionService(WarehouseDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<DistributionSummary> GetVirtualBalanceSummaryAsync(Guid virtualBalanceId, CancellationToken ct = default)
+    {
+        var balance = await _dbContext.AgnumVirtualWarehouseBalances
+            .AsNoTracking()
+            .FirstOrDefaultAsync(x => x.Id == virtualBalanceId, ct);
+
+        if (balance is null)
+        {
+            throw new KeyNotFoundException($"Agnum virtual balance '{virtualBalanceId}' was not found.");
+        }
+
+        var distributions = await _dbContext.AgnumBalanceDistributions
+            .AsNoTracking()
+            .Where(x => x.VirtualBalanceId == virtualBalanceId)
+            .OrderByDescending(x => x.DistributedAt)
+            .Select(x => new AgnumBalanceDistributionDto(
+                x.Id,
+                x.VirtualBalanceId,
+                x.SndId,
+                x.AgnumProductId,
+                x.Sku,
+                x.LocationCode,
+                x.WarehouseId,
+                x.Quantity,
+                x.StockMovementCommandId,
+                x.DistributedAt,
+                x.DistributedBy))
+            .ToListAsync(ct);
+
+        var distributedQty = distributions.Sum(x => x.Quantity);
+        return new DistributionSummary(
+            balance.Id,
+            balance.Quantity,
+            distributedQty,
+            balance.Quantity - distributedQty,
+            distributions);
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/DependencyInjection.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/DependencyInjection.cs
@@ -69,6 +69,7 @@ public static class DependencyInjection
         services.AddSingleton<IAgnumApiClientFactory, AgnumApiClientFactory>();
         services.AddScoped<IAgnumNomenclatureImportService, AgnumNomenclatureImportService>();
         services.AddScoped<IAgnumBalanceImportService, AgnumBalanceImportService>();
+        services.AddScoped<IAgnumDistributionService, AgnumDistributionService>();
 
         // Consistency checks
         services.AddScoped<IConsistencyCheck, StuckReservationCheck>();

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260520100000_AddAgnumBalanceDistributions.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260520100000_AddAgnumBalanceDistributions.cs
@@ -1,0 +1,76 @@
+using System;
+using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    [DbContext(typeof(WarehouseDbContext))]
+    [Migration("20260520100000_AddAgnumBalanceDistributions")]
+    public partial class AddAgnumBalanceDistributions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "agnum_balance_distributions",
+                schema: "public",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    VirtualBalanceId = table.Column<Guid>(type: "uuid", nullable: false),
+                    SndId = table.Column<int>(type: "integer", nullable: false),
+                    AgnumProductId = table.Column<int>(type: "integer", nullable: false),
+                    Sku = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: false),
+                    LocationCode = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    WarehouseId = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    Quantity = table.Column<decimal>(type: "numeric(18,4)", precision: 18, scale: 4, nullable: false),
+                    StockMovementCommandId = table.Column<Guid>(type: "uuid", nullable: false),
+                    DistributedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    DistributedBy = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_agnum_balance_distributions", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_agnum_balance_distributions_agnum_virtual_warehouse_bala~",
+                        column: x => x.VirtualBalanceId,
+                        principalSchema: "public",
+                        principalTable: "agnum_virtual_warehouse_balances",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_balance_distributions_SndId_AgnumProductId",
+                schema: "public",
+                table: "agnum_balance_distributions",
+                columns: new[] { "SndId", "AgnumProductId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_balance_distributions_StockMovementCommandId",
+                schema: "public",
+                table: "agnum_balance_distributions",
+                column: "StockMovementCommandId",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_agnum_balance_distributions_VirtualBalanceId",
+                schema: "public",
+                table: "agnum_balance_distributions",
+                column: "VirtualBalanceId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "agnum_balance_distributions",
+                schema: "public");
+        }
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/WarehouseDbContextModelSnapshot.cs
@@ -235,6 +235,63 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                     b.ToTable("agnum_balance_import_runs", "public");
                 });
 
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumBalanceDistribution", b =>
+                {
+                    b.Property<Guid>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("uuid");
+
+                    b.Property<int>("AgnumProductId")
+                        .HasColumnType("integer");
+
+                    b.Property<DateTime>("DistributedAt")
+                        .HasColumnType("timestamp with time zone");
+
+                    b.Property<string>("DistributedBy")
+                        .IsRequired()
+                        .HasMaxLength(200)
+                        .HasColumnType("character varying(200)");
+
+                    b.Property<string>("LocationCode")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.Property<decimal>("Quantity")
+                        .HasPrecision(18, 4)
+                        .HasColumnType("numeric(18,4)");
+
+                    b.Property<int>("SndId")
+                        .HasColumnType("integer");
+
+                    b.Property<string>("Sku")
+                        .IsRequired()
+                        .HasMaxLength(100)
+                        .HasColumnType("character varying(100)");
+
+                    b.Property<Guid>("StockMovementCommandId")
+                        .HasColumnType("uuid");
+
+                    b.Property<Guid>("VirtualBalanceId")
+                        .HasColumnType("uuid");
+
+                    b.Property<string>("WarehouseId")
+                        .IsRequired()
+                        .HasMaxLength(50)
+                        .HasColumnType("character varying(50)");
+
+                    b.HasKey("Id");
+
+                    b.HasIndex("SndId", "AgnumProductId");
+
+                    b.HasIndex("StockMovementCommandId")
+                        .IsUnique();
+
+                    b.HasIndex("VirtualBalanceId");
+
+                    b.ToTable("agnum_balance_distributions", "public");
+                });
+
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumExportConfig", b =>
                 {
                     b.Property<Guid>("Id")
@@ -3916,6 +3973,17 @@ namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
                         .IsRequired();
 
                     b.Navigation("Item");
+                });
+
+            modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumBalanceDistribution", b =>
+                {
+                    b.HasOne("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumVirtualWarehouseBalance", "VirtualBalance")
+                        .WithMany()
+                        .HasForeignKey("VirtualBalanceId")
+                        .OnDelete(DeleteBehavior.Restrict)
+                        .IsRequired();
+
+                    b.Navigation("VirtualBalance");
                 });
 
             modelBuilder.Entity("LKvitai.MES.Modules.Warehouse.Domain.Entities.AgnumVirtualWarehouseBalance", b =>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
@@ -65,6 +65,7 @@ public class WarehouseDbContext : DbContext
     public DbSet<ItemExternalAttribute> ItemExternalAttributes => Set<ItemExternalAttribute>();
     public DbSet<AgnumBalanceImportRun> AgnumBalanceImportRuns => Set<AgnumBalanceImportRun>();
     public DbSet<AgnumVirtualWarehouseBalance> AgnumVirtualWarehouseBalances => Set<AgnumVirtualWarehouseBalance>();
+    public DbSet<AgnumBalanceDistribution> AgnumBalanceDistributions => Set<AgnumBalanceDistribution>();
     public DbSet<TransactionExport> TransactionExports => Set<TransactionExport>();
     public DbSet<SupplierItemMapping> SupplierItemMappings => Set<SupplierItemMapping>();
     public DbSet<Location> Locations => Set<Location>();
@@ -365,6 +366,24 @@ public class WarehouseDbContext : DbContext
             entity.HasIndex(e => new { e.SndId, e.AgnumProductId });
             entity.HasOne(e => e.ImportRun).WithMany().HasForeignKey(e => e.ImportRunId).OnDelete(DeleteBehavior.Cascade);
             entity.HasOne<Item>().WithMany().HasForeignKey(e => e.ItemId).OnDelete(DeleteBehavior.Restrict);
+        });
+
+        modelBuilder.Entity<AgnumBalanceDistribution>(entity =>
+        {
+            entity.ToTable("agnum_balance_distributions");
+            entity.HasKey(e => e.Id);
+            entity.Property(e => e.Sku).HasMaxLength(100).IsRequired();
+            entity.Property(e => e.LocationCode).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.WarehouseId).HasMaxLength(50).IsRequired();
+            entity.Property(e => e.Quantity).HasPrecision(18, 4).IsRequired();
+            entity.Property(e => e.DistributedBy).HasMaxLength(200).IsRequired();
+            entity.HasIndex(e => e.VirtualBalanceId);
+            entity.HasIndex(e => e.StockMovementCommandId).IsUnique();
+            entity.HasIndex(e => new { e.SndId, e.AgnumProductId });
+            entity.HasOne(e => e.VirtualBalance)
+                .WithMany()
+                .HasForeignKey(e => e.VirtualBalanceId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<Supplier>(entity =>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AgnumDtos.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AgnumDtos.cs
@@ -115,9 +115,12 @@ public sealed record AgnumVirtualWarehouseDto
 
 public sealed record AgnumBalanceRowDto
 {
+    public Guid Id { get; init; }
     public int AgnumProductId { get; init; }
     public string? Sku { get; init; }
     public decimal Quantity { get; init; }
+    public decimal DistributedQty { get; init; }
+    public decimal RemainingQty { get; init; }
     public string Uom { get; init; } = string.Empty;
     public int? ItemId { get; init; }
     public DateTime ImportedAt { get; init; }
@@ -129,4 +132,25 @@ public sealed record AgnumBalancesResponseDto
     public Guid? RunId { get; init; }
     public DateTime? ImportedAt { get; init; }
     public IReadOnlyList<AgnumBalanceRowDto> Balances { get; init; } = Array.Empty<AgnumBalanceRowDto>();
+}
+
+public sealed record DistributeAgnumBalanceRequestDto(
+    string LocationCode,
+    string WarehouseId,
+    decimal Quantity,
+    Guid OperatorId);
+
+public sealed record AgnumBalanceDistributionDto
+{
+    public Guid Id { get; init; }
+    public Guid VirtualBalanceId { get; init; }
+    public int SndId { get; init; }
+    public int AgnumProductId { get; init; }
+    public string Sku { get; init; } = string.Empty;
+    public string LocationCode { get; init; } = string.Empty;
+    public string WarehouseId { get; init; } = string.Empty;
+    public decimal Quantity { get; init; }
+    public Guid StockMovementCommandId { get; init; }
+    public DateTime DistributedAt { get; init; }
+    public string DistributedBy { get; init; } = string.Empty;
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Balances.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Balances.razor
@@ -2,6 +2,7 @@
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @inject AgnumClient AgnumClient
+@inject MasterDataAdminClient MasterDataAdminClient
 
 <PageTitle>Agnum Balances</PageTitle>
 
@@ -43,6 +44,8 @@
         <div class="d-flex flex-wrap gap-3 text-muted small mt-3">
             <span>Rows: @FilteredRows.Count</span>
             <span>Total qty: @FilteredRows.Sum(x => x.Quantity).ToString("0.###")</span>
+            <span>Distributed: @FilteredRows.Sum(x => x.DistributedQty).ToString("0.###")</span>
+            <span>Remaining: @FilteredRows.Sum(x => x.RemainingQty).ToString("0.###")</span>
             @if (_balances?.ImportedAt is not null)
             {
                 <span>Imported: @_balances.ImportedAt.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
@@ -61,15 +64,18 @@
                     <th>Agnum Product</th>
                     <th>MES Item</th>
                     <th class="text-end">Quantity</th>
+                    <th class="text-end">Distributed</th>
+                    <th class="text-end">Remaining</th>
                     <th>UoM</th>
                     <th>Imported</th>
+                    <th></th>
                 </tr>
                 </thead>
                 <tbody>
                 @if (FilteredRows.Count == 0)
                 {
                     <tr>
-                        <td colspan="6" class="text-muted py-3">No Agnum balances found.</td>
+                        <td colspan="9" class="text-muted py-3">No Agnum balances found.</td>
                     </tr>
                 }
                 else
@@ -81,14 +87,84 @@
                             <td class="font-monospace">@row.AgnumProductId</td>
                             <td>@(row.ItemId?.ToString() ?? "-")</td>
                             <td class="text-end">@row.Quantity.ToString("0.###")</td>
+                            <td class="text-end">@row.DistributedQty.ToString("0.###")</td>
+                            <td class="text-end">@row.RemainingQty.ToString("0.###")</td>
                             <td>@row.Uom</td>
                             <td>@row.ImportedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</td>
+                            <td class="text-end">
+                                <button class="btn btn-sm btn-outline-primary"
+                                        type="button"
+                                        disabled="@string.IsNullOrWhiteSpace(row.Sku)"
+                                        @onclick="() => BeginDistributionAsync(row)">
+                                    Distribute
+                                </button>
+                            </td>
                         </tr>
                     }
                 }
                 </tbody>
             </table>
         </div>
+
+        @if (_distributionRow is not null)
+        {
+            <div class="border rounded p-3 mt-3 bg-light">
+                <div class="d-flex justify-content-between align-items-start gap-3">
+                    <div>
+                        <div class="fw-semibold">Distribute @(_distributionRow.Sku ?? "-")</div>
+                        <div class="text-muted small">
+                            Remaining @_distributionRow.RemainingQty.ToString("0.###") @_distributionRow.Uom from Agnum product @_distributionRow.AgnumProductId
+                        </div>
+                    </div>
+                    <button class="btn-close" type="button" aria-label="Close" @onclick="CancelDistribution"></button>
+                </div>
+
+                <div class="row g-3 align-items-end mt-1">
+                    <div class="col-12 col-md-4">
+                        <label class="form-label">Warehouse</label>
+                        <select class="form-select" @bind="_distributionWarehouseGuid" @bind:after="LoadDistributionLocationsAsync">
+                            <option value="">Select warehouse</option>
+                            @foreach (var warehouse in _physicalWarehouses)
+                            {
+                                <option value="@warehouse.Id">@warehouse.Code - @warehouse.Name</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-4">
+                        <label class="form-label">Location</label>
+                        <select class="form-select" @bind="_distributionLocationCode" disabled="@(_isLoadingLocations || _distributionLocations.Count == 0)">
+                            <option value="">Select location</option>
+                            @foreach (var location in _distributionLocations)
+                            {
+                                <option value="@location.Code">@location.Code (@location.Type)</option>
+                            }
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-2">
+                        <label class="form-label">Quantity</label>
+                        <input class="form-control"
+                               type="number"
+                               min="0.0001"
+                               max="@_distributionRow.RemainingQty"
+                               step="0.0001"
+                               @bind="_distributionQuantity" />
+                    </div>
+                    <div class="col-12 col-md-2 d-flex gap-2">
+                        <button class="btn btn-primary"
+                                type="button"
+                                disabled="@(!CanSubmitDistribution)"
+                                @onclick="SubmitDistributionAsync">
+                            Submit
+                        </button>
+                    </div>
+                </div>
+
+                @if (!string.IsNullOrWhiteSpace(_distributionMessage))
+                {
+                    <div class="text-muted small mt-2">@_distributionMessage</div>
+                }
+            </div>
+        }
 
         @if (FilteredRows.Count > 500)
         {
@@ -102,8 +178,25 @@
     private AgnumBalancesResponseDto? _balances;
     private ApiException? _apiError;
     private bool _isLoading;
+    private bool _isSubmittingDistribution;
+    private bool _isLoadingLocations;
     private int _selectedSndId;
     private string? _search;
+    private readonly List<AdminWarehouseDto> _physicalWarehouses = [];
+    private readonly List<AdminLocationDto> _distributionLocations = [];
+    private AgnumBalanceRowDto? _distributionRow;
+    private string _distributionWarehouseGuid = string.Empty;
+    private string _distributionLocationCode = string.Empty;
+    private decimal _distributionQuantity;
+    private string? _distributionMessage;
+
+    private bool CanSubmitDistribution =>
+        !_isSubmittingDistribution
+        && _distributionRow is not null
+        && Guid.TryParse(_distributionWarehouseGuid, out _)
+        && !string.IsNullOrWhiteSpace(_distributionLocationCode)
+        && _distributionQuantity > 0m
+        && _distributionQuantity <= _distributionRow.RemainingQty;
 
     private List<AgnumBalanceRowDto> FilteredRows
     {
@@ -138,6 +231,9 @@
         {
             _warehouses.Clear();
             _warehouses.AddRange(await AgnumClient.GetVirtualWarehousesAsync());
+            _physicalWarehouses.Clear();
+            var warehouses = await MasterDataAdminClient.GetWarehousesAsync(null, "Active", false, 1, 200);
+            _physicalWarehouses.AddRange(warehouses.Items);
             if (_selectedSndId <= 0)
             {
                 _selectedSndId = _warehouses.FirstOrDefault(x => x.IsImportEnabled)?.SndId
@@ -171,6 +267,8 @@
         try
         {
             _balances = await AgnumClient.GetBalancesAsync(_selectedSndId);
+            _distributionRow = null;
+            _distributionLocations.Clear();
         }
         catch (ApiException ex)
         {
@@ -185,6 +283,106 @@
     private void DismissError()
     {
         _apiError = null;
+    }
+
+    private async Task BeginDistributionAsync(AgnumBalanceRowDto row)
+    {
+        _distributionRow = row;
+        _distributionMessage = null;
+        _distributionQuantity = row.RemainingQty > 0m ? row.RemainingQty : 0m;
+        _distributionLocationCode = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(_distributionWarehouseGuid) && _physicalWarehouses.Count > 0)
+        {
+            _distributionWarehouseGuid = _physicalWarehouses[0].Id.ToString();
+        }
+
+        await LoadDistributionLocationsAsync();
+    }
+
+    private async Task LoadDistributionLocationsAsync()
+    {
+        _distributionLocations.Clear();
+        _distributionLocationCode = string.Empty;
+
+        if (!Guid.TryParse(_distributionWarehouseGuid, out var warehouseId))
+        {
+            return;
+        }
+
+        _isLoadingLocations = true;
+        _apiError = null;
+
+        try
+        {
+            var locations = await MasterDataAdminClient.GetLocationsAsync(
+                null,
+                "Active",
+                false,
+                1,
+                500,
+                warehouseId,
+                "Bin,Shelf");
+
+            _distributionLocations.AddRange(locations.Items);
+            _distributionLocationCode = _distributionLocations.FirstOrDefault()?.Code ?? string.Empty;
+        }
+        catch (ApiException ex)
+        {
+            _apiError = ex;
+        }
+        finally
+        {
+            _isLoadingLocations = false;
+        }
+    }
+
+    private async Task SubmitDistributionAsync()
+    {
+        if (_distributionRow is null || !Guid.TryParse(_distributionWarehouseGuid, out var warehouseGuid))
+        {
+            return;
+        }
+
+        var warehouse = _physicalWarehouses.FirstOrDefault(x => x.Id == warehouseGuid);
+        if (warehouse is null)
+        {
+            _distributionMessage = "Select a warehouse.";
+            return;
+        }
+
+        _isSubmittingDistribution = true;
+        _apiError = null;
+        _distributionMessage = null;
+
+        try
+        {
+            await AgnumClient.DistributeAsync(
+                _distributionRow.Id,
+                _distributionLocationCode,
+                warehouse.Code,
+                _distributionQuantity,
+                Guid.Empty);
+
+            await LoadBalancesAsync();
+        }
+        catch (ApiException ex)
+        {
+            _apiError = ex;
+        }
+        finally
+        {
+            _isSubmittingDistribution = false;
+        }
+    }
+
+    private void CancelDistribution()
+    {
+        _distributionRow = null;
+        _distributionMessage = null;
+        _distributionLocations.Clear();
+        _distributionLocationCode = string.Empty;
+        _distributionQuantity = 0m;
     }
 
     private static string BuildErrorMessage(ApiException ex)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/AgnumClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/AgnumClient.cs
@@ -92,6 +92,27 @@ public sealed class AgnumClient
     public Task<AgnumBalancesResponseDto> GetBalancesAsync(int sndId, CancellationToken cancellationToken = default)
         => GetAsync<AgnumBalancesResponseDto>($"/api/warehouse/v1/agnum/balances?sndId={sndId}", cancellationToken);
 
+    public async Task DistributeAsync(
+        Guid virtualBalanceId,
+        string locationCode,
+        string warehouseId,
+        decimal quantity,
+        Guid operatorId,
+        CancellationToken cancellationToken = default)
+    {
+        await PostAsync<object>(
+            $"/api/warehouse/v1/agnum/balances/{virtualBalanceId}/distribute",
+            new DistributeAgnumBalanceRequestDto(locationCode, warehouseId, quantity, operatorId),
+            cancellationToken);
+    }
+
+    public Task<List<AgnumBalanceDistributionDto>> GetDistributionsAsync(
+        Guid virtualBalanceId,
+        CancellationToken cancellationToken = default)
+        => GetAsync<List<AgnumBalanceDistributionDto>>(
+            $"/api/warehouse/v1/agnum/balances/{virtualBalanceId}/distributions",
+            cancellationToken);
+
     private Task<T> GetAsync<T>(string relativeUrl, CancellationToken cancellationToken)
         => SendAndReadAsync<T>(() =>
         {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/MasterDataAdminClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/MasterDataAdminClient.cs
@@ -215,6 +215,8 @@ public sealed class MasterDataAdminClient
         bool includeVirtual,
         int pageNumber,
         int pageSize,
+        Guid? warehouseId = null,
+        string? type = null,
         CancellationToken cancellationToken = default)
     {
         var query = new List<string>
@@ -232,6 +234,16 @@ public sealed class MasterDataAdminClient
         if (!string.IsNullOrWhiteSpace(status))
         {
             query.Add($"status={Uri.EscapeDataString(status)}");
+        }
+
+        if (warehouseId.HasValue)
+        {
+            query.Add($"warehouseId={warehouseId.Value}");
+        }
+
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            query.Add($"type={Uri.EscapeDataString(type)}");
         }
 
         return GetAsync<PagedApiResponse<AdminLocationDto>>(


### PR DESCRIPTION
## Summary

- **New table** `agnum_balance_distributions` tracks each distribution event with FK to virtual balance and idempotency key (`StockMovementCommandId` unique index)
- **`DistributeAgnumBalanceCommand`** + handler: validates remaining qty, sends `RecordStockMovementCommand` (RECEIPT, FromLocation=AGNUM), then writes distribution record
- **API**: `POST /agnum/balances/{id}/distribute`, `GET /agnum/balances/{id}/distributions`, extended balance list with `DistributedQty`/`RemainingQty`
- **WebUI**: `Balances.razor` gets Distribute button per row with inline warehouse/location picker and quantity input
- **Migration** `20260520100000_AddAgnumBalanceDistributions` — follows correct pattern (`[DbContext]` attr, no `InsertData`, snapshot updated)

## Architecture note

Handler lives in `Api/Services/` (consistent with existing ARCH-02 tech debt — 34 files already there). Moving to a proper port in Application layer requires abstracting EF Core access and is tracked in the backlog.

## Test plan

- [ ] Deploy to test, confirm migration creates `agnum_balance_distributions` table
- [ ] Open `/agnum/balances`, select warehouse with imported data
- [ ] Click Distribute on a linked row (has SKU), pick physical warehouse + location + qty
- [ ] Confirm `DistributedQty` updates and `RemainingQty` decreases
- [ ] Confirm `LocationBalance` read model shows stock at the physical location after distribution

Made with [Cursor](https://cursor.com)