### PR TITLE
feat(agnum): Slice 2 — distribute Agnum virtual balance to physical MES location

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/MartenStockLedgerRepository.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/MartenStockLedgerRepository.cs
@@ -48,7 +48,19 @@ public class MartenStockLedgerRepository : IStockLedgerRepository
 
         try
         {
-            session.Events.Append(streamId, expectedVersion, evt);
+            if (expectedVersion == -2)
+            {
+                // New stream (no prior events): skip version check — the stream does not yet exist
+                // so there is nothing to conflict with. Two concurrent inbound receipts to the
+                // same brand-new (warehouse, location, sku) are extremely rare; the retry loop
+                // handles the resulting ConcurrencyException if they do race.
+                session.Events.Append(streamId, evt);
+            }
+            else
+            {
+                session.Events.Append(streamId, expectedVersion, evt);
+            }
+
             await session.SaveChangesAsync(ct);
         }
         catch (Marten.Exceptions.EventStreamUnexpectedMaxEventIdException ex)


### PR DESCRIPTION
## Summary

- **New table** `agnum_balance_distributions` tracks each distribution event with FK to virtual balance and idempotency guard (`StockMovementCommandId` unique index)
- **`DistributeAgnumBalanceCommand`** + handler: validates remaining qty, sends `RecordStockMovementCommand` (RECEIPT, FromLocation=AGNUM), then writes distribution record
- **API**: `POST /agnum/balances/{id}/distribute`, `GET /agnum/balances/{id}/distributions`, extended balance list with `DistributedQty`/`RemainingQty`
- **WebUI**: `Balances.razor` gets Distribute button per row with inline warehouse/location picker and quantity input
- **Migration** `20260520100000_AddAgnumBalanceDistributions` — `[DbContext]` attr, no `InsertData`, snapshot updated
- **Bug fix**: `MartenStockLedgerRepository` — RECEIPT to a brand-new location (stream doesn't exist yet) was failing with `ConcurrencyException` because Marten's version check `expectedStartingVersion = expectedVersion - events.Count = -2 - 1 = -3 ≠ 0`. Fixed by skipping version guard for new streams (`expectedVersion == -2`)

## Architecture note

Handler lives in `Api/Services/` (consistent with existing ARCH-02 tech debt). Moving to a proper Application layer port requires abstracting EF Core access — tracked in backlog.

## Test plan

- [ ] Deploy to test, confirm migration creates `agnum_balance_distributions` table
- [ ] Open `/agnum/balances`, confirm Distributed/Remaining columns visible
- [ ] Click Distribute on a row with SKU, pick warehouse + location + qty, Submit
- [ ] Confirm `DistributedQty` updates and `RemainingQty` decreases
- [ ] Confirm `LocationBalance` read model shows stock at the physical location

Made with [Cursor](https://cursor.com)