### PR TITLE
[codex] Add MudBlazor golden screen patterns

### DIFF
--- a/docs/migration/mudblazor-migration-strategy.md
+++ b/docs/migration/mudblazor-migration-strategy.md
@@ -162,23 +162,19 @@ This gives:
 
 ---
 
-### Phase 1 — Priority warehouse pages (business-driven, 1–2 weeks)
+### Phase 1 — Golden warehouse screens (pattern-driven, 2–4 days)
 
-**Goal:** Migrate pages business has flagged as highest priority. Coexistence with unmigrated pages is still active.
+**Goal:** Migrate a small set of representative screens first, then reuse their settled density, spacing, and interaction patterns for the rest of Warehouse WebUI. Coexistence with unmigrated pages is still active.
 
-**Priority order** (suggest confirming with business):
+**Golden screens:**
 
-| Priority | Page | Route | Branch reuse? |
-|----------|------|-------|--------------|
-| P1 | Items list + detail | `/admin/items`, `/admin/items/{id}` | Template only — verify DTOs |
-| P1 | Stock Adjustments | `/warehouse/stock/adjustments` | Template only |
-| P1 | Inbound Shipments (list + create + detail) | `/warehouse/inbound/shipments/*` | Template only |
-| P1 | Transfers (list + create + execute) | `/warehouse/transfers/*` | Template only |
-| P2 | Receiving QC + Putaway | `/warehouse/inbound/qc`, `/warehouse/putaway` | Template only |
-| P2 | Locations admin | `/admin/locations` | Template only |
-| P2 | UoM + Suppliers | `/admin/uom`, `/admin/suppliers` | Template only |
-| P3 | Stock Movement reports | `/reports/stock-movements` | Template only |
-| P3 | Picking tasks | `/warehouse/picking/tasks` | Not migrated in branch |
+| Pattern | Page | Route | What it defines |
+|---------|------|-------|-----------------|
+| Dense operational list | Available Stock | `/available-stock` | Filter bar, result toolbar, dense grid, list/gallery alternatives, compact empty state |
+| Admin CRUD/list | Lots | `/admin/lots` | Single panel with filters + server grid + pager, 30px rows, 32px controls |
+| Workflow + history | Stock Adjustments | `/warehouse/stock/adjustments` | Create/action panel, warning state, dense history table, signed quantity chips |
+
+**Deferred after golden screens:** Items, Locations, UoM, Suppliers, Inbound Shipments, Transfers, Receiving QC, Putaway, reports, picking tasks, reservations, labels, dashboards, and the remaining warehouse workflows. These should follow the closest golden pattern instead of inventing page-local density rules.
 
 **Per-page migration checklist:**
 - [ ] Compare mudblazor branch version vs main version (diff DTOs, API calls, behaviors)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
@@ -1,47 +1,66 @@
 <form data-testid="stock-filters" @onsubmit="HandleSubmitAsync" @onsubmit:preventDefault="true">
-    <div class="card shadow-sm mb-3">
-        <div class="card-body">
-            <div class="row g-3">
-                <div class="col-12 col-md-3">
-                    <label class="form-label" for="warehouse">Warehouse</label>
-                    <select id="warehouse" class="form-select" @bind="_warehouse" data-testid="stock-warehouse">
-                        <option value="">All</option>
-                        @foreach (var warehouse in Warehouses)
-                        {
-                            <option value="@warehouse.Code">@warehouse.Code - @warehouse.Name</option>
-                        }
-                    </select>
-                </div>
-
-                <div class="col-12 col-md-3">
-                    <label class="form-label" for="location">Location</label>
-                    <input id="location" class="form-control" @bind="_location" placeholder="e.g. A01*" data-testid="stock-location" />
-                </div>
-
-                <div class="col-12 col-md-3">
-                    <label class="form-label" for="sku">SKU</label>
-                    <input id="sku" class="form-control" @bind="_sku" placeholder="e.g. SKU*" data-testid="stock-search" />
-                </div>
-
-                <div class="col-12 col-md-3 d-flex align-items-end">
-                    <div class="form-check">
-                        <input id="include-virtual" class="form-check-input" type="checkbox" @bind="_includeVirtual" data-testid="stock-include-virtual" />
-                        <label class="form-check-label" for="include-virtual">Show virtual locations</label>
-                    </div>
-                </div>
+    <MudPaper Outlined="true" Elevation="0" Class="panel stock-filter-panel">
+        <div class="lk-toolbar stock-filter-toolbar">
+            <div class="lk-field--filter stock-field stock-filter__warehouse">
+                <MudSelect T="string"
+                           Variant="Variant.Outlined"
+                           Margin="Margin.Dense"
+                           @bind-Value="_warehouse"
+                           InputAttributes="@WarehouseAttributes">
+                    <MudSelectItem T="string" Value="@string.Empty">All warehouses</MudSelectItem>
+                    @foreach (var warehouse in Warehouses)
+                    {
+                        <MudSelectItem T="string" Value="@warehouse.Code">@warehouse.Code - @warehouse.Name</MudSelectItem>
+                    }
+                </MudSelect>
             </div>
 
-            @if (!string.IsNullOrWhiteSpace(_validationError))
-            {
-                <div class="text-danger mt-2" data-testid="stock-validation-error">@_validationError</div>
-            }
+            <div class="lk-field--filter stock-field stock-filter__location">
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_location"
+                              Placeholder="Location e.g. A01*"
+                              InputAttributes="@LocationAttributes" />
+            </div>
 
-            <div class="mt-3 d-flex gap-2">
-                <button type="submit" class="btn btn-primary" data-testid="stock-search-btn">Search</button>
-                <button type="button" class="btn btn-outline-secondary" @onclick="ResetAsync" data-testid="stock-clear">Reset</button>
+            <div class="lk-field--filter stock-field stock-filter__sku">
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_sku"
+                              Placeholder="SKU e.g. SKU*"
+                              InputAttributes="@SkuAttributes" />
+            </div>
+
+            <div class="stock-filter__toggle" data-testid="stock-include-virtual">
+                <MudCheckBox T="bool"
+                             Dense="true"
+                             Label="Virtual"
+                             @bind-Checked="_includeVirtual" />
+            </div>
+
+            <div class="stock-filter__actions">
+                <MudButton ButtonType="ButtonType.Submit"
+                           Variant="Variant.Filled"
+                           Color="Color.Primary"
+                           UserAttributes="@SearchButtonAttributes">
+                    Search
+                </MudButton>
+                <MudButton ButtonType="ButtonType.Button"
+                           Variant="Variant.Outlined"
+                           OnClick="ResetAsync"
+                           UserAttributes="@ClearButtonAttributes">
+                    Reset
+                </MudButton>
             </div>
         </div>
-    </div>
+
+        @if (!string.IsNullOrWhiteSpace(_validationError))
+        {
+            <div class="lk-state lk-state--warn stock-filter__validation" data-testid="stock-validation-error">@_validationError</div>
+        }
+    </MudPaper>
 </form>
 
 @code {
@@ -59,6 +78,11 @@
     private string _sku = string.Empty;
     private bool _includeVirtual;
     private string? _validationError;
+    private static readonly Dictionary<string, object> WarehouseAttributes = new() { ["data-testid"] = "stock-warehouse", ["aria-label"] = "Warehouse" };
+    private static readonly Dictionary<string, object> LocationAttributes = new() { ["data-testid"] = "stock-location", ["aria-label"] = "Location" };
+    private static readonly Dictionary<string, object> SkuAttributes = new() { ["data-testid"] = "stock-search", ["aria-label"] = "SKU" };
+    private static readonly Dictionary<string, object> SearchButtonAttributes = new() { ["data-testid"] = "stock-search-btn" };
+    private static readonly Dictionary<string, object> ClearButtonAttributes = new() { ["data-testid"] = "stock-clear" };
 
     protected override void OnParametersSet()
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
@@ -1,7 +1,7 @@
 <form data-testid="stock-filters" @onsubmit="HandleSubmitAsync" @onsubmit:preventDefault="true">
     <MudPaper Outlined="true" Elevation="0" Class="panel stock-filter-panel">
         <div class="lk-toolbar stock-filter-toolbar">
-            <div class="lk-field--filter stock-field stock-filter__warehouse">
+            <div class="lk-field--filter stock-field stock-filter__warehouse" data-testid="stock-warehouse">
                 <MudSelect T="string"
                            Variant="Variant.Outlined"
                            Margin="Margin.Dense"
@@ -15,7 +15,7 @@
                 </MudSelect>
             </div>
 
-            <div class="lk-field--filter stock-field stock-filter__location">
+            <div class="lk-field--filter stock-field stock-filter__location" data-testid="stock-location">
                 <MudTextField T="string"
                               Variant="Variant.Outlined"
                               Margin="Margin.Dense"
@@ -24,7 +24,7 @@
                               InputAttributes="@LocationAttributes" />
             </div>
 
-            <div class="lk-field--filter stock-field stock-filter__sku">
+            <div class="lk-field--filter stock-field stock-filter__sku" data-testid="stock-search">
                 <MudTextField T="string"
                               Variant="Variant.Outlined"
                               Margin="Margin.Dense"
@@ -78,9 +78,9 @@
     private string _sku = string.Empty;
     private bool _includeVirtual;
     private string? _validationError;
-    private static readonly Dictionary<string, object> WarehouseAttributes = new() { ["data-testid"] = "stock-warehouse", ["aria-label"] = "Warehouse" };
-    private static readonly Dictionary<string, object> LocationAttributes = new() { ["data-testid"] = "stock-location", ["aria-label"] = "Location" };
-    private static readonly Dictionary<string, object> SkuAttributes = new() { ["data-testid"] = "stock-search", ["aria-label"] = "SKU" };
+    private static readonly Dictionary<string, object> WarehouseAttributes = new() { ["aria-label"] = "Warehouse" };
+    private static readonly Dictionary<string, object> LocationAttributes = new() { ["aria-label"] = "Location" };
+    private static readonly Dictionary<string, object> SkuAttributes = new() { ["aria-label"] = "SKU" };
     private static readonly Dictionary<string, object> SearchButtonAttributes = new() { ["data-testid"] = "stock-search-btn" };
     private static readonly Dictionary<string, object> ClearButtonAttributes = new() { ["data-testid"] = "stock-clear" };
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
@@ -21,49 +21,54 @@
     </div>
 }
 
-<div class="card shadow-sm position-relative">
+<MudPaper Outlined="true" Elevation="0" Class="panel stock-results-panel">
     <LoadingSpinner IsLoading="@(_isLoadingWarehouses || _isSearching)" />
 
-    <div class="card-body">
-        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-            <div class="text-muted" data-testid="stock-summary">
+        <div class="stock-grid-head">
+            <div class="stock-grid-head__summary" data-testid="stock-summary">
                 @_summaryText
             </div>
-            <div class="d-flex flex-wrap gap-2 align-items-center">
-                <div class="btn-group" role="group" aria-label="View mode">
-                    <button class="btn btn-sm @(GetModeClass(StockViewMode.Table))" @onclick="@(() => SetMode(StockViewMode.Table))">Table</button>
-                    <button class="btn btn-sm @(GetModeClass(StockViewMode.List))" @onclick="@(() => SetMode(StockViewMode.List))">List</button>
-                    <button class="btn btn-sm @(GetModeClass(StockViewMode.Gallery))" @onclick="@(() => SetMode(StockViewMode.Gallery))">Gallery</button>
+            <div class="stock-grid-head__actions">
+                <div class="stock-view-toggle" role="group" aria-label="View mode">
+                    <MudButton Size="Size.Small" Variant="@GetModeVariant(StockViewMode.Table)" Color="Color.Primary" OnClick="@(() => SetMode(StockViewMode.Table))">Table</MudButton>
+                    <MudButton Size="Size.Small" Variant="@GetModeVariant(StockViewMode.List)" Color="Color.Primary" OnClick="@(() => SetMode(StockViewMode.List))">List</MudButton>
+                    <MudButton Size="Size.Small" Variant="@GetModeVariant(StockViewMode.Gallery)" Color="Color.Primary" OnClick="@(() => SetMode(StockViewMode.Gallery))">Gallery</MudButton>
                 </div>
-                <label class="form-label mb-0 text-muted small" for="stock-page-size-select">Page size</label>
-                <select id="stock-page-size-select"
-                        class="form-select form-select-sm"
-                        style="width: 110px;"
-                        data-testid="stock-page-size"
-                        value="@_pageSize"
-                        @onchange="OnPageSizeChangedFromChangeEventAsync">
-                    <option value="25">25</option>
-                    <option value="50">50</option>
-                    <option value="100">100</option>
-                </select>
-                <button class="btn btn-outline-secondary btn-sm"
-                        data-testid="stock-refresh"
-                        @onclick="RefreshAsync"
-                        disabled="@(_isLoadingWarehouses || _isSearching)">
+                <div class="lk-field--filter stock-page-size" data-testid="stock-page-size">
+                    <MudSelect T="int"
+                               Variant="Variant.Outlined"
+                               Margin="Margin.Dense"
+                               Value="@_pageSize"
+                               ValueChanged="OnPageSizeChangedAsync"
+                               InputAttributes="@StockPageSizeAttributes">
+                        <MudSelectItem T="int" Value="25">25</MudSelectItem>
+                        <MudSelectItem T="int" Value="50">50</MudSelectItem>
+                        <MudSelectItem T="int" Value="100">100</MudSelectItem>
+                    </MudSelect>
+                </div>
+                <MudButton Variant="Variant.Outlined"
+                           Size="Size.Small"
+                           OnClick="RefreshAsync"
+                           Disabled="@(_isLoadingWarehouses || _isSearching)"
+                           UserAttributes="@StockRefreshAttributes">
                     Refresh
-                </button>
-                <button class="btn btn-outline-secondary btn-sm"
-                        data-testid="stock-export"
-                        @onclick="ExportCsvAsync"
-                        disabled="@(_items.Count == 0)">
+                </MudButton>
+                <MudButton Variant="Variant.Outlined"
+                           Size="Size.Small"
+                           OnClick="ExportCsvAsync"
+                           Disabled="@(_items.Count == 0)"
+                           UserAttributes="@StockExportAttributes">
                     Export CSV
-                </button>
+                </MudButton>
             </div>
         </div>
 
         @if (!_hasSearched)
         {
-            <p class="text-muted mb-0" data-testid="stock-before-search">Enter at least one filter and click Search.</p>
+            <div class="stock-grid__empty" data-testid="stock-before-search">
+                <span class="stock-grid__empty-title">Ready for search</span>
+                <span>Enter at least one filter and click Search.</span>
+            </div>
         }
         else
         {
@@ -76,34 +81,48 @@
                              Dense="true"
                              Hover="true"
                              Loading="@_isSearching"
+                             Class="lk-grid stock-grid"
                              @attributes="@StockGridAttributes">
                     <NoRecordsContent>
-                        <p class="text-muted mb-0 py-2">No stock found matching filters.</p>
+                        <div class="stock-grid__empty">
+                            <span class="stock-grid__empty-title">No stock found</span>
+                            <span>No stock matches the current filters.</span>
+                        </div>
                     </NoRecordsContent>
                     <Columns>
                         <TemplateColumn Title="">
                             <CellTemplate>
                                 @if (!string.IsNullOrWhiteSpace(context.Item.PrimaryThumbnailUrl))
                                 {
-                                    <img src="@context.Item.PrimaryThumbnailUrl" alt="@context.Item.SKU" loading="lazy" style="width:48px;height:48px;object-fit:cover;border-radius:4px;" />
+                                    <img class="stock-thumb" src="@context.Item.PrimaryThumbnailUrl" alt="@context.Item.SKU" loading="lazy" />
                                 }
                                 else
                                 {
-                                    <div class="bg-light border text-muted d-flex align-items-center justify-content-center" style="width:48px;height:48px;border-radius:4px;">-</div>
+                                    <span class="stock-thumb stock-thumb--empty">-</span>
                                 }
                             </CellTemplate>
                         </TemplateColumn>
                         <PropertyColumn Property="x => x.WarehouseId" Title="Warehouse" />
                         <PropertyColumn Property="x => x.Location" Title="Location" />
-                        <PropertyColumn Property="x => x.SKU" Title="SKU" />
+                        <TemplateColumn Title="SKU">
+                            <CellTemplate>
+                                <span class="sku-link">@context.Item.SKU</span>
+                            </CellTemplate>
+                        </TemplateColumn>
                         <PropertyColumn Property="x => x.ItemName" Title="Name" />
-                        <PropertyColumn Property="x => x.PhysicalQty" Title="Physical Qty" />
-                        <PropertyColumn Property="x => x.ReservedQty" Title="Reserved Qty" />
-                        <PropertyColumn Property="x => x.AvailableQty" Title="Available Qty" />
+                        <TemplateColumn Title="Physical">
+                            <CellTemplate><span class="is-num">@FormatQty(context.Item.PhysicalQty)</span></CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Reserved">
+                            <CellTemplate><span class="is-num">@FormatQty(context.Item.ReservedQty)</span></CellTemplate>
+                        </TemplateColumn>
+                        <TemplateColumn Title="Available">
+                            <CellTemplate><span class="is-num"><strong>@FormatQty(context.Item.AvailableQty)</strong></span></CellTemplate>
+                        </TemplateColumn>
                         <TemplateColumn Title="Last Updated">
                             <CellTemplate>
-                                @context.Item.LastUpdated.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")
-                                <span class="ms-2"><StaleBadge LastUpdated="context.Item.LastUpdated" /></span>
+                                <span class="mono">@context.Item.LastUpdated.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
+                                <span class="stock-stale"><StaleBadge LastUpdated="context.Item.LastUpdated" /></span>
                             </CellTemplate>
                         </TemplateColumn>
                     </Columns>
@@ -111,25 +130,25 @@
             }
             else if (_viewMode == StockViewMode.List)
             {
-                <div class="d-flex flex-column gap-2">
+                <div class="stock-list">
                     @foreach (var row in _items)
                     {
-                        <div class="border rounded p-2 d-flex align-items-center gap-3">
+                        <div class="stock-list-row">
                             @if (!string.IsNullOrWhiteSpace(row.PrimaryThumbnailUrl))
                             {
-                                <img src="@row.PrimaryThumbnailUrl" alt="@row.SKU" loading="lazy" style="width:64px;height:64px;object-fit:cover;border-radius:4px;" />
+                                <img class="stock-list-row__thumb" src="@row.PrimaryThumbnailUrl" alt="@row.SKU" loading="lazy" />
                             }
                             else
                             {
-                                <div class="bg-light border text-muted d-flex align-items-center justify-content-center" style="width:64px;height:64px;border-radius:4px;">-</div>
+                                <span class="stock-list-row__thumb stock-thumb--empty">-</span>
                             }
-                            <div class="flex-grow-1">
-                                <div><strong>@row.SKU</strong> - @row.ItemName</div>
-                                <div class="small text-muted">@row.WarehouseId / @row.Location</div>
+                            <div class="stock-list-row__main">
+                                <div><span class="sku-link">@row.SKU</span> @row.ItemName</div>
+                                <div class="stock-list-row__meta">@row.WarehouseId / @row.Location</div>
                             </div>
-                            <div class="text-end">
-                                <div>On hand: @row.PhysicalQty</div>
-                                <div>Available: @row.AvailableQty</div>
+                            <div class="stock-list-row__qty">
+                                <div>On hand: <span class="mono">@FormatQty(row.PhysicalQty)</span></div>
+                                <div>Available: <strong class="mono">@FormatQty(row.AvailableQty)</strong></div>
                             </div>
                         </div>
                     }
@@ -137,42 +156,39 @@
             }
             else
             {
-                <div class="row g-3">
+                <div class="stock-gallery">
                     @foreach (var row in _items)
                     {
-                        <div class="col-6 col-md-4 col-lg-3">
-                            <div class="card h-100">
-                                @if (!string.IsNullOrWhiteSpace(row.PrimaryThumbnailUrl))
-                                {
-                                    <img src="@row.PrimaryThumbnailUrl" alt="@row.SKU" loading="lazy" style="height:150px;object-fit:cover;" />
-                                }
-                                else
-                                {
-                                    <div class="bg-light border text-muted d-flex align-items-center justify-content-center" style="height:150px;">No image</div>
-                                }
-                                <div class="card-body">
-                                    <div><strong>@row.SKU</strong></div>
-                                    <div class="small text-muted mb-2">@row.ItemName</div>
-                                    <div class="small">@row.WarehouseId / @row.Location</div>
-                                    <div class="small">On hand: @row.PhysicalQty</div>
-                                    <div class="small">Available: @row.AvailableQty</div>
-                                </div>
+                        <div class="stock-gallery-card">
+                            @if (!string.IsNullOrWhiteSpace(row.PrimaryThumbnailUrl))
+                            {
+                                <img class="stock-gallery-card__image" src="@row.PrimaryThumbnailUrl" alt="@row.SKU" loading="lazy" />
+                            }
+                            else
+                            {
+                                <div class="stock-gallery-card__image stock-thumb--empty">No image</div>
+                            }
+                            <div class="stock-gallery-card__body">
+                                <div><span class="sku-link">@row.SKU</span></div>
+                                <div class="stock-list-row__meta">@row.ItemName</div>
+                                <div>@row.WarehouseId / @row.Location</div>
+                                <div>On hand: <span class="mono">@FormatQty(row.PhysicalQty)</span></div>
+                                <div>Available: <strong class="mono">@FormatQty(row.AvailableQty)</strong></div>
                             </div>
                         </div>
                     }
                 </div>
             }
 
-            <div class="mt-3">
-                <Pagination CurrentPage="@_page"
-                            TotalPages="@_totalPages"
-                            PageSize="@_pageSize"
-                            OnPageChanged="OnPageChangedAsync"
-                            OnPageSizeChanged="OnPageSizeChangedAsync" />
+            <div class="stock-grid-footer" data-testid="stock-pager">
+                <span class="mono">Page @_page of @_totalPages</span>
+                <div class="stock-grid-footer__actions">
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => OnPageChangedAsync(_page - 1))" Disabled="@(_page <= 1)">Previous</MudButton>
+                    <MudButton Variant="Variant.Outlined" Size="Size.Small" OnClick="@(() => OnPageChangedAsync(_page + 1))" Disabled="@(_page >= _totalPages)">Next</MudButton>
+                </div>
             </div>
         }
-    </div>
-</div>
+</MudPaper>
 </div>
 
 @code {
@@ -192,6 +208,9 @@
     private bool _isDisposed;
     private readonly CancellationTokenSource _disposeCts = new();
     private static readonly Dictionary<string, object> StockGridAttributes = new() { ["data-testid"] = "stock-grid" };
+    private static readonly Dictionary<string, object> StockPageSizeAttributes = new() { ["aria-label"] = "Page size" };
+    private static readonly Dictionary<string, object> StockRefreshAttributes = new() { ["data-testid"] = "stock-refresh" };
+    private static readonly Dictionary<string, object> StockExportAttributes = new() { ["data-testid"] = "stock-export" };
 
     private StockViewMode _viewMode = StockViewMode.Table;
     private int _totalPages => Math.Max(1, (int)Math.Ceiling(_totalCount / (double)Math.Max(1, _pageSize)));
@@ -366,23 +385,16 @@
         await LoadPageAsync(_page, _pageSize);
     }
 
-    private async Task OnPageSizeChangedFromChangeEventAsync(ChangeEventArgs args)
-    {
-        if (args.Value is null || !int.TryParse(args.Value.ToString(), out var parsed))
-        {
-            return;
-        }
-
-        await OnPageSizeChangedAsync(parsed);
-    }
-
     private void SetMode(StockViewMode mode)
     {
         _viewMode = mode;
     }
 
-    private string GetModeClass(StockViewMode mode)
-        => _viewMode == mode ? "btn-primary" : "btn-outline-primary";
+    private Variant GetModeVariant(StockViewMode mode)
+        => _viewMode == mode ? Variant.Filled : Variant.Outlined;
+
+    private static string FormatQty(decimal value)
+        => value.ToString("0.###");
 
     private static string BuildErrorMessage(ApiException ex)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockAdjustments.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/StockAdjustments.razor
@@ -15,106 +15,159 @@
     <ErrorBanner Message="@BuildErrorMessage(_apiError)" TraceId="@_apiError.TraceId" OnRetry="LoadHistoryAsync" OnDismiss="DismissError" />
 }
 
-<div class="card shadow-sm mb-3">
-    <div class="card-body">
-        <h5>Create Adjustment</h5>
-        <div class="row g-2">
-            <div class="col-md-3">
-                <label class="form-label">Item</label>
-                <select class="form-select" @bind="_itemId">
-                    <option value="0">Select item</option>
-                    @foreach (var item in _items)
-                    {
-                        <option value="@item.Id">@item.InternalSKU - @item.Name</option>
-                    }
-                </select>
-            </div>
-            <div class="col-md-3">
-                <label class="form-label">Location</label>
-                <select class="form-select" @bind="_locationId">
-                    <option value="0">Select location</option>
-                    @foreach (var loc in _locations)
-                    {
-                        <option value="@loc.Id">@loc.Code</option>
-                    }
-                </select>
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Qty Delta</label>
-                <input type="number" step="0.01" class="form-control" @bind="_qtyDelta" />
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Reason</label>
-                <select class="form-select" @bind="_reasonCode">
-                    <option value="">Select reason</option>
-                    @foreach (var reason in _reasons)
-                    {
-                        <option value="@reason.Code">@reason.Code</option>
-                    }
-                </select>
-            </div>
-            <div class="col-md-2">
-                <label class="form-label">Lot Id (optional)</label>
-                <input type="number" min="1" class="form-control" @bind="_lotId" />
-            </div>
-            <div class="col-12">
-                <label class="form-label">Notes</label>
-                <input class="form-control" @bind="_notes" />
-            </div>
+<MudPaper Outlined="true" Elevation="0" Class="panel adjustments-panel">
+    <div class="panel__head adjustments-panel__head">
+        <div>
+            <div class="panel__title">Create Adjustment</div>
+            <small>Post controlled stock corrections with a reason code.</small>
         </div>
-        <div class="mt-3 d-flex gap-2">
-            <button class="btn btn-primary" @onclick="CreateAsync" disabled="@_isSubmitting">Create</button>
-            <button class="btn btn-outline-secondary" @onclick="LoadHistoryAsync" disabled="@_isLoading">Refresh History</button>
+        <div class="panel__actions adjustments-panel__actions">
+            <MudButton Variant="Variant.Outlined"
+                       Color="Color.Primary"
+                       OnClick="LoadHistoryAsync"
+                       Disabled="@_isLoading">
+                Refresh History
+            </MudButton>
+            <MudButton Variant="Variant.Filled"
+                       Color="Color.Primary"
+                       OnClick="CreateAsync"
+                       Disabled="@_isSubmitting">
+                Create
+            </MudButton>
         </div>
-        @if (!string.IsNullOrWhiteSpace(_warning))
-        {
-            <div class="alert alert-warning mt-3 mb-0">@_warning</div>
-        }
     </div>
-</div>
 
-<div class="card shadow-sm position-relative">
-    <LoadingSpinner IsLoading="_isLoading" />
-    <div class="card-body">
-        <h5>Adjustment History</h5>
-        <div class="table-responsive">
-            <table class="table table-sm table-hover align-middle">
-                <thead>
-                    <tr>
-                        <th>Timestamp</th>
-                        <th>SKU</th>
-                        <th>Location</th>
-                        <th class="text-end">Qty Delta</th>
-                        <th>Reason</th>
-                        <th>User</th>
-                        <th>Notes</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    @if (_history.Count == 0)
-                    {
-                        <tr><td colspan="7">No adjustment records.</td></tr>
-                    }
-                    else
-                    {
-                        @foreach (var row in _history)
-                        {
-                            <tr>
-                                <td>@row.Timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
-                                <td>@row.ItemSku</td>
-                                <td>@row.LocationCode</td>
-                                <td class="text-end @(row.QtyDelta < 0 ? "text-danger" : "text-success")">@row.QtyDelta</td>
-                                <td>@row.ReasonCode</td>
-                                <td>@(row.UserName ?? row.UserId)</td>
-                                <td>@(row.Notes ?? "-")</td>
-                            </tr>
-                        }
-                    }
-                </tbody>
-            </table>
+    <div class="adjustment-form-grid">
+        <div class="lk-field--filter adjustment-field adjustment-field--item">
+            <MudSelect T="int"
+                       Label="Item"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       @bind-Value="_itemId">
+                <MudSelectItem T="int" Value="0">Select item</MudSelectItem>
+                @foreach (var item in _items)
+                {
+                    <MudSelectItem T="int" Value="@item.Id">@item.InternalSKU - @item.Name</MudSelectItem>
+                }
+            </MudSelect>
+        </div>
+
+        <div class="lk-field--filter adjustment-field adjustment-field--location">
+            <MudSelect T="int"
+                       Label="Location"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       @bind-Value="_locationId">
+                <MudSelectItem T="int" Value="0">Select location</MudSelectItem>
+                @foreach (var loc in _locations)
+                {
+                    <MudSelectItem T="int" Value="@loc.Id">@loc.Code</MudSelectItem>
+                }
+            </MudSelect>
+        </div>
+
+        <div class="lk-field--filter adjustment-field adjustment-field--qty">
+            <MudNumericField T="decimal"
+                             Label="Qty Delta"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Step="0.01m"
+                             @bind-Value="_qtyDelta" />
+        </div>
+
+        <div class="lk-field--filter adjustment-field adjustment-field--reason">
+            <MudSelect T="string"
+                       Label="Reason"
+                       Variant="Variant.Outlined"
+                       Margin="Margin.Dense"
+                       @bind-Value="_reasonCode">
+                <MudSelectItem T="string" Value="@string.Empty">Select reason</MudSelectItem>
+                @foreach (var reason in _reasons)
+                {
+                    <MudSelectItem T="string" Value="@reason.Code">@reason.Code</MudSelectItem>
+                }
+            </MudSelect>
+        </div>
+
+        <div class="lk-field--filter adjustment-field adjustment-field--lot">
+            <MudNumericField T="int?"
+                             Label="Lot Id"
+                             Variant="Variant.Outlined"
+                             Margin="Margin.Dense"
+                             Min="1"
+                             @bind-Value="_lotId" />
+        </div>
+
+        <div class="lk-field--filter adjustment-field adjustment-field--notes">
+            <MudTextField T="string"
+                          Label="Notes"
+                          Variant="Variant.Outlined"
+                          Margin="Margin.Dense"
+                          @bind-Value="_notes" />
         </div>
     </div>
-</div>
+
+    @if (!string.IsNullOrWhiteSpace(_warning))
+    {
+        <div class="lk-state lk-state--warn adjustment-warning">@_warning</div>
+    }
+</MudPaper>
+
+<MudPaper Outlined="true" Elevation="0" Class="panel adjustments-history-panel">
+    <LoadingSpinner IsLoading="_isLoading" />
+    <div class="panel__head">
+        <div>
+            <div class="panel__title">Adjustment History</div>
+            <small>Latest 200 records</small>
+        </div>
+    </div>
+
+    <div class="adjustments-table-wrap">
+        <table class="lk-table adjustments-table">
+            <thead>
+                <tr>
+                    <th>Timestamp</th>
+                    <th>SKU</th>
+                    <th>Location</th>
+                    <th class="is-num">Qty Delta</th>
+                    <th>Reason</th>
+                    <th>User</th>
+                    <th>Notes</th>
+                </tr>
+            </thead>
+            <tbody>
+                @if (_history.Count == 0)
+                {
+                    <tr>
+                        <td colspan="7">
+                            <div class="stock-grid__empty adjustments-empty">
+                                <span class="stock-grid__empty-title">No adjustments</span>
+                                <span>No adjustment records are available yet.</span>
+                            </div>
+                        </td>
+                    </tr>
+                }
+                else
+                {
+                    @foreach (var row in _history)
+                    {
+                        <tr>
+                            <td class="mono">@row.Timestamp.ToLocalTime().ToString("yyyy-MM-dd HH:mm")</td>
+                            <td class="mono">@row.ItemSku</td>
+                            <td class="mono">@row.LocationCode</td>
+                            <td class="is-num">
+                                <span class="@GetDeltaChipClass(row.QtyDelta)">@FormatDelta(row.QtyDelta)</span>
+                            </td>
+                            <td><span class="chip chip--slate">@row.ReasonCode</span></td>
+                            <td>@(row.UserName ?? row.UserId)</td>
+                            <td class="adjustments-table__notes">@(row.Notes ?? "-")</td>
+                        </tr>
+                    }
+                }
+            </tbody>
+        </table>
+    </div>
+</MudPaper>
 
 @code {
     private readonly List<AdminItemDto> _items = [];
@@ -225,6 +278,12 @@
     }
 
     private void DismissError() => _apiError = null;
+
+    private static string FormatDelta(decimal value)
+        => value > 0 ? $"+{value:0.###}" : value.ToString("0.###");
+
+    private static string GetDeltaChipClass(decimal value)
+        => value < 0 ? "chip chip--out" : "chip chip--ok";
 
     private static string BuildErrorMessage(ApiException ex)
         => ex.UserMessage

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -402,7 +402,8 @@ h1:focus { outline: none; }
 .chip--ok       { background: var(--ok-bg);     color: var(--ok-fg);     border-color: var(--ok-bd); }
 .chip--low      { background: var(--warn-bg);    color: var(--warn-fg);   border-color: var(--warn-bd); }
 .chip--out      { background: var(--danger-bg);  color: var(--danger-fg); border-color: var(--danger-bd); }
-.chip--locked   { background: var(--slate-bg);   color: var(--slate-fg);  border-color: var(--slate-bd); }
+.chip--locked,
+.chip--slate    { background: var(--slate-bg);   color: var(--slate-fg);  border-color: var(--slate-bd); }
 .chip--reserved { background: var(--info-bg);    color: var(--info-fg);   border-color: var(--info-bd); }
 
 .chip--entered    { background: var(--slate-bg);  color: var(--slate-fg);  border-color: var(--slate-bd); }
@@ -759,6 +760,313 @@ td.is-num strong { font-weight: 700; }
   color: var(--accent-700);
   cursor: pointer;
   font-weight: 700;
+}
+
+.stock-filter-panel,
+.stock-results-panel {
+  margin-bottom: 12px;
+}
+
+.stock-filter-toolbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px 10px;
+  padding: 6px 12px;
+  background: var(--n-25);
+}
+
+.stock-field {
+  min-width: 0;
+}
+
+.stock-filter__warehouse {
+  flex: 0 1 240px;
+}
+
+.stock-filter__location,
+.stock-filter__sku {
+  flex: 1 1 220px;
+}
+
+.stock-filter__toggle {
+  display: flex;
+  align-items: center;
+  min-height: var(--control-h);
+  color: var(--n-600);
+  font-size: 12px;
+  white-space: nowrap;
+}
+
+.stock-filter__actions,
+.stock-grid-head__actions,
+.stock-grid-footer__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.stock-filter__actions .mud-button-root,
+.stock-grid-head__actions .mud-button-root,
+.stock-grid-footer__actions .mud-button-root {
+  min-height: var(--control-h);
+  padding: 0 12px;
+}
+
+.stock-filter__validation {
+  margin: 0 12px 10px;
+}
+
+.stock-grid-head,
+.stock-grid-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 38px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--n-150);
+  background: var(--n-25);
+}
+
+.stock-grid-footer {
+  border-top: 1px solid var(--n-150);
+  border-bottom: 0;
+  color: var(--n-600);
+  font-size: 12px;
+}
+
+.stock-grid-head__summary {
+  color: var(--n-600);
+  font-size: 12.5px;
+}
+
+.stock-view-toggle {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.stock-page-size {
+  width: 76px;
+}
+
+.stock-thumb,
+.stock-list-row__thumb {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: var(--r-sm);
+  object-fit: cover;
+  vertical-align: middle;
+}
+
+.stock-thumb--empty {
+  border: 1px solid var(--n-200);
+  background: var(--n-50);
+  color: var(--n-400);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+
+.stock-stale {
+  margin-left: 6px;
+}
+
+.stock-grid__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 3px;
+  padding: 18px 16px;
+  color: var(--n-500);
+  font-size: 12.5px;
+  text-align: center;
+}
+
+.stock-grid__empty-title {
+  color: var(--n-600);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+}
+
+.stock-list {
+  display: grid;
+  gap: 0;
+}
+
+.stock-list-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-top: 1px solid var(--n-100);
+}
+
+.stock-list-row:first-child {
+  border-top: 0;
+}
+
+.stock-list-row__thumb {
+  width: 36px;
+  height: 36px;
+  flex: 0 0 36px;
+}
+
+.stock-list-row__main {
+  min-width: 0;
+  flex: 1;
+}
+
+.stock-list-row__meta {
+  color: var(--n-500);
+  font-size: 12px;
+}
+
+.stock-list-row__qty {
+  color: var(--n-700);
+  font-size: 12px;
+  text-align: right;
+}
+
+.stock-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: 10px;
+  padding: 12px;
+}
+
+.stock-gallery-card {
+  overflow: hidden;
+  border: 1px solid var(--n-200);
+  border-radius: var(--r-md);
+  background: var(--n-0);
+}
+
+.stock-gallery-card__image {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+}
+
+.stock-gallery-card__body {
+  display: grid;
+  gap: 3px;
+  padding: 8px 10px;
+  color: var(--n-700);
+  font-size: 12px;
+}
+
+.adjustments-panel,
+.adjustments-history-panel {
+  margin-bottom: 12px;
+}
+
+.adjustments-panel__head {
+  align-items: flex-start;
+}
+
+.adjustments-panel__head small,
+.adjustments-history-panel .panel__head small {
+  color: var(--n-500);
+  font-size: 12px;
+}
+
+.adjustments-panel__actions {
+  flex-shrink: 0;
+}
+
+.adjustment-form-grid {
+  display: grid;
+  grid-template-columns: minmax(260px, 1.4fr) minmax(180px, 0.9fr) minmax(110px, 0.5fr) minmax(160px, 0.7fr) minmax(100px, 0.45fr);
+  gap: 10px;
+  padding: 12px;
+  background: var(--n-0);
+}
+
+.adjustment-field {
+  min-width: 0;
+}
+
+.adjustment-field--notes {
+  grid-column: 1 / -1;
+}
+
+.adjustment-warning {
+  margin: 0 12px 12px;
+}
+
+.adjustments-table-wrap {
+  overflow-x: auto;
+}
+
+.adjustments-table thead th {
+  white-space: nowrap;
+}
+
+.adjustments-table tbody td {
+  vertical-align: middle;
+}
+
+.adjustments-table tbody tr:first-child td {
+  border-top: 0;
+}
+
+.adjustments-table .chip {
+  justify-content: center;
+  min-width: 64px;
+}
+
+.adjustments-table__notes {
+  max-width: 320px;
+  color: var(--n-600);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.adjustments-empty {
+  padding: 12px 16px;
+}
+
+@media (max-width: 720px) {
+  .stock-filter__warehouse,
+  .stock-filter__location,
+  .stock-filter__sku,
+  .stock-filter__toggle,
+  .stock-filter__actions,
+  .stock-grid-head__actions {
+    flex: 1 1 100%;
+  }
+
+  .stock-grid-head,
+  .stock-grid-footer,
+  .stock-list-row {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .stock-list-row__qty {
+    text-align: left;
+  }
+
+  .adjustments-panel__head,
+  .adjustments-panel__actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .adjustment-form-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 720px) {

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/Ui/MudBlazorGridFullFlowTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/Ui/MudBlazorGridFullFlowTests.cs
@@ -35,7 +35,7 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
             await lotHeader.ClickAsync();
             await Expect(ByTestId(page, "lots-grid")).ToBeVisibleAsync();
 
-            await TrySelectLotsPageSizeAsync(page, "25");
+            await TrySelectMudSelectOptionAsync(page, "lots-page-size", "25");
             await EnsureMudOverlayClosedAsync(page);
 
             await TryChangePageAsync(page, "lots-pager", "lots-current-page");
@@ -63,7 +63,7 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
             await Expect(ByTestId(page, "stock-grid")).ToBeVisibleAsync();
             await Expect(ByTestId(page, "stock-summary")).ToContainTextAsync("Showing");
 
-            await ByTestId(page, "stock-include-virtual").CheckAsync();
+            await TrySetCheckboxAsync(page, "stock-include-virtual", true);
             await ByTestId(page, "stock-search-btn").ClickAsync();
             await Expect(ByTestId(page, "stock-grid")).ToBeVisibleAsync();
 
@@ -71,8 +71,8 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
             await skuHeader.ClickAsync();
             await Expect(ByTestId(page, "stock-grid")).ToBeVisibleAsync();
 
-            await ByTestId(page, "stock-page-size").SelectOptionAsync("25");
-            Assert.Equal("25", await ByTestId(page, "stock-page-size").InputValueAsync());
+            await TrySelectMudSelectOptionAsync(page, "stock-page-size", "25");
+            await Expect(ByTestId(page, "stock-grid")).ToBeVisibleAsync();
 
             await TryChangePageAsync(page, "stock-pager", "stock-summary");
 
@@ -169,9 +169,9 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
         await Expect(ByTestId(page, "stock-search")).ToBeVisibleAsync();
     }
 
-    private static async Task TrySelectLotsPageSizeAsync(IPage page, string optionText)
+    private static async Task TrySelectMudSelectOptionAsync(IPage page, string testId, string optionText)
     {
-        var scope = ByTestId(page, "lots-page-size");
+        var scope = ByTestId(page, testId);
         if (await scope.CountAsync() == 0)
         {
             return;
@@ -220,6 +220,28 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
         }
 
         await EnsureMudOverlayClosedAsync(page);
+    }
+
+    private static async Task TrySetCheckboxAsync(IPage page, string testId, bool isChecked)
+    {
+        var scope = ByTestId(page, testId);
+        if (await scope.CountAsync() == 0)
+        {
+            return;
+        }
+
+        var target = scope.GetByRole(AriaRole.Checkbox);
+        if (await target.CountAsync() == 0)
+        {
+            target = scope.Locator("input[type='checkbox']");
+        }
+
+        if (await target.CountAsync() == 0)
+        {
+            target = scope;
+        }
+
+        await target.First.SetCheckedAsync(isChecked);
     }
 
     private static async Task EnsureMudOverlayClosedAsync(IPage page)

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/Ui/MudBlazorGridFullFlowTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/Ui/MudBlazorGridFullFlowTests.cs
@@ -128,7 +128,7 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
         {
             await WaitForStockFiltersReadyAsync(page);
 
-            var stockSearch = ByTestId(page, "stock-search");
+            var stockSearch = StockSearchInput(page);
             await Expect(stockSearch).ToBeVisibleAsync();
             await stockSearch.FillAsync(searchValue);
             await stockSearch.PressAsync("Tab");
@@ -166,8 +166,11 @@ public sealed class MudBlazorGridFullFlowTests : PlaywrightUiTestBase
             });
         }
 
-        await Expect(ByTestId(page, "stock-search")).ToBeVisibleAsync();
+        await Expect(StockSearchInput(page)).ToBeVisibleAsync();
     }
+
+    private static ILocator StockSearchInput(IPage page)
+        => ByTestId(page, "stock-search").GetByRole(AriaRole.Textbox).First;
 
     private static async Task TrySelectMudSelectOptionAsync(IPage page, string testId, string optionText)
     {


### PR DESCRIPTION
## Summary
- updates Phase 1 strategy to golden screens: Available Stock, Lots, Stock Adjustments
- migrates Available Stock filters/results to the compact MudBlazor panel, toolbar, grid/list/gallery pattern
- migrates Stock Adjustments to the workflow + dense history pattern and keeps Lots as the CRUD/list reference
- updates E2E helpers for MudSelect and MudCheckBox controls

## Validation
- dotnet build src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/LKvitai.MES.Modules.Warehouse.WebUI.csproj
- dotnet build tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.E2E/LKvitai.MES.Tests.Warehouse.E2E.csproj
- git diff --check

## Notes
- Local MudBlazorGridFullFlowTests run could not start because this machine is missing pwsh and the Playwright Chromium browser install.