### PR TITLE
fix(stock): warehouse filter uses Code not GUID, All shows cross-warehouse stock

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
@@ -79,11 +79,7 @@ public sealed class StockController : ControllerBase
             .Query<AvailableStockView>()
             .Where(x => x.OnHandQty != 0m);
 
-        if (string.IsNullOrWhiteSpace(warehouse))
-        {
-            query = query.Where(x => x.WarehouseId == DefaultWarehouseId);
-        }
-        else
+        if (!string.IsNullOrWhiteSpace(warehouse))
         {
             var normalizedWarehouse = warehouse.Trim();
             query = query.Where(x => x.WarehouseId == normalizedWarehouse);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
@@ -8,7 +8,7 @@
                         <option value="">All</option>
                         @foreach (var warehouse in Warehouses)
                         {
-                            <option value="@warehouse.Id">@warehouse.Code - @warehouse.Name</option>
+                            <option value="@warehouse.Code">@warehouse.Code - @warehouse.Name</option>
                         }
                     </select>
                 </div>


### PR DESCRIPTION
## Problem

Two bugs causing distributed Agnum stock to be invisible in Available Stock:

1. **`StockFilters.razor`** — warehouse dropdown was using `warehouse.Id` (GUID) as the option value, but `AvailableStockView.WarehouseId` stores the warehouse **Code** string (e.g. `"1"`, `"WH1"`). The filter never matched.

2. **`StockController`** — when no warehouse was selected ("All"), the controller defaulted to `DefaultWarehouseId = "WH1"`, hiding stock in all other warehouses.

## Fix

- `StockFilters.razor`: use `warehouse.Code` as the option value
- `StockController`: remove the WH1 default — empty warehouse = return all warehouses

## Root Cause

Discovered while debugging why distributed Agnum stock (SKU 1422073200, qty 27, location R3-C6-L1-B1, warehouseId "1") was not visible in Available Stock after successful distribution via Slice 2 UI.

Also fixed directly in DB: projection shadow data was correct but main table had stale data from a failed rebuild — patched `mt_doc_available_stock_view` directly via SQL.

Made with [Cursor](https://cursor.com)