### PR TITLE
Compact MudBlazor admin list density

### DIFF
--- a/docs/migration/mudblazor-designer-followup-decisions.md
+++ b/docs/migration/mudblazor-designer-followup-decisions.md
@@ -9,7 +9,8 @@
 - Scope bridge overrides to `.lk .mud-*`, `.lk-grid`, `.lk-dialog`, `.lk-state`, and `.panel`.
 - Keep `.lk-bare` as an emergency escape hatch for rare raw-Mud experiments.
 - Use one bordered Mud field base style:
-  - `.lk-field--filter` for 30px toolbar filters.
+  - `.lk-field--filter` for 32px interactive toolbar filters.
+  - Filter labels are external mono-caps micro-labels; do not use Mud floating labels in dense list toolbars.
   - `.lk-field--inline` for row actions / inline fields without labels.
 - Dialogs:
   - Neutral header by default.
@@ -27,6 +28,13 @@
 - Tables:
   - 30px rows everywhere, including admin/catalog and read-heavy reports.
   - For read-heavy reports, use grouping and section spacing instead of taller rows.
+- Admin/list density:
+  - Keep the intentional split: `--row-h: 30px` for display rows, `--control-h: 32px` for interactive inputs/buttons.
+  - Filter toolbar and grid live in one `MudPaper.panel`; do not stack a separate filter card above a separate grid card.
+  - Fold `Total` and page indicator into a 34px grid header strip.
+  - MudDataGrid pager target is 36px with 28x28 icon buttons.
+  - Empty filtered grids use one compact 56-64px block with mono-caps title and optional `Clear filters` action.
+  - Non-row chrome under the page title should stay at or below about 168px on admin/list screens.
 - State grammar:
   - `.lk-state` is for page/panel context.
   - `.chip` is for a single row, record, cell, or field.

--- a/docs/migration/mudblazor-migration-strategy.md
+++ b/docs/migration/mudblazor-migration-strategy.md
@@ -92,11 +92,12 @@ This gives:
 **Designer follow-up decisions locked for Phase 1+:**
 - Keep `.lk` globally on the Warehouse `MudLayout`. Overrides are scoped to `.lk .mud-*`, so Bootstrap-only pages are unaffected and any Mud component rendered from an unmigrated page still receives the approved design language.
 - Reserve `.lk-bare` as a rare escape hatch for raw Mud experiments; prefer adding targeted resets there over removing the global `.lk` wrapper.
-- Forms use one bordered base style, plus `.lk-field--filter` for 30px toolbar filters and `.lk-field--inline` for row-action/inline fields without labels.
+- Forms use one bordered base style, plus `.lk-field--filter` for 32px interactive toolbar filters with external mono-caps labels and `.lk-field--inline` for row-action/inline fields without labels.
 - Dialogs use neutral headers by default. Destructive confirmations use `.lk-dialog--danger` on the header only, neutral body, and filled danger only for the final confirmation button.
 - Disabled Mud buttons use the dashed disabled grammar globally. Destructive row actions are outlined danger; filled danger is reserved for final destructive confirmation.
 - Use Material Outlined icons. Filled icons are allowed only for active nav and critical status signals. Nav icons, including collapsed sidebar icons, are 18px.
 - Operational table rows are 30px everywhere, including admin/catalog and read-heavy reports.
+- Admin/list screens use one density split: `--row-h: 30px` for display rows, `--control-h: 32px` for interactive inputs/buttons. Filter toolbar and grid should live in one `MudPaper.panel`, with the `Total`/page strip folded into the grid panel.
 - `.lk-state` is for page/panel state; `.chip` is for one record, row, cell, or field.
 - Golden Phase 1 screens: `AvailableStock` (operational list), `Admin/Lots` (CRUD), `StockAdjustments` (workflow/confirmations/state banners).
 

--- a/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-tokens.css
+++ b/src/BuildingBlocks/LKvitai.MES.BuildingBlocks.WebUI/wwwroot/css/portal-tokens.css
@@ -94,6 +94,10 @@
   --r-md: 6px;
   --r-lg: 8px;
 
+  /* Density */
+  --row-h: 30px;
+  --control-h: 32px;
+
   /* Shell layout — content cap shared across all modules (Sales, Warehouse,
      Frontline, Portal). Each module's main content wrapper uses this value.
      1600px fits comfortably on 1920px monitors (160px side breathing room)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
@@ -17,119 +17,116 @@
     </div>
 }
 
-<div class="card shadow-sm mb-3">
-    <div class="card-body">
-        <div class="row g-2 align-items-end">
-            <div class="col-md-4" data-testid="lots-search">
-                <MudTextField T="string"
-                              Label="Search"
-                              Variant="Variant.Outlined"
-                              Margin="Margin.Dense"
-                              @bind-Value="_search"
-                              Placeholder="Lot number, SKU, item name"
-                              InputAttributes="@LotsFilterSearchAttributes" />
-            </div>
-            <div class="col-md-3">
-                <MudSelect T="string"
-                           Label="Status"
+<MudPaper Outlined="true" Elevation="0" Class="panel lots-filter-panel">
+    <div class="lk-toolbar lots-filter-toolbar">
+        <div class="lk-field--filter lots-filter__search" data-testid="lots-search">
+            <MudTextField T="string"
+                          Label="Search"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          @bind-Value="_search"
+                          Placeholder="Lot number, SKU, item name"
+                          InputAttributes="@LotsFilterSearchAttributes" />
+        </div>
+        <div class="lk-field--filter lots-filter__status">
+            <MudSelect T="string"
+                       Label="Status"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       @bind-Value="_status"
+                       InputAttributes="@LotsFilterStatusAttributes">
+                <MudSelectItem T="string" Value="@string.Empty">All</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Active")">Active</MudSelectItem>
+                <MudSelectItem T="string" Value="@("ExpiringSoon")">Expiring soon</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Expired")">Expired</MudSelectItem>
+                <MudSelectItem T="string" Value="@("Depleted")">Depleted</MudSelectItem>
+            </MudSelect>
+        </div>
+        <div class="lk-field--filter lots-filter__page-size">
+            <div data-testid="lots-page-size">
+                <MudSelect T="int"
+                           Label="Page size"
                            Variant="Variant.Outlined"
                            Margin="Margin.Dense"
-                           @bind-Value="_status"
-                           InputAttributes="@LotsFilterStatusAttributes">
-                    <MudSelectItem T="string" Value="@string.Empty">All</MudSelectItem>
-                    <MudSelectItem T="string" Value="@("Active")">Active</MudSelectItem>
-                    <MudSelectItem T="string" Value="@("ExpiringSoon")">Expiring soon</MudSelectItem>
-                    <MudSelectItem T="string" Value="@("Expired")">Expired</MudSelectItem>
-                    <MudSelectItem T="string" Value="@("Depleted")">Depleted</MudSelectItem>
+                           Value="@_pageSize"
+                           ValueChanged="OnPageSizeChangedAsync"
+                           InputAttributes="@LotsPageSizeAttributes">
+                    <MudSelectItem T="int" Value="25">25</MudSelectItem>
+                    <MudSelectItem T="int" Value="50">50</MudSelectItem>
+                    <MudSelectItem T="int" Value="100">100</MudSelectItem>
                 </MudSelect>
             </div>
-            <div class="col-md-2">
-                <div data-testid="lots-page-size">
-                    <MudSelect T="int"
-                               Label="Page size"
-                               Variant="Variant.Outlined"
-                               Margin="Margin.Dense"
-                               Value="@_pageSize"
-                               ValueChanged="OnPageSizeChangedAsync"
-                               InputAttributes="@LotsPageSizeAttributes">
-                        <MudSelectItem T="int" Value="25">25</MudSelectItem>
-                        <MudSelectItem T="int" Value="50">50</MudSelectItem>
-                        <MudSelectItem T="int" Value="100">100</MudSelectItem>
-                    </MudSelect>
-                </div>
-            </div>
-            <div class="col-md-3 d-flex gap-2">
-                <MudButton Variant="Variant.Filled"
-                           Color="Color.Primary"
-                           OnClick="ApplyFiltersAsync"
-                           UserAttributes="@LotsSearchButtonAttributes">
-                    Filter
-                </MudButton>
-                <MudButton Variant="Variant.Outlined"
-                           Color="Color.Primary"
-                           OnClick="RefreshAsync"
-                           UserAttributes="@LotsRefreshAttributes">
-                    Refresh
-                </MudButton>
-            </div>
+        </div>
+        <div class="lots-filter__actions">
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="ApplyFiltersAsync"
+                       UserAttributes="@LotsSearchButtonAttributes">
+                Filter
+            </MudButton>
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Primary"
+                       OnClick="RefreshAsync"
+                       UserAttributes="@LotsRefreshAttributes">
+                Refresh
+            </MudButton>
         </div>
     </div>
-</div>
+</MudPaper>
 
-<div class="card shadow-sm position-relative">
-    <div class="card-body">
-        <div class="d-flex justify-content-between align-items-center mb-2">
-            <strong data-testid="lots-summary">Total: @_totalCount</strong>
-            <span class="text-muted small" data-testid="lots-current-page">Page @_currentPage</span>
-        </div>
-
-        <MudDataGrid T="LotListItemDto"
-                     @ref="_grid"
-                     @key="_gridRenderKey"
-                     ServerData="LoadServerDataAsync"
-                     Filterable="false"
-                     SortMode="SortMode.Single"
-                     Dense="true"
-                     Hover="true"
-                     RowsPerPage="@_pageSize"
-                     Loading="@_isLoading"
-                     @attributes="@LotsGridAttributes">
-            <Columns>
-                <PropertyColumn Property="x => x.LotNumber" Title="Lot" />
-                <TemplateColumn Title="Item">
-                    <CellTemplate>
-                        @($"{context.Item.ItemSku} - {context.Item.ItemName}")
-                    </CellTemplate>
-                </TemplateColumn>
-                <TemplateColumn Title="Qty">
-                    <CellTemplate>@context.Item.Qty.ToString("0.###")</CellTemplate>
-                </TemplateColumn>
-                <TemplateColumn Title="Reserved">
-                    <CellTemplate>@context.Item.ReservedQty.ToString("0.###")</CellTemplate>
-                </TemplateColumn>
-                <TemplateColumn Title="Available">
-                    <CellTemplate>@context.Item.AvailableQty.ToString("0.###")</CellTemplate>
-                </TemplateColumn>
-                <PropertyColumn Property="x => x.BaseUom" Title="UoM" />
-                <TemplateColumn Title="Production">
-                    <CellTemplate>@FormatDate(context.Item.ProductionDate)</CellTemplate>
-                </TemplateColumn>
-                <TemplateColumn Title="Expiry">
-                    <CellTemplate>@FormatDate(context.Item.ExpiryDate)</CellTemplate>
-                </TemplateColumn>
-                <PropertyColumn Property="x => x.Status" Title="Status" />
-            </Columns>
-            <NoRecordsContent>
-                <MudText Typo="Typo.body2" Class="text-muted">No lots found.</MudText>
-            </NoRecordsContent>
-            <PagerContent>
-                <div data-testid="lots-pager">
-                    <MudDataGridPager T="LotListItemDto" />
-                </div>
-            </PagerContent>
-        </MudDataGrid>
+<MudPaper Outlined="true" Elevation="0" Class="panel lots-grid-panel">
+    <div class="lots-grid-head">
+        <strong data-testid="lots-summary">Total: @_totalCount</strong>
+        <span data-testid="lots-current-page">Page @_currentPage</span>
     </div>
-</div>
+
+    <MudDataGrid T="LotListItemDto"
+                 @ref="_grid"
+                 @key="_gridRenderKey"
+                 ServerData="LoadServerDataAsync"
+                 Filterable="false"
+                 SortMode="SortMode.Single"
+                 Dense="true"
+                 Hover="true"
+                 RowsPerPage="@_pageSize"
+                 Loading="@_isLoading"
+                 Class="lk-grid lots-grid"
+                 @attributes="@LotsGridAttributes">
+        <Columns>
+            <PropertyColumn Property="x => x.LotNumber" Title="Lot" />
+            <TemplateColumn Title="Item">
+                <CellTemplate>
+                    @($"{context.Item.ItemSku} - {context.Item.ItemName}")
+                </CellTemplate>
+            </TemplateColumn>
+            <TemplateColumn Title="Qty">
+                <CellTemplate>@context.Item.Qty.ToString("0.###")</CellTemplate>
+            </TemplateColumn>
+            <TemplateColumn Title="Reserved">
+                <CellTemplate>@context.Item.ReservedQty.ToString("0.###")</CellTemplate>
+            </TemplateColumn>
+            <TemplateColumn Title="Available">
+                <CellTemplate>@context.Item.AvailableQty.ToString("0.###")</CellTemplate>
+            </TemplateColumn>
+            <PropertyColumn Property="x => x.BaseUom" Title="UoM" />
+            <TemplateColumn Title="Production">
+                <CellTemplate>@FormatDate(context.Item.ProductionDate)</CellTemplate>
+            </TemplateColumn>
+            <TemplateColumn Title="Expiry">
+                <CellTemplate>@FormatDate(context.Item.ExpiryDate)</CellTemplate>
+            </TemplateColumn>
+            <PropertyColumn Property="x => x.Status" Title="Status" />
+        </Columns>
+        <NoRecordsContent>
+            <MudText Typo="Typo.body2" Class="lk-empty lots-empty">No lots found.</MudText>
+        </NoRecordsContent>
+        <PagerContent>
+            <div class="lots-pager" data-testid="lots-pager">
+                <MudDataGridPager T="LotListItemDto" />
+            </div>
+        </PagerContent>
+    </MudDataGrid>
+</MudPaper>
 </div>
 
 @code {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
@@ -17,20 +17,20 @@
     </div>
 }
 
-<MudPaper Outlined="true" Elevation="0" Class="panel lots-filter-panel">
+<MudPaper Outlined="true" Elevation="0" Class="panel lots-list-panel lots-filter">
     <div class="lk-toolbar lots-filter-toolbar">
-        <div class="lk-field--filter lots-filter__search" data-testid="lots-search">
+        <div class="lk-field--filter lots-field lots-field--grow lots-filter__search" data-testid="lots-search">
+            <span class="lots-field__label">Search</span>
             <MudTextField T="string"
-                          Label="Search"
                           Variant="Variant.Outlined"
                           Margin="Margin.Dense"
                           @bind-Value="_search"
                           Placeholder="Lot number, SKU, item name"
                           InputAttributes="@LotsFilterSearchAttributes" />
         </div>
-        <div class="lk-field--filter lots-filter__status">
+        <div class="lk-field--filter lots-field lots-filter__status">
+            <span class="lots-field__label">Status</span>
             <MudSelect T="string"
-                       Label="Status"
                        Variant="Variant.Outlined"
                        Margin="Margin.Dense"
                        @bind-Value="_status"
@@ -42,10 +42,10 @@
                 <MudSelectItem T="string" Value="@("Depleted")">Depleted</MudSelectItem>
             </MudSelect>
         </div>
-        <div class="lk-field--filter lots-filter__page-size">
+        <div class="lk-field--filter lots-field lots-filter__page-size">
+            <span class="lots-field__label">Page size</span>
             <div data-testid="lots-page-size">
                 <MudSelect T="int"
-                           Label="Page size"
                            Variant="Variant.Outlined"
                            Margin="Margin.Dense"
                            Value="@_pageSize"
@@ -72,12 +72,10 @@
             </MudButton>
         </div>
     </div>
-</MudPaper>
 
-<MudPaper Outlined="true" Elevation="0" Class="panel lots-grid-panel">
     <div class="lots-grid-head">
         <strong data-testid="lots-summary">Total: @_totalCount</strong>
-        <span data-testid="lots-current-page">Page @_currentPage</span>
+        <span class="mono" data-testid="lots-current-page">Page @_currentPage</span>
     </div>
 
     <MudDataGrid T="LotListItemDto"
@@ -118,7 +116,16 @@
             <PropertyColumn Property="x => x.Status" Title="Status" />
         </Columns>
         <NoRecordsContent>
-            <MudText Typo="Typo.body2" Class="lk-empty lots-empty">No lots found.</MudText>
+            <div class="lots-grid__empty">
+                <span class="lots-grid__empty-title">No lots found</span>
+                <span>
+                    No lots match the current filter.
+                    @if (HasAppliedFilters)
+                    {
+                        <button type="button" class="lots-grid__empty-action" @onclick="ClearFiltersAsync">Clear filters</button>
+                    }
+                </span>
+            </div>
         </NoRecordsContent>
         <PagerContent>
             <div class="lots-pager" data-testid="lots-pager">
@@ -143,9 +150,9 @@
     private ApiException? _apiError;
 
     private static readonly Dictionary<string, object> LotsGridAttributes = new() { ["data-testid"] = "lots-grid" };
-    private static readonly Dictionary<string, object> LotsFilterSearchAttributes = new() { ["data-testid"] = "lots-search-input" };
-    private static readonly Dictionary<string, object> LotsFilterStatusAttributes = new() { ["data-testid"] = "lots-status" };
-    private static readonly Dictionary<string, object> LotsPageSizeAttributes = new() { ["data-testid"] = "lots-page-size" };
+    private static readonly Dictionary<string, object> LotsFilterSearchAttributes = new() { ["data-testid"] = "lots-search-input", ["aria-label"] = "Search" };
+    private static readonly Dictionary<string, object> LotsFilterStatusAttributes = new() { ["data-testid"] = "lots-status", ["aria-label"] = "Status" };
+    private static readonly Dictionary<string, object> LotsPageSizeAttributes = new() { ["data-testid"] = "lots-page-size", ["aria-label"] = "Page size" };
     private static readonly Dictionary<string, object> LotsRefreshAttributes = new() { ["data-testid"] = "lots-refresh" };
     private static readonly Dictionary<string, object> LotsSearchButtonAttributes = new() { ["data-testid"] = "lots-search-btn" };
 
@@ -160,6 +167,19 @@
     private async Task OnPageSizeChangedAsync(int pageSize)
     {
         _pageSize = Math.Clamp(pageSize, 1, 500);
+        _gridRenderKey++;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private bool HasAppliedFilters =>
+        !string.IsNullOrWhiteSpace(_appliedSearch) || !string.IsNullOrWhiteSpace(_appliedStatus);
+
+    private async Task ClearFiltersAsync()
+    {
+        _search = string.Empty;
+        _status = string.Empty;
+        _appliedSearch = null;
+        _appliedStatus = null;
         _gridRenderKey++;
         await InvokeAsync(StateHasChanged);
     }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -589,6 +589,104 @@ td.is-num strong { font-weight: 700; }
 .lk-grid .mud-table-pagination button.mud-selected { background: var(--accent-600) !important; color: #fff !important; }
 .lk-grid .mud-progress-linear .mud-progress-linear-bar { background: var(--accent-500) !important; }
 
+.lots-filter-panel {
+  margin-bottom: 12px;
+}
+
+.lots-filter-toolbar {
+  display: flex;
+  align-items: flex-end;
+  border-bottom: 0;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 10px;
+}
+
+.lots-filter__search {
+  flex: 1 1 280px;
+  min-width: 240px;
+}
+
+.lots-filter__status {
+  flex: 0 1 230px;
+}
+
+.lots-filter__page-size {
+  flex: 0 0 138px;
+}
+
+.lots-filter__search .mud-input-control,
+.lots-filter__status .mud-input-control,
+.lots-filter__page-size .mud-input-control {
+  width: 100%;
+}
+
+.lots-filter__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 1px;
+}
+
+.lots-filter__actions .mud-button-root {
+  min-height: 30px;
+  padding: 0 12px;
+}
+
+.lots-grid-panel {
+  margin-bottom: 16px;
+}
+
+.lots-grid-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--n-150);
+  color: var(--n-900);
+  font-size: 12.5px;
+}
+
+.lots-grid-head span {
+  color: var(--n-500);
+  font-size: 12px;
+}
+
+.lots-grid .mud-table-head th {
+  height: 30px !important;
+  padding: 5px 10px !important;
+}
+
+.lots-grid .mud-table-cell {
+  padding: 5px 10px !important;
+}
+
+.lots-grid .mud-table-pagination {
+  min-height: 38px;
+  padding: 4px 8px;
+}
+
+.lots-grid .mud-table-pagination .mud-input-control {
+  margin: 0;
+}
+
+.lots-empty {
+  display: block;
+  padding: 12px;
+  color: var(--n-500) !important;
+  text-align: center;
+}
+
+@media (max-width: 720px) {
+  .lots-filter__search,
+  .lots-filter__status,
+  .lots-filter__page-size,
+  .lots-filter__actions {
+    flex: 1 1 100%;
+  }
+}
+
 .mud-paper.panel {
   border-radius: var(--r-md) !important;
   border: 1px solid var(--n-200) !important;
@@ -692,6 +790,52 @@ td.is-num strong { font-weight: 700; }
 .lk-field--filter .mud-input-control .mud-input-slot,
 .lk-toolbar .mud-input-control .mud-input-slot {
   min-height: 30px;
+}
+
+.lk-field--filter .mud-input-control,
+.lk-toolbar .mud-input-control {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.lk-field--filter .mud-input,
+.lk-toolbar .mud-input {
+  min-height: 30px;
+  font-size: 12.5px;
+}
+
+.lk-field--filter .mud-input > input.mud-input-root,
+.lk-field--filter .mud-input > .mud-input-root,
+.lk-toolbar .mud-input > input.mud-input-root,
+.lk-toolbar .mud-input > .mud-input-root {
+  padding: 6px 8px !important;
+}
+
+.lk-field--filter .mud-input-outlined-border,
+.lk-toolbar .mud-input-outlined-border {
+  border-color: var(--n-200) !important;
+  border-radius: var(--r-sm) !important;
+}
+
+.lk-field--filter .mud-input-control.mud-focused .mud-input-outlined-border,
+.lk-toolbar .mud-input-control.mud-focused .mud-input-outlined-border {
+  border-color: var(--accent-500) !important;
+  box-shadow: 0 0 0 3px rgba(47, 143, 139, 0.12);
+}
+
+.lk-field--filter .mud-input-label,
+.lk-toolbar .mud-input-label {
+  padding: 0 4px;
+  background: var(--n-0);
+  color: var(--n-700);
+  font-size: 10.5px;
+  line-height: 1;
+  transform: translate(10px, -6px) scale(0.85);
+}
+
+.lk-field--filter .mud-input-adornment-end,
+.lk-toolbar .mud-input-adornment-end {
+  margin-right: 4px;
 }
 
 .lk-field--inline .mud-input-control {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -508,14 +508,14 @@ td.is-num strong { font-weight: 700; }
 .field {
   display: flex; align-items: center; gap: 6px;
   background: var(--n-50); border: 1px solid var(--n-200); border-radius: var(--r-sm);
-  padding: 0 8px 0 10px; min-height: 30px;
+  padding: 0 8px 0 10px; min-height: var(--control-h);
 }
 
 .field:focus-within { border-color: var(--accent-500); background: var(--n-0); box-shadow: 0 0 0 3px rgba(47, 143, 139, 0.12); }
 
 .field input, .field select {
   border: 0; outline: none; background: transparent;
-  font-size: 12.5px; color: var(--n-900); min-height: 30px; padding: 0 2px;
+  font-size: 12.5px; color: var(--n-900); min-height: var(--control-h); padding: 0 2px;
 }
 
 .field--search { flex: 1 1 240px; max-width: 340px; }
@@ -567,6 +567,7 @@ td.is-num strong { font-weight: 700; }
 .lk-grid .mud-table-root { border-collapse: collapse; }
 
 .lk-grid .mud-table-head th {
+  height: var(--row-h) !important;
   position: sticky; top: 0; z-index: 1;
   background: var(--n-50) !important; color: var(--n-700) !important;
   font-family: var(--font-mono) !important;
@@ -575,7 +576,7 @@ td.is-num strong { font-weight: 700; }
   border-bottom: 1px solid var(--n-200) !important;
 }
 
-.lk-grid .mud-table-cell { padding: 6px 12px !important; font-size: 12.5px !important; height: 30px !important; border-bottom: 1px solid var(--n-100) !important; }
+.lk-grid .mud-table-cell { padding: 6px 12px !important; font-size: 12.5px !important; height: var(--row-h) !important; border-bottom: 1px solid var(--n-100) !important; }
 .lk-grid .mud-table-row:hover .mud-table-cell { background: var(--n-25) !important; }
 
 .lk-grid .mud-table-row.is-selected .mud-table-cell { background: var(--accent-50) !important; }
@@ -589,30 +590,52 @@ td.is-num strong { font-weight: 700; }
 .lk-grid .mud-table-pagination button.mud-selected { background: var(--accent-600) !important; color: #fff !important; }
 .lk-grid .mud-progress-linear .mud-progress-linear-bar { background: var(--accent-500) !important; }
 
-.lots-filter-panel {
-  margin-bottom: 12px;
+.lots-list-panel {
+  margin-bottom: 16px;
 }
 
 .lots-filter-toolbar {
   display: flex;
   align-items: flex-end;
-  border-bottom: 0;
   flex-wrap: wrap;
-  gap: 8px;
-  padding: 8px 10px;
+  gap: 8px 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--n-150);
+  background: var(--n-25);
+}
+
+.lots-field {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.lots-field--grow {
+  flex: 1 1 280px;
+}
+
+.lots-field__label {
+  padding-left: 1px;
+  color: var(--n-600);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 1.4px;
+  line-height: 1.2;
+  text-transform: uppercase;
 }
 
 .lots-filter__search {
-  flex: 1 1 280px;
   min-width: 240px;
 }
 
 .lots-filter__status {
-  flex: 0 1 230px;
+  flex: 0 0 170px;
 }
 
 .lots-filter__page-size {
-  flex: 0 0 138px;
+  flex: 0 0 96px;
 }
 
 .lots-filter__search .mud-input-control,
@@ -623,18 +646,13 @@ td.is-num strong { font-weight: 700; }
 
 .lots-filter__actions {
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   gap: 8px;
-  padding-bottom: 1px;
 }
 
 .lots-filter__actions .mud-button-root {
-  min-height: 30px;
-  padding: 0 12px;
-}
-
-.lots-grid-panel {
-  margin-bottom: 16px;
+  min-height: var(--control-h);
+  padding: 0 14px;
 }
 
 .lots-grid-head {
@@ -642,8 +660,10 @@ td.is-num strong { font-weight: 700; }
   align-items: center;
   justify-content: space-between;
   gap: 12px;
-  padding: 9px 12px;
+  height: 34px;
+  padding: 0 12px;
   border-bottom: 1px solid var(--n-150);
+  background: var(--n-25);
   color: var(--n-900);
   font-size: 12.5px;
 }
@@ -654,28 +674,56 @@ td.is-num strong { font-weight: 700; }
 }
 
 .lots-grid .mud-table-head th {
-  height: 30px !important;
-  padding: 5px 10px !important;
+  height: var(--row-h) !important;
+  padding: 0 12px !important;
 }
 
 .lots-grid .mud-table-cell {
-  padding: 5px 10px !important;
+  height: var(--row-h) !important;
+  padding: 0 12px !important;
 }
 
 .lots-grid .mud-table-pagination {
-  min-height: 38px;
-  padding: 4px 8px;
+  min-height: 36px;
+  padding: 0 8px;
 }
 
 .lots-grid .mud-table-pagination .mud-input-control {
   margin: 0;
 }
 
-.lots-empty {
-  display: block;
-  padding: 12px;
-  color: var(--n-500) !important;
-  text-align: center;
+.lots-grid .mud-table-pagination .mud-button-root {
+  min-width: 28px;
+  min-height: 28px;
+  padding: 0;
+}
+
+.lots-grid__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 18px 16px;
+  color: var(--n-500);
+  font-size: 12.5px;
+}
+
+.lots-grid__empty-title {
+  color: var(--n-600);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+
+.lots-grid__empty-action {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--accent-700);
+  cursor: pointer;
+  font-weight: 700;
 }
 
 @media (max-width: 720px) {
@@ -789,7 +837,9 @@ td.is-num strong { font-weight: 700; }
 
 .lk-field--filter .mud-input-control .mud-input-slot,
 .lk-toolbar .mud-input-control .mud-input-slot {
-  min-height: 30px;
+  min-height: var(--control-h);
+  padding: 0 10px;
+  align-items: center;
 }
 
 .lk-field--filter .mud-input-control,
@@ -800,7 +850,7 @@ td.is-num strong { font-weight: 700; }
 
 .lk-field--filter .mud-input,
 .lk-toolbar .mud-input {
-  min-height: 30px;
+  min-height: var(--control-h);
   font-size: 12.5px;
 }
 
@@ -808,13 +858,12 @@ td.is-num strong { font-weight: 700; }
 .lk-field--filter .mud-input > .mud-input-root,
 .lk-toolbar .mud-input > input.mud-input-root,
 .lk-toolbar .mud-input > .mud-input-root {
-  padding: 6px 8px !important;
+  padding: 0 10px !important;
 }
 
 .lk-field--filter .mud-input-outlined-border,
 .lk-toolbar .mud-input-outlined-border {
-  border-color: var(--n-200) !important;
-  border-radius: var(--r-sm) !important;
+  display: none !important;
 }
 
 .lk-field--filter .mud-input-control.mud-focused .mud-input-outlined-border,
@@ -825,12 +874,7 @@ td.is-num strong { font-weight: 700; }
 
 .lk-field--filter .mud-input-label,
 .lk-toolbar .mud-input-label {
-  padding: 0 4px;
-  background: var(--n-0);
-  color: var(--n-700);
-  font-size: 10.5px;
-  line-height: 1;
-  transform: translate(10px, -6px) scale(0.85);
+  display: none !important;
 }
 
 .lk-field--filter .mud-input-adornment-end,


### PR DESCRIPTION
## Summary
- apply designer-confirmed admin/list density rules for MudBlazor
- merge Lots filters and grid into one panel, remove floating filter labels, and compact pager/empty state
- add shared row/control density tokens and document the 30px/32px split

## Validation
- dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj
- git diff --check origin/main..HEAD