### PR TITLE
Use tight Lots filter toolbar

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/Admin/Lots.razor
@@ -20,7 +20,6 @@
 <MudPaper Outlined="true" Elevation="0" Class="panel lots-list-panel lots-filter">
     <div class="lk-toolbar lots-filter-toolbar">
         <div class="lk-field--filter lots-field lots-field--grow lots-filter__search" data-testid="lots-search">
-            <span class="lots-field__label">Search</span>
             <MudTextField T="string"
                           Variant="Variant.Outlined"
                           Margin="Margin.Dense"
@@ -29,7 +28,6 @@
                           InputAttributes="@LotsFilterSearchAttributes" />
         </div>
         <div class="lk-field--filter lots-field lots-filter__status">
-            <span class="lots-field__label">Status</span>
             <MudSelect T="string"
                        Variant="Variant.Outlined"
                        Margin="Margin.Dense"
@@ -43,7 +41,6 @@
             </MudSelect>
         </div>
         <div class="lk-field--filter lots-field lots-filter__page-size">
-            <span class="lots-field__label">Page size</span>
             <div data-testid="lots-page-size">
                 <MudSelect T="int"
                            Variant="Variant.Outlined"

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -596,10 +596,10 @@ td.is-num strong { font-weight: 700; }
 
 .lots-filter-toolbar {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   flex-wrap: wrap;
   gap: 8px 10px;
-  padding: 8px 12px;
+  padding: 6px 12px;
   border-bottom: 1px solid var(--n-150);
   background: var(--n-25);
 }
@@ -646,7 +646,7 @@ td.is-num strong { font-weight: 700; }
 
 .lots-filter__actions {
   display: flex;
-  align-items: flex-end;
+  align-items: center;
   gap: 8px;
 }
 


### PR DESCRIPTION
## Summary
- switch Lots filter toolbar to the designer-approved tight-bar variant
- remove external filter labels from Lots to reduce toolbar height
- keep existing aria labels and placeholders for accessible field names

## Validation
- dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj
- git diff --check