### PR TITLE
[codex] Fix Agnum MES physical and 3D visibility

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/AgnumImportController.cs
@@ -215,7 +215,7 @@ public sealed class AgnumImportController : ControllerBase
         {
             await using var querySession = _documentStore.QuerySession();
             var physicalStockRows = await Marten.QueryableExtensions.ToListAsync(
-                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU)),
+                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU) && x.OnHandQty > 0m),
                 ct);
 
             physicalStockBySku = physicalStockRows
@@ -346,7 +346,7 @@ public sealed class AgnumImportController : ControllerBase
         {
             await using var querySession = _documentStore.QuerySession();
             var physicalStockRows = await Marten.QueryableExtensions.ToListAsync(
-                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU)),
+                querySession.Query<AvailableStockView>().Where(x => skus.Contains(x.SKU) && x.OnHandQty > 0m),
                 ct);
 
             physicalBySku = physicalStockRows

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/WarehouseVisualizationController.cs
@@ -511,10 +511,14 @@ public sealed class WarehouseVisualizationController : ControllerBase
             var location = node.Location;
             var hasHardLock = hardLockByLocation.TryGetValue(location.Code, out var hardLockedQty) &&
                               hardLockedQty > 0m;
-            var onHandQty = qtyByLocation.GetValueOrDefault(location.Code, 0m);
-            var utilization = ComputeUtilization(location, onHandQty);
-            var utilizationPercent = decimal.Round(utilization * 100m, 2, MidpointRounding.AwayFromZero);
             var handlingUnitsForLocation = husByLocation.GetValueOrDefault(location.Code, new List<HandlingUnitView>());
+            var onHandQty = qtyByLocation.GetValueOrDefault(location.Code, 0m);
+            var huQty = handlingUnitsForLocation
+                .SelectMany(x => x.Lines)
+                .Sum(x => x.Quantity);
+            var displayedQty = onHandQty > 0m ? onHandQty : huQty;
+            var utilization = ComputeUtilization(location, displayedQty);
+            var utilizationPercent = decimal.Round(utilization * 100m, 2, MidpointRounding.AwayFromZero);
             var status = ResolveCapacityStatus(utilization);
             var color = ResolveStatusColor(status);
             var handlingUnitResponses = handlingUnitsForLocation.Select(x =>
@@ -527,7 +531,7 @@ public sealed class WarehouseVisualizationController : ControllerBase
                     firstLine?.Quantity ?? 0m);
             }).ToList();
 
-            if (handlingUnitResponses.Count == 0 && onHandQty > 0m)
+            if (handlingUnitResponses.Count == 0 && displayedQty > 0m)
             {
                 handlingUnitResponses.AddRange(stockRows
                     .Where(x => string.Equals(GetStockLocationCode(x), location.Code, StringComparison.OrdinalIgnoreCase))

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Projections/HandlingUnitProjection.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Projections/HandlingUnitProjection.cs
@@ -19,9 +19,9 @@ namespace LKvitai.MES.Modules.Warehouse.Projections;
 ///   If toLocation == HU.location: AddLine(sku, qty)
 ///   If locations differ: Update HU.location
 ///
-/// Sealed invariant (defensive): once Status == "SEALED", LineAdded / LineRemoved /
-/// StockMoved are silently ignored. Primary enforcement is in the command path;
-/// the projection guard prevents stale or replayed events from corrupting state.
+/// Sealed invariant (defensive): once Status == "SEALED", explicit LineAdded /
+/// LineRemoved events are silently ignored. StockMoved is still projected because
+/// receipt transactions can be grouped after the seal event by the async daemon.
 ///
 /// CRITICAL: Async lifecycle (uses Marten async daemon)
 /// CRITICAL: V-5 Rule B — uses only self-contained event data (no external queries)
@@ -86,9 +86,6 @@ public class HandlingUnitProjection : MultiStreamProjection<HandlingUnitView, st
 
     public HandlingUnitView Apply(StockMovedEvent evt, HandlingUnitView current)
     {
-        // Sealed HU is immutable — ignore post-seal mutations (defensive)
-        if (current.Status == "SEALED") return current;
-
         // Design spec projection logic:
         //   If fromLocation == HU.location: RemoveLine(sku, qty)
         //   If toLocation == HU.location: AddLine(sku, qty)
@@ -193,7 +190,8 @@ public class HandlingUnitGrouper : IAggregateGrouper<string>
 /// without Marten infrastructure. Mirrors the Apply methods on HandlingUnitProjection.
 ///
 /// V-5 Rule B: Uses only self-contained event data (no external queries).
-/// Sealed invariant: post-seal LineAdded/LineRemoved/StockMoved are ignored.
+/// Sealed invariant: post-seal LineAdded/LineRemoved are ignored. StockMoved is
+/// still applied so async projection ordering cannot drop receipt HU contents.
 /// </summary>
 public static class HandlingUnitAggregation
 {
@@ -238,8 +236,6 @@ public static class HandlingUnitAggregation
 
     public static HandlingUnitView ApplyStockMoved(StockMovedEvent evt, HandlingUnitView current)
     {
-        if (current.Status == "SEALED") return current;
-
         var huLocation = current.CurrentLocation;
 
         if (!string.IsNullOrEmpty(huLocation))
@@ -280,6 +276,6 @@ public static class HandlingUnitAggregation
 
     private static bool IsVirtualLocation(string location)
     {
-        return location is "SUPPLIER" or "PRODUCTION" or "SCRAP" or "SYSTEM";
+        return location is "SUPPLIER" or "PRODUCTION" or "SCRAP" or "SYSTEM" or "AGNUM";
     }
 }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/HandlingUnitProjectionTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/HandlingUnitProjectionTests.cs
@@ -335,7 +335,7 @@ public class HandlingUnitProjectionTests
         view.IsEmpty.Should().BeFalse();
     }
 
-    // ── Sealed HU guards (defensive — projection ignores post-seal mutations) ──
+    // ── Sealed HU guards (defensive — projection ignores explicit line mutations) ──
 
     [Fact]
     public void Sealed_LineAdded_DoesNotChangeLines()
@@ -364,31 +364,46 @@ public class HandlingUnitProjectionTests
     }
 
     [Fact]
-    public void Sealed_StockMoved_DoesNotChangeLocationOrLines()
+    public void Sealed_StockMoved_AppliesMovement()
     {
         var view = MakeSealedView();
-        var locationBefore = view.CurrentLocation;
-        var linesBefore = view.Lines.Select(l => (l.SKU, l.Quantity)).ToList();
         var evt = MakeStockMoved(Location, "LOC-B", Sku1, 50m, HuId);
 
         var result = HandlingUnitAggregation.ApplyStockMoved(evt, view);
 
         result.Status.Should().Be("SEALED");
-        result.CurrentLocation.Should().Be(locationBefore);
-        result.Lines.Select(l => (l.SKU, l.Quantity)).Should().BeEquivalentTo(linesBefore);
+        result.CurrentLocation.Should().Be("LOC-B");
+        result.Lines.Should().HaveCount(1);
+        result.Lines[0].SKU.Should().Be(Sku1);
+        result.Lines[0].Quantity.Should().Be(50m);
     }
 
     [Fact]
-    public void Sealed_StockMoved_Receipt_DoesNotAddLine()
+    public void Sealed_StockMoved_Receipt_AddsLine()
     {
         var view = MakeSealedView();
-        var lineCountBefore = view.Lines.Count;
         var evt = MakeStockMoved("SUPPLIER", Location, Sku2, 200m, HuId);
 
         var result = HandlingUnitAggregation.ApplyStockMoved(evt, view);
 
         result.Status.Should().Be("SEALED");
-        result.Lines.Should().HaveCount(lineCountBefore);
+        result.Lines.Should().HaveCount(2);
+        result.Lines.Should().Contain(x => x.SKU == Sku2 && x.Quantity == 200m);
+    }
+
+    [Fact]
+    public void Sealed_StockMoved_AgnumReceipt_AfterSeal_AddsLine()
+    {
+        var view = MakeOpenView();
+        HandlingUnitAggregation.ApplySealed(MakeSealed(HuId, DateTime.UtcNow), view);
+        var evt = MakeStockMoved("AGNUM", Location, Sku2, 18m, HuId);
+
+        var result = HandlingUnitAggregation.ApplyStockMoved(evt, view);
+
+        result.Status.Should().Be("SEALED");
+        result.CurrentLocation.Should().Be(Location);
+        result.IsEmpty.Should().BeFalse();
+        result.Lines.Should().ContainSingle(x => x.SKU == Sku2 && x.Quantity == 18m);
     }
 
     // ── Helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Count MES physical stock from positive on-hand rows only, so virtual/source adjustments do not make Agnum MES Physical negative while location chips show positive stock.
- Keep Agnum balance/reconciliation physical totals aligned with the physical locations shown in the UI.
- Fix 3D visibility after Agnum distribution by allowing HU projection to apply StockMoved events even when the HU seal event is projected first.
- Use HU line quantities as a 3D utilization/status fallback when AvailableStockView has not caught up yet.

## Validation
- `dotnet build src/LKvitai.MES.sln -c Release --no-restore`
- `dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/ -c Release --no-restore`
