### PR TITLE
[codex] Complete Agnum phase 5 discrepancy view

### DIFF
--- a/docs/agnum-integration-plan/MVP-SCOPE.md
+++ b/docs/agnum-integration-plan/MVP-SCOPE.md
@@ -25,8 +25,8 @@ The first deliverable is read-only visibility and a distribution bridge:
 | 1 | Agnum read connector (`IAgnumApiClient`, `AgnumApiClient`, DTOs) | **Done** — PR #159, shipping on main |
 | 2 | Product/nomenclature import (`AgnumProductLink`, `ItemExternalAttribute`, conflict detection, apply, supplier sync, UoM auto-create, category hierarchy) | **Done** — PR #159 + fixes #162–169 |
 | 3 | Virtual balance import (`AgnumVirtualWarehouseBalance`, `AgnumBalanceImportRun`), Hangfire daily job, `Balances.razor` read-only UI | **Done** — PR #160 + #161 + #169 |
-| 4 | Distribution from virtual balance to physical MES location | **SLICE 2** — next |
-| 5 | Product search + 2D/3D location visibility after distribution | **SLICE 3** — after Slice 2 |
+| 4 | Distribution from virtual balance to physical MES location | **Done** — PR #171 + #172 + #174 |
+| 5 | Product search + 2D/3D location visibility after distribution | **Done** — PR #174 + Phase 5 UI |
 | 6 | Real warehouse operations | **NOT NEEDED** — packages A–F already implement all MES warehouse operations; no changes required |
 | 7 | Agnum document export | **BACKLOG** — governed by ADR-006; do not start until phases 1–5 are stable |
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
@@ -1,5 +1,7 @@
+using LKvitai.MES.Contracts.ReadModels;
 using LKvitai.MES.BuildingBlocks.SharedKernel;
 using LKvitai.MES.Modules.Warehouse.Api.Security;
+using LKvitai.MES.Modules.Warehouse.Api.Services;
 using LKvitai.MES.Modules.Warehouse.Application.Commands;
 using LKvitai.MES.Modules.Warehouse.Application.Ports;
 using LKvitai.MES.Modules.Warehouse.Domain.Entities;
@@ -20,6 +22,7 @@ public sealed class AgnumImportController : ControllerBase
     private readonly IAgnumNomenclatureImportService _nomenclatureImportService;
     private readonly IAgnumBalanceImportService _balanceImportService;
     private readonly IAgnumDistributionService _distributionService;
+    private readonly Marten.IDocumentStore _documentStore;
     private readonly IMediator _mediator;
 
     public AgnumImportController(
@@ -27,12 +30,14 @@ public sealed class AgnumImportController : ControllerBase
         IAgnumNomenclatureImportService nomenclatureImportService,
         IAgnumBalanceImportService balanceImportService,
         IAgnumDistributionService distributionService,
+        Marten.IDocumentStore documentStore,
         IMediator mediator)
     {
         _dbContext = dbContext;
         _nomenclatureImportService = nomenclatureImportService;
         _balanceImportService = balanceImportService;
         _distributionService = distributionService;
+        _documentStore = documentStore;
         _mediator = mediator;
     }
 
@@ -197,17 +202,62 @@ public sealed class AgnumImportController : ControllerBase
             })
             .ToListAsync(ct);
 
+        var skus = balanceRows
+            .Select(x => x.Sku)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var physicalStockBySku = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        var physicalLocationsBySku = new Dictionary<string, List<AgnumPhysicalLocationDto>>(StringComparer.OrdinalIgnoreCase);
+        if (skus.Count > 0)
+        {
+            await using var querySession = _documentStore.QuerySession();
+            var physicalStockRows = await Marten.QueryableExtensions.ToListAsync(
+                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU)),
+                ct);
+
+            physicalStockBySku = physicalStockRows
+                .GroupBy(x => x.SKU, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x.Key, x => x.Sum(y => y.OnHandQty), StringComparer.OrdinalIgnoreCase);
+
+            physicalLocationsBySku = physicalStockRows
+                .GroupBy(x => x.SKU, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(
+                    x => x.Key,
+                    x => x
+                        .GroupBy(y => new { y.WarehouseId, LocationCode = y.LocationCode ?? y.Location })
+                        .Select(g => new AgnumPhysicalLocationDto(
+                            g.Key.WarehouseId,
+                            g.Key.LocationCode,
+                            g.Sum(y => y.OnHandQty)))
+                        .Where(location => location.Qty > 0m)
+                        .OrderBy(location => location.LocationCode)
+                        .ToList(),
+                    StringComparer.OrdinalIgnoreCase);
+        }
+
         var balances = balanceRows
             .Select(x =>
             {
                 var distributedQty = distributedLookup.GetValueOrDefault(x.Id);
-                return new AgnumVirtualBalanceRow(
+                var mesPhysicalQty = string.IsNullOrWhiteSpace(x.Sku)
+                    ? 0m
+                    : physicalStockBySku.GetValueOrDefault(x.Sku);
+                var mesLocations = string.IsNullOrWhiteSpace(x.Sku)
+                    ? new List<AgnumPhysicalLocationDto>()
+                    : physicalLocationsBySku.GetValueOrDefault(x.Sku, new List<AgnumPhysicalLocationDto>());
+
+                return new AgnumVirtualWarehouseBalanceDto(
                     x.Id,
                     x.AgnumProductId,
                     x.Sku,
                     x.Quantity,
                     distributedQty,
                     x.Quantity - distributedQty,
+                    mesPhysicalQty,
+                    mesLocations,
                     x.Uom,
                     x.ItemId,
                     x.ImportedAt);
@@ -215,6 +265,120 @@ public sealed class AgnumImportController : ControllerBase
             .ToList();
 
         return Ok(new { SndId = sndId, RunId = latestRun.Id, ImportedAt = latestRun.FinishedAt, Balances = balances });
+    }
+
+    [HttpGet("reconciliation")]
+    public async Task<IActionResult> GetReconciliationAsync(
+        [FromQuery] int sndId,
+        CancellationToken ct = default)
+    {
+        if (sndId <= 0)
+        {
+            return BadRequest(new { Error = "sndId is required." });
+        }
+
+        var latestRun = await _dbContext.AgnumBalanceImportRuns
+            .AsNoTracking()
+            .Where(x => x.SndId == sndId && x.Status == "Completed")
+            .OrderByDescending(x => x.FinishedAt)
+            .FirstOrDefaultAsync(ct);
+
+        if (latestRun is null)
+        {
+            return Ok(Array.Empty<AgnumReconciliationRowDto>());
+        }
+
+        var balanceRows = await _dbContext.AgnumVirtualWarehouseBalances
+            .AsNoTracking()
+            .Where(x => x.ImportRunId == latestRun.Id)
+            .OrderBy(x => x.Sku ?? string.Empty)
+            .Select(x => new
+            {
+                x.Id,
+                x.AgnumProductId,
+                x.ItemId,
+                x.Sku,
+                x.Quantity
+            })
+            .ToListAsync(ct);
+
+        var balanceIds = balanceRows.Select(x => x.Id).ToList();
+        var distributedByBalance = await _dbContext.AgnumBalanceDistributions
+            .AsNoTracking()
+            .Where(d => balanceIds.Contains(d.VirtualBalanceId))
+            .GroupBy(d => d.VirtualBalanceId)
+            .Select(g => new { VirtualBalanceId = g.Key, Total = g.Sum(x => x.Quantity) })
+            .ToListAsync(ct);
+        var distributedLookup = distributedByBalance.ToDictionary(x => x.VirtualBalanceId, x => x.Total);
+
+        var itemIds = balanceRows
+            .Select(x => x.ItemId)
+            .Where(x => x.HasValue)
+            .Select(x => x!.Value)
+            .Distinct()
+            .ToList();
+
+        var itemNameById = itemIds.Count == 0
+            ? new Dictionary<int, string>()
+            : await _dbContext.Items
+                .AsNoTracking()
+                .Where(x => itemIds.Contains(x.Id))
+                .ToDictionaryAsync(x => x.Id, x => x.Name, ct);
+
+        var agnumProductIds = balanceRows
+            .Select(x => x.AgnumProductId)
+            .Distinct()
+            .ToList();
+        var agnumCodeByProductId = await _dbContext.AgnumProductLinks
+            .AsNoTracking()
+            .Where(x => x.SndId == sndId && agnumProductIds.Contains(x.AgnumProductId))
+            .ToDictionaryAsync(x => x.AgnumProductId, x => x.AgnumCode, ct);
+
+        var skus = balanceRows
+            .Select(x => x.Sku)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Select(x => x!)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+
+        var physicalBySku = new Dictionary<string, decimal>(StringComparer.OrdinalIgnoreCase);
+        if (skus.Count > 0)
+        {
+            await using var querySession = _documentStore.QuerySession();
+            var physicalStockRows = await Marten.QueryableExtensions.ToListAsync(
+                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU)),
+                ct);
+
+            physicalBySku = physicalStockRows
+                .GroupBy(x => x.SKU, StringComparer.OrdinalIgnoreCase)
+                .ToDictionary(x => x.Key, x => x.Sum(y => y.OnHandQty), StringComparer.OrdinalIgnoreCase);
+        }
+
+        var rows = balanceRows
+            .Select(x =>
+            {
+                var distributedQty = distributedLookup.GetValueOrDefault(x.Id);
+                var remainingQty = x.Quantity - distributedQty;
+                var mesPhysicalQty = string.IsNullOrWhiteSpace(x.Sku)
+                    ? 0m
+                    : physicalBySku.GetValueOrDefault(x.Sku);
+                var delta = mesPhysicalQty - distributedQty;
+                var status = AgnumReconciliationStatusCalculator.GetStatus(x.Sku, delta);
+
+                return new AgnumReconciliationRowDto(
+                    agnumCodeByProductId.GetValueOrDefault(x.AgnumProductId, x.AgnumProductId.ToString()),
+                    x.Sku,
+                    x.ItemId.HasValue && itemNameById.TryGetValue(x.ItemId.Value, out var itemName) ? itemName : null,
+                    x.Quantity,
+                    distributedQty,
+                    remainingQty,
+                    mesPhysicalQty,
+                    delta,
+                    status);
+            })
+            .ToList();
+
+        return Ok(rows);
     }
 
     [HttpPost("balances/{id:guid}/distribute")]
@@ -270,16 +434,31 @@ public sealed class AgnumImportController : ControllerBase
         string ApiKeyConfigName,
         bool IsImportEnabled);
 
-    private sealed record AgnumVirtualBalanceRow(
+    public sealed record AgnumVirtualWarehouseBalanceDto(
         Guid Id,
         int AgnumProductId,
         string? Sku,
         decimal Quantity,
         decimal DistributedQty,
         decimal RemainingQty,
+        decimal MesPhysicalQty,
+        List<AgnumPhysicalLocationDto> MesLocations,
         string Uom,
         int? ItemId,
         DateTime ImportedAt);
+
+    public sealed record AgnumPhysicalLocationDto(string WarehouseId, string LocationCode, decimal Qty);
+
+    public sealed record AgnumReconciliationRowDto(
+        string AgnumCode,
+        string? Sku,
+        string? ItemName,
+        decimal VirtualQty,
+        decimal DistributedQty,
+        decimal RemainingQty,
+        decimal MesPhysicalQty,
+        decimal Delta,
+        string Status);
 
     public sealed record DistributeAgnumBalanceRequest(
         string LocationCode,

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
@@ -379,6 +379,7 @@ public sealed class WarehouseVisualizationController : ControllerBase
             _dbContext.Warehouses.AsNoTracking(),
             x => x.Code == layout.WarehouseCode,
             cancellationToken);
+        var warehouseKeys = BuildWarehouseKeys(layout.WarehouseCode, warehouseEntity);
 
         List<Location> locations;
         if (warehouseEntity is not null)
@@ -445,12 +446,12 @@ public sealed class WarehouseVisualizationController : ControllerBase
         var locationCodes = resolvedLocations.Select(x => x.Code).ToArray();
         var locationSet = new HashSet<string>(locationCodes, StringComparer.OrdinalIgnoreCase);
         var stockRows = stockCandidates
-            .Where(x => x.WarehouseId == layout.WarehouseCode &&
-                        locationSet.Contains(x.Location))
+            .Where(x => warehouseKeys.Contains(x.WarehouseId) &&
+                        locationSet.Contains(GetStockLocationCode(x)))
             .ToList();
 
         var qtyByLocation = stockRows
-            .GroupBy(x => x.Location, StringComparer.OrdinalIgnoreCase)
+            .GroupBy(GetStockLocationCode, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 x => x.Key,
                 x => x.Sum(y => y.OnHandQty),
@@ -458,7 +459,7 @@ public sealed class WarehouseVisualizationController : ControllerBase
 
         var hardLockRows = await _hardLocksRepository.GetAllActiveLocksAsync(cancellationToken);
         var hardLockByLocation = hardLockRows
-            .Where(x => x.WarehouseId == layout.WarehouseCode)
+            .Where(x => warehouseKeys.Contains(x.WarehouseId))
             .GroupBy(x => x.Location, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 x => x.Key,
@@ -467,12 +468,13 @@ public sealed class WarehouseVisualizationController : ControllerBase
 
         var handlingUnitViews = await MartenAsync.ToListAsync(
             session.Query<HandlingUnitView>()
-                .Where(x => x.WarehouseId == layout.WarehouseCode)
+                .Where(x => locationCodes.Contains(x.CurrentLocation))
                 .OrderBy(x => x.LPN),
             cancellationToken);
 
         var husByLocation = handlingUnitViews
-            .Where(x => !x.IsEmpty)
+            .Where(x => !x.IsEmpty &&
+                        (warehouseKeys.Contains(x.WarehouseId) || locationSet.Contains(x.CurrentLocation)))
             .GroupBy(x => x.CurrentLocation, StringComparer.OrdinalIgnoreCase)
             .ToDictionary(
                 x => x.Key,
@@ -513,8 +515,29 @@ public sealed class WarehouseVisualizationController : ControllerBase
             var utilization = ComputeUtilization(location, onHandQty);
             var utilizationPercent = decimal.Round(utilization * 100m, 2, MidpointRounding.AwayFromZero);
             var handlingUnitsForLocation = husByLocation.GetValueOrDefault(location.Code, new List<HandlingUnitView>());
-            var status = ResolveCapacityStatus(handlingUnitsForLocation.Count, utilization);
+            var status = ResolveCapacityStatus(utilization);
             var color = ResolveStatusColor(status);
+            var handlingUnitResponses = handlingUnitsForLocation.Select(x =>
+            {
+                var firstLine = x.Lines.FirstOrDefault();
+                return new VisualizationHandlingUnitResponse(
+                    x.HuId,
+                    x.LPN,
+                    firstLine?.SKU ?? string.Empty,
+                    firstLine?.Quantity ?? 0m);
+            }).ToList();
+
+            if (handlingUnitResponses.Count == 0 && onHandQty > 0m)
+            {
+                handlingUnitResponses.AddRange(stockRows
+                    .Where(x => string.Equals(GetStockLocationCode(x), location.Code, StringComparison.OrdinalIgnoreCase))
+                    .GroupBy(x => x.SKU, StringComparer.OrdinalIgnoreCase)
+                    .Select(x => new VisualizationHandlingUnitResponse(
+                        Guid.Empty,
+                        "Physical stock",
+                        x.Key,
+                        x.Sum(y => y.OnHandQty))));
+            }
 
             return new VisualizationBinResponse(
                 location.Id,
@@ -540,15 +563,7 @@ public sealed class WarehouseVisualizationController : ControllerBase
                 node.StartSlot,
                 node.Span,
                 node.LocationRole,
-                handlingUnitsForLocation.Select(x =>
-                {
-                    var firstLine = x.Lines.FirstOrDefault();
-                    return new VisualizationHandlingUnitResponse(
-                        x.HuId,
-                        x.LPN,
-                        firstLine?.SKU ?? string.Empty,
-                        firstLine?.Quantity ?? 0m);
-                }).ToList());
+                handlingUnitResponses);
         }).ToList();
 
         ApiDurationMs.Record(Stopwatch.GetElapsedTime(startedAt).TotalMilliseconds);
@@ -692,11 +707,9 @@ public sealed class WarehouseVisualizationController : ControllerBase
         return onHandQty > 0m ? 0.6m : 0m;
     }
 
-    private static string ResolveCapacityStatus(
-        int huCount,
-        decimal utilization)
+    private static string ResolveCapacityStatus(decimal utilization)
     {
-        if (huCount == 0)
+        if (utilization <= 0m)
         {
             return EmptyStatus;
         }
@@ -718,6 +731,28 @@ public sealed class WarehouseVisualizationController : ControllerBase
 
         return LowStatus;
     }
+
+    private static HashSet<string> BuildWarehouseKeys(
+        string layoutWarehouseCode,
+        Domain.Aggregates.WarehouseLayout? warehouseEntity)
+    {
+        var keys = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        if (!string.IsNullOrWhiteSpace(layoutWarehouseCode))
+        {
+            keys.Add(layoutWarehouseCode.Trim());
+        }
+
+        if (warehouseEntity is not null)
+        {
+            keys.Add(warehouseEntity.Code);
+            keys.Add(warehouseEntity.WarehouseId.ToString());
+        }
+
+        return keys;
+    }
+
+    private static string GetStockLocationCode(AvailableStockView stock)
+        => string.IsNullOrWhiteSpace(stock.LocationCode) ? stock.Location : stock.LocationCode;
 
     private static string ResolveStatusColor(string status)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/AgnumReconciliationStatusCalculator.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Services/AgnumReconciliationStatusCalculator.cs
@@ -1,0 +1,21 @@
+namespace LKvitai.MES.Modules.Warehouse.Api.Services;
+
+public static class AgnumReconciliationStatusCalculator
+{
+    private const decimal DeltaTolerance = 0.0001m;
+
+    public static string GetStatus(string? sku, decimal delta)
+    {
+        if (string.IsNullOrWhiteSpace(sku))
+        {
+            return "NotLinked";
+        }
+
+        if (Math.Abs(delta) <= DeltaTolerance)
+        {
+            return "Matched";
+        }
+
+        return delta > 0m ? "Over" : "Under";
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AgnumDtos.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AgnumDtos.cs
@@ -121,9 +121,18 @@ public sealed record AgnumBalanceRowDto
     public decimal Quantity { get; init; }
     public decimal DistributedQty { get; init; }
     public decimal RemainingQty { get; init; }
+    public decimal MesPhysicalQty { get; init; }
+    public IReadOnlyList<AgnumPhysicalLocationDto> MesLocations { get; init; } = Array.Empty<AgnumPhysicalLocationDto>();
     public string Uom { get; init; } = string.Empty;
     public int? ItemId { get; init; }
     public DateTime ImportedAt { get; init; }
+}
+
+public sealed record AgnumPhysicalLocationDto
+{
+    public string WarehouseId { get; init; } = string.Empty;
+    public string LocationCode { get; init; } = string.Empty;
+    public decimal Qty { get; init; }
 }
 
 public sealed record AgnumBalancesResponseDto
@@ -132,6 +141,19 @@ public sealed record AgnumBalancesResponseDto
     public Guid? RunId { get; init; }
     public DateTime? ImportedAt { get; init; }
     public IReadOnlyList<AgnumBalanceRowDto> Balances { get; init; } = Array.Empty<AgnumBalanceRowDto>();
+}
+
+public sealed record AgnumReconciliationRowDto
+{
+    public string AgnumCode { get; init; } = string.Empty;
+    public string? Sku { get; init; }
+    public string? ItemName { get; init; }
+    public decimal VirtualQty { get; init; }
+    public decimal DistributedQty { get; init; }
+    public decimal RemainingQty { get; init; }
+    public decimal MesPhysicalQty { get; init; }
+    public decimal Delta { get; init; }
+    public string Status { get; init; } = string.Empty;
 }
 
 public sealed record DistributeAgnumBalanceRequestDto(

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Balances.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Balances.razor
@@ -46,6 +46,7 @@
             <span>Total qty: @FilteredRows.Sum(x => x.Quantity).ToString("0.###")</span>
             <span>Distributed: @FilteredRows.Sum(x => x.DistributedQty).ToString("0.###")</span>
             <span>Remaining: @FilteredRows.Sum(x => x.RemainingQty).ToString("0.###")</span>
+            <span>MES physical: @FilteredRows.Sum(x => x.MesPhysicalQty).ToString("0.###")</span>
             @if (_balances?.ImportedAt is not null)
             {
                 <span>Imported: @_balances.ImportedAt.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
@@ -66,6 +67,9 @@
                     <th class="text-end">Quantity</th>
                     <th class="text-end">Distributed</th>
                     <th class="text-end">Remaining</th>
+                    <th class="text-end">MES Physical</th>
+                    <th class="text-end">Delta</th>
+                    <th>Locations</th>
                     <th>UoM</th>
                     <th>Imported</th>
                     <th></th>
@@ -75,7 +79,7 @@
                 @if (FilteredRows.Count == 0)
                 {
                     <tr>
-                        <td colspan="9" class="text-muted py-3">No Agnum balances found.</td>
+                        <td colspan="12" class="text-muted py-3">No Agnum balances found.</td>
                     </tr>
                 }
                 else
@@ -89,6 +93,32 @@
                             <td class="text-end">@row.Quantity.ToString("0.###")</td>
                             <td class="text-end">@row.DistributedQty.ToString("0.###")</td>
                             <td class="text-end">@row.RemainingQty.ToString("0.###")</td>
+                            <td class="text-end">@row.MesPhysicalQty.ToString("0.###")</td>
+                            <td class="text-end">
+                                <span class="@GetDeltaChipClass(row.MesPhysicalQty - row.DistributedQty)">
+                                    @((row.MesPhysicalQty - row.DistributedQty).ToString("0.###"))
+                                </span>
+                            </td>
+                            <td>
+                                @if (row.MesLocations.Count == 0)
+                                {
+                                    <span class="text-muted">-</span>
+                                }
+                                else
+                                {
+                                    @foreach (var location in row.MesLocations.Take(2))
+                                    {
+                                        <a class="font-monospace me-2"
+                                           href="@BuildLocationHref(row, location)">
+                                            @location.LocationCode (@location.Qty.ToString("0.###"))
+                                        </a>
+                                    }
+                                    @if (row.MesLocations.Count > 2)
+                                    {
+                                        <span class="chip chip--slate">+@(row.MesLocations.Count - 2) more</span>
+                                    }
+                                }
+                            </td>
                             <td>@row.Uom</td>
                             <td>@row.ImportedAt.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</td>
                             <td class="text-end">
@@ -390,4 +420,33 @@
            ?? ex.ProblemDetails?.Detail
            ?? ex.ProblemDetails?.Title
            ?? "Agnum balances request failed.";
+
+    private static string GetDeltaChipClass(decimal delta)
+    {
+        if (delta > 0m)
+        {
+            return "chip chip--ok";
+        }
+
+        if (delta < 0m)
+        {
+            return "chip chip--danger";
+        }
+
+        return "chip chip--slate";
+    }
+
+    private static string BuildLocationHref(AgnumBalanceRowDto row, AgnumPhysicalLocationDto location)
+    {
+        var query = new Dictionary<string, string?>
+        {
+            ["selected"] = location.LocationCode,
+            ["location"] = location.LocationCode,
+            ["sku"] = row.Sku
+        };
+
+        return Microsoft.AspNetCore.WebUtilities.QueryHelpers.AddQueryString(
+            "/warehouse/visualization/3d",
+            query);
+    }
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Reconciliation.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Agnum/Reconciliation.razor
@@ -1,170 +1,187 @@
 @page "/agnum/reconcile"
-@using System.Globalization
-@using System.Text
 @using LKvitai.MES.Modules.Warehouse.WebUI.Infrastructure
 @using LKvitai.MES.Modules.Warehouse.WebUI.Models
 @inject AgnumClient AgnumClient
-@inject IJSRuntime JS
-@inject ToastService ToastService
 
 <PageTitle>Agnum Reconciliation</PageTitle>
 
-<h1>Agnum Reconciliation Report</h1>
+<h1>Agnum Reconciliation</h1>
+
+@if (_apiError is not null)
+{
+    <ErrorBanner Message="@BuildErrorMessage(_apiError)"
+                 TraceId="@_apiError.TraceId"
+                 OnRetry="LoadReconciliationAsync"
+                 OnDismiss="DismissError" />
+}
 
 <div class="card shadow-sm position-relative">
+    <LoadingSpinner IsLoading="_isLoading" />
+
     <div class="card-body">
         <div class="row g-3 align-items-end">
-            <div class="col-12 col-md-3">
-                <label class="form-label">Date</label>
-                <InputDate class="form-control" @bind-Value="_reportDate" />
-            </div>
-            <div class="col-12 col-md-5">
-                <label class="form-label">Agnum Balance CSV</label>
-                <InputFile OnChange="HandleFileChange" accept=".csv,text/csv" />
-            </div>
-            <div class="col-12 col-md-4 d-flex gap-2">
-                <button class="btn btn-primary" @onclick="GenerateAsync" disabled="@(_isLoading || _selectedFile is null)">
-                    Generate Report
-                </button>
-                <button class="btn btn-outline-secondary" @onclick="ApplyFiltersAsync" disabled="@(_isLoading || _report is null)">
-                    Apply Filters
-                </button>
-                <button class="btn btn-outline-success ms-auto" @onclick="ExportCsvAsync" disabled="@(_report is null || _report.Lines.Count == 0)">
-                    Export CSV
-                </button>
-            </div>
-        </div>
-
-        <div class="row g-3 mt-1">
             <div class="col-12 col-md-4">
-                <label class="form-label">Account Code</label>
-                <InputText class="form-control" @bind-Value="_accountCodeFilter" />
+                <label class="form-label">Virtual warehouse</label>
+                <select class="form-select" @bind="_selectedSndId" @bind:after="LoadReconciliationAsync">
+                    @foreach (var warehouse in _warehouses)
+                    {
+                        <option value="@warehouse.SndId">
+                            @warehouse.AgnumName (@warehouse.SndId) - @warehouse.MesVirtualWarehouseCode
+                        </option>
+                    }
+                </select>
             </div>
             <div class="col-12 col-md-4">
-                <label class="form-label">Variance Threshold Amount ($)</label>
-                <InputNumber class="form-control" @bind-Value="_varianceThresholdAmount" />
+                <label class="form-label">Search</label>
+                <input class="form-control" @bind="_search" @bind:event="oninput" placeholder="SKU or product name" />
             </div>
-            <div class="col-12 col-md-4">
-                <label class="form-label">Variance Threshold Percent (%)</label>
-                <InputNumber class="form-control" @bind-Value="_varianceThresholdPercent" />
+            <div class="col-12 col-md-2">
+                <div class="form-check">
+                    <input id="only-discrepancies"
+                           class="form-check-input"
+                           type="checkbox"
+                           @bind="_onlyDiscrepancies" />
+                    <label class="form-check-label" for="only-discrepancies">Only show discrepancies</label>
+                </div>
+            </div>
+            <div class="col-12 col-md-2 d-flex gap-2">
+                <button class="btn btn-outline-secondary" type="button" @onclick="LoadAsync" disabled="@_isLoading">Refresh</button>
             </div>
         </div>
 
-        @if (_apiError is not null)
-        {
-            <div class="alert alert-danger mt-3">@BuildErrorMessage(_apiError!)</div>
-        }
-    </div>
-</div>
+        <div class="d-flex flex-wrap gap-3 text-muted small mt-3">
+            <span>Rows: @FilteredRows.Count</span>
+            <span>Virtual: @FilteredRows.Sum(x => x.VirtualQty).ToString("0.###")</span>
+            <span>Distributed: @FilteredRows.Sum(x => x.DistributedQty).ToString("0.###")</span>
+            <span>MES physical: @FilteredRows.Sum(x => x.MesPhysicalQty).ToString("0.###")</span>
+            <span>Delta: @FilteredRows.Sum(x => x.Delta).ToString("0.###")</span>
+        </div>
 
-@if (_isLoading)
-{
-    <div class="mt-3">
-        <LoadingSpinner IsLoading="true" />
-    </div>
-}
-else if (_report is null)
-{
-    <div class="alert alert-light border mt-3">
-        No reconciliation report generated. Upload Agnum balance and click Generate.
-    </div>
-}
-else
-{
-    <div class="row g-3 mt-1">
-        <div class="col-12 col-md-4">
-            <div class="card border-0 bg-light">
-                <div class="card-body">
-                    <h6 class="text-muted mb-1">Total Variance</h6>
-                    <div class="fs-4 fw-semibold">@_report.Summary.TotalVariance.ToString("0.00", CultureInfo.InvariantCulture)</div>
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-4">
-            <div class="card border-0 bg-light">
-                <div class="card-body">
-                    <h6 class="text-muted mb-1">Items With Variance</h6>
-                    <div class="fs-4 fw-semibold">@_report.Summary.ItemsWithVariance</div>
-                </div>
-            </div>
-        </div>
-        <div class="col-12 col-md-4">
-            <div class="card border-0 bg-light">
-                <div class="card-body">
-                    <h6 class="text-muted mb-1">Largest Variance</h6>
-                    <div class="fw-semibold">
-                        @(_report.Summary.LargestVarianceSku ?? "-")
-                        (@_report.Summary.LargestVarianceAmount.ToString("0.00", CultureInfo.InvariantCulture))
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-
-    @if (_report.Lines.Count == 0)
-    {
-        <div class="alert alert-info mt-3">No rows match current filters.</div>
-    }
-    else
-    {
         <div class="table-responsive mt-3">
-            <table class="table table-sm table-striped align-middle">
+            <table class="table table-sm align-middle">
                 <thead>
                 <tr>
-                    <th>Account</th>
-                    <th>SKU</th>
+                    <th>Agnum Code</th>
+                    <th>SKU (MES)</th>
                     <th>Item Name</th>
-                    <th class="text-end">Warehouse Qty</th>
-                    <th class="text-end">Warehouse Cost</th>
-                    <th class="text-end">Warehouse Value</th>
-                    <th class="text-end">Agnum Balance</th>
-                    <th class="text-end">Variance</th>
-                    <th class="text-end">Variance %</th>
+                    <th class="text-end">Virtual Balance (Agnum)</th>
+                    <th class="text-end">Distributed to MES</th>
+                    <th class="text-end">Remaining</th>
+                    <th class="text-end">MES Physical (actual)</th>
+                    <th class="text-end">Delta</th>
+                    <th>Status</th>
                 </tr>
                 </thead>
                 <tbody>
-                @foreach (var row in _report.Lines)
+                @if (FilteredRows.Count == 0)
                 {
                     <tr>
-                        <td>@row.AccountCode</td>
-                        <td>@row.Sku</td>
-                        <td>@row.ItemName</td>
-                        <td class="text-end">@row.WarehouseQty.ToString("0.###", CultureInfo.InvariantCulture)</td>
-                        <td class="text-end">@row.WarehouseCost.ToString("0.####", CultureInfo.InvariantCulture)</td>
-                        <td class="text-end">@row.WarehouseValue.ToString("0.00", CultureInfo.InvariantCulture)</td>
-                        <td class="text-end">@row.AgnumBalance.ToString("0.00", CultureInfo.InvariantCulture)</td>
-                        <td class="@GetVarianceClass(row.Variance)">@row.Variance.ToString("0.00", CultureInfo.InvariantCulture)</td>
-                        <td class="text-end">@row.VariancePercent.ToString("0.00", CultureInfo.InvariantCulture)</td>
+                        <td colspan="9" class="text-muted py-3">No reconciliation rows found.</td>
                     </tr>
+                }
+                else
+                {
+                    @foreach (var row in FilteredRows.Take(500))
+                    {
+                        <tr>
+                            <td class="font-monospace">@row.AgnumCode</td>
+                            <td class="font-monospace">@(row.Sku ?? "-")</td>
+                            <td>@(row.ItemName ?? "-")</td>
+                            <td class="text-end">@row.VirtualQty.ToString("0.###")</td>
+                            <td class="text-end">@row.DistributedQty.ToString("0.###")</td>
+                            <td class="text-end">@row.RemainingQty.ToString("0.###")</td>
+                            <td class="text-end">@row.MesPhysicalQty.ToString("0.###")</td>
+                            <td class="text-end">
+                                <span class="@GetDeltaChipClass(row.Delta)">@row.Delta.ToString("0.###")</span>
+                            </td>
+                            <td><span class="@GetStatusChipClass(row.Status)">@FormatStatus(row.Status)</span></td>
+                        </tr>
+                    }
                 }
                 </tbody>
             </table>
         </div>
-    }
-}
+
+        @if (FilteredRows.Count > 500)
+        {
+            <div class="text-muted small">Showing first 500 rows. Use search to narrow the list.</div>
+        }
+    </div>
+</div>
 
 @code {
-    private const long MaxCsvBytes = 10 * 1024 * 1024;
+    private const decimal DeltaTolerance = 0.0001m;
 
-    private DateOnly _reportDate = DateOnly.FromDateTime(DateTime.UtcNow.AddDays(-1));
-    private IBrowserFile? _selectedFile;
-    private AgnumReconciliationReportDto? _report;
+    private readonly List<AgnumVirtualWarehouseDto> _warehouses = [];
+    private IReadOnlyList<AgnumReconciliationRowDto> _rows = Array.Empty<AgnumReconciliationRowDto>();
     private ApiException? _apiError;
     private bool _isLoading;
-    private string? _accountCodeFilter;
-    private decimal? _varianceThresholdAmount;
-    private decimal? _varianceThresholdPercent;
+    private bool _onlyDiscrepancies = true;
+    private int _selectedSndId;
+    private string? _search;
 
-    private void HandleFileChange(InputFileChangeEventArgs args)
+    private List<AgnumReconciliationRowDto> FilteredRows
     {
-        _selectedFile = args.File;
+        get
+        {
+            IEnumerable<AgnumReconciliationRowDto> query = _rows;
+
+            if (_onlyDiscrepancies)
+            {
+                query = query.Where(x => Math.Abs(x.Delta) > DeltaTolerance || x.Status == "NotLinked");
+            }
+
+            if (!string.IsNullOrWhiteSpace(_search))
+            {
+                var term = _search.Trim();
+                query = query.Where(x =>
+                    (x.Sku?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || (x.ItemName?.Contains(term, StringComparison.OrdinalIgnoreCase) ?? false)
+                    || x.AgnumCode.Contains(term, StringComparison.OrdinalIgnoreCase));
+            }
+
+            return query.ToList();
+        }
     }
 
-    private async Task GenerateAsync()
+    protected override async Task OnInitializedAsync()
     {
-        if (_selectedFile is null)
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        _isLoading = true;
+        _apiError = null;
+
+        try
         {
-            ToastService.ShowError("Agnum balance CSV file is required.");
+            _warehouses.Clear();
+            _warehouses.AddRange(await AgnumClient.GetVirtualWarehousesAsync());
+            if (_selectedSndId <= 0)
+            {
+                _selectedSndId = _warehouses.FirstOrDefault(x => x.IsImportEnabled)?.SndId
+                    ?? _warehouses.FirstOrDefault()?.SndId
+                    ?? 0;
+            }
+
+            await LoadReconciliationAsync();
+        }
+        catch (ApiException ex)
+        {
+            _apiError = ex;
+        }
+        finally
+        {
+            _isLoading = false;
+        }
+    }
+
+    private async Task LoadReconciliationAsync()
+    {
+        if (_selectedSndId <= 0)
+        {
+            _rows = Array.Empty<AgnumReconciliationRowDto>();
             return;
         }
 
@@ -173,25 +190,11 @@ else
 
         try
         {
-            await using var stream = _selectedFile.OpenReadStream(MaxCsvBytes);
-            _report = await AgnumClient.GenerateReconciliationAsync(
-                _reportDate,
-                _selectedFile.Name,
-                stream,
-                _accountCodeFilter,
-                _varianceThresholdAmount,
-                _varianceThresholdPercent);
-
-            ToastService.ShowSuccess($"Reconciliation report generated: {_report.Lines.Count} rows.");
+            _rows = await AgnumClient.GetReconciliationDataAsync(_selectedSndId);
         }
         catch (ApiException ex)
         {
             _apiError = ex;
-            ToastService.ShowError(BuildErrorMessage(ex));
-        }
-        catch (Exception ex)
-        {
-            ToastService.ShowError(ex.Message);
         }
         finally
         {
@@ -199,88 +202,42 @@ else
         }
     }
 
-    private async Task ApplyFiltersAsync()
+    private void DismissError()
     {
-        if (_report is null)
-        {
-            return;
-        }
-
-        _isLoading = true;
         _apiError = null;
-
-        try
-        {
-            _report = await AgnumClient.GetReconciliationReportAsync(
-                _report.ReportId,
-                _accountCodeFilter,
-                _varianceThresholdAmount,
-                _varianceThresholdPercent);
-
-            ToastService.ShowSuccess("Reconciliation filters applied.");
-        }
-        catch (ApiException ex)
-        {
-            _apiError = ex;
-            ToastService.ShowError(BuildErrorMessage(ex));
-        }
-        finally
-        {
-            _isLoading = false;
-        }
     }
 
-    private async Task ExportCsvAsync()
+    private static string GetDeltaChipClass(decimal delta)
     {
-        if (_report is null || _report.Lines.Count == 0)
+        if (delta > DeltaTolerance)
         {
-            return;
+            return "chip chip--ok";
         }
 
-        var builder = new StringBuilder();
-        builder.AppendLine("AccountCode,SKU,ItemName,WarehouseQty,WarehouseCost,WarehouseValue,AgnumBalance,Variance,VariancePercent");
-        foreach (var row in _report.Lines)
+        if (delta < -DeltaTolerance)
         {
-            builder.AppendLine(string.Join(",",
-                Csv(row.AccountCode),
-                Csv(row.Sku),
-                Csv(row.ItemName),
-                Csv(row.WarehouseQty.ToString("0.###", CultureInfo.InvariantCulture)),
-                Csv(row.WarehouseCost.ToString("0.####", CultureInfo.InvariantCulture)),
-                Csv(row.WarehouseValue.ToString("0.00", CultureInfo.InvariantCulture)),
-                Csv(row.AgnumBalance.ToString("0.00", CultureInfo.InvariantCulture)),
-                Csv(row.Variance.ToString("0.00", CultureInfo.InvariantCulture)),
-                Csv(row.VariancePercent.ToString("0.00", CultureInfo.InvariantCulture))));
+            return "chip chip--danger";
         }
 
-        await JS.InvokeVoidAsync(
-            "csvExport.download",
-            $"agnum-reconciliation-{_reportDate:yyyyMMdd}.csv",
-            builder.ToString());
+        return "chip chip--slate";
     }
 
-    private static string Csv(string? value)
-    {
-        var normalized = value ?? string.Empty;
-        if (!normalized.Contains(',') && !normalized.Contains('"') && !normalized.Contains('\n'))
+    private static string GetStatusChipClass(string status)
+        => status switch
         {
-            return normalized;
-        }
+            "Matched" => "chip chip--ok",
+            "Over" => "chip chip--info",
+            "Under" => "chip chip--danger",
+            "NotLinked" => "chip chip--slate",
+            _ => "chip chip--slate"
+        };
 
-        return string.Concat("\"", normalized.Replace("\"", "\"\"", StringComparison.Ordinal), "\"");
-    }
-
-    private static string GetVarianceClass(decimal variance)
-    {
-        return variance >= 0m
-            ? "text-end text-success"
-            : "text-end text-danger";
-    }
+    private static string FormatStatus(string status)
+        => status == "NotLinked" ? "Not linked" : status;
 
     private static string BuildErrorMessage(ApiException ex)
-    {
-        return ex.ProblemDetails?.Detail
-               ?? ex.ProblemDetails?.Title
-               ?? ex.Message;
-    }
+        => ex.UserMessage
+           ?? ex.ProblemDetails?.Detail
+           ?? ex.ProblemDetails?.Title
+           ?? "Agnum reconciliation request failed.";
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Visualization/Warehouse3D.razor
@@ -393,7 +393,7 @@
                                 <dt class="col-5">Type</dt>
                                 <dd class="col-7">@_selectedRack.Type</dd>
                                 <dt class="col-5">Origin</dt>
-                                <dd class="col-7">@_selectedRack.Origin.X, @_selectedRack.Origin.Y, @_selectedRack.Origin.Z</dd>
+                                <dd class="col-7">@FormatCoordinates(_selectedRack.Origin)</dd>
                                 <dt class="col-5">Dimensions</dt>
                                 <dd class="col-7">@FormatRackDimensions(_selectedRack.Dimensions)</dd>
                                 <dt class="col-5">Levels</dt>
@@ -445,7 +445,7 @@
                                 }
                             }
                             <dt class="col-5">Coordinates</dt>
-                            <dd class="col-7">@_selectedSlot.Origin.X, @_selectedSlot.Origin.Y, @_selectedSlot.Origin.Z</dd>
+                            <dd class="col-7">@FormatCoordinates(_selectedSlot.Origin)</dd>
                             <dt class="col-5">Dimensions</dt>
                             <dd class="col-7">@FormatRackDimensions(_selectedSlot.Dimensions)</dd>
                         </dl>
@@ -474,7 +474,7 @@
                         <dt class="col-5">Utilization</dt>
                         <dd class="col-7">@_selectedBin.UtilizationPercent.ToString("0.##", CultureInfo.InvariantCulture)%</dd>
                         <dt class="col-5">Coordinates</dt>
-                        <dd class="col-7">@_selectedBin.Coordinates.X, @_selectedBin.Coordinates.Y, @_selectedBin.Coordinates.Z</dd>
+                        <dd class="col-7">@FormatCoordinates(_selectedBin.Coordinates)</dd>
                         @if (!string.IsNullOrWhiteSpace(_selectedBin.Address))
                         {
                             <dt class="col-5">Address</dt>
@@ -1109,7 +1109,9 @@
     {
         var uri = NavigationManager.ToAbsoluteUri(NavigationManager.Uri);
         var query = QueryHelpers.ParseQuery(uri.Query);
-        if (!query.TryGetValue("selected", out var selected))
+
+        if (!query.TryGetValue("selected", out var selected) &&
+            !query.TryGetValue("location", out selected))
         {
             return null;
         }
@@ -1124,6 +1126,11 @@
         var volume = capacity.Volume.HasValue ? $"{capacity.Volume.Value} m3" : "n/a";
         return $"{weight} / {volume}";
     }
+
+    private static string FormatCoordinates(VisualizationCoordinateDto coordinates)
+        => string.Create(
+            CultureInfo.InvariantCulture,
+            $"{coordinates.X:0.0}, {coordinates.Y:0.0}, {coordinates.Z:0.0}");
 
     private static string FormatDimensions(VisualizationBinDimensionsDto dimensions)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/AgnumClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/AgnumClient.cs
@@ -92,6 +92,13 @@ public sealed class AgnumClient
     public Task<AgnumBalancesResponseDto> GetBalancesAsync(int sndId, CancellationToken cancellationToken = default)
         => GetAsync<AgnumBalancesResponseDto>($"/api/warehouse/v1/agnum/balances?sndId={sndId}", cancellationToken);
 
+    public Task<IReadOnlyList<AgnumReconciliationRowDto>> GetReconciliationDataAsync(
+        int sndId,
+        CancellationToken cancellationToken = default)
+        => GetAsync<IReadOnlyList<AgnumReconciliationRowDto>>(
+            $"/api/warehouse/v1/agnum/reconciliation?sndId={sndId}",
+            cancellationToken);
+
     public async Task DistributeAsync(
         Guid virtualBalanceId,
         string locationCode,

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumReconciliationTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AgnumReconciliationTests.cs
@@ -1,0 +1,47 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Api.Services;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AgnumReconciliationTests
+{
+    [Fact]
+    [Trait("Category", "AgnumReconciliation")]
+    public void Reconciliation_Delta_IsPositive_WhenMesStockExceedsDistributed()
+    {
+        var delta = 12m - 10m;
+        var status = AgnumReconciliationStatusCalculator.GetStatus("SKU-001", delta);
+
+        delta.Should().BePositive();
+        status.Should().Be("Over");
+    }
+
+    [Fact]
+    [Trait("Category", "AgnumReconciliation")]
+    public void Reconciliation_Status_IsNotLinked_WhenSkuIsNull()
+    {
+        var status = AgnumReconciliationStatusCalculator.GetStatus(null, 0m);
+
+        status.Should().Be("NotLinked");
+    }
+
+    [Fact]
+    [Trait("Category", "AgnumReconciliation")]
+    public void Reconciliation_Status_IsMatched_WhenDeltaIsZero()
+    {
+        var status = AgnumReconciliationStatusCalculator.GetStatus("SKU-001", 0m);
+
+        status.Should().Be("Matched");
+    }
+
+    [Fact]
+    [Trait("Category", "AgnumReconciliation")]
+    public void Reconciliation_Status_IsUnder_WhenMesStockLessThanDistributed()
+    {
+        var delta = 8m - 10m;
+        var status = AgnumReconciliationStatusCalculator.GetStatus("SKU-001", delta);
+
+        status.Should().Be("Under");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds the Agnum Phase 5 four-way discrepancy view: virtual balance, distributed quantity, remaining quantity, MES physical stock, and delta status.
- Extends Agnum balances with MES physical stock totals plus physical location links into the 3D warehouse viewer.
- Replaces the CSV-upload reconciliation UI with imported-data reconciliation by virtual warehouse, search, discrepancy filter, and status chips.
- Hardens 3D warehouse visibility for Agnum-distributed stock by using physical stock for status, resolving warehouse key mismatches, showing stock fallback rows when HU projections lag, and formatting coordinates to 1 decimal.
- Marks MVP scope phases 4 and 5 as done.

## Why

Agnum MVP required end-to-end visibility after distribution: operators need to compare Agnum virtual stock against distributed MES stock and actual physical stock, then jump directly to the physical warehouse location.

## Validation

- dotnet build src/LKvitai.MES.sln -c Release --no-restore
- dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ -c Release --no-restore

Both passed with 0 errors. Existing package vulnerability warnings remain for Marten, OpenTelemetry Jaeger, and ImageSharp.
