### PR TITLE
[codex] make Shopfloor workflow prototype full bleed

### DIFF
--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
@@ -3,23 +3,7 @@
 <PageTitle>LKvitai.MES · Workflow Editor</PageTitle>
 
 <main class="workflow-page workflow-page--embed">
-    <section class="workflow-head">
-        <div>
-            <div class="eyebrow mono">Shopfloor · Engineering</div>
-            <h1>Workflow editor</h1>
-            <p>Embedded working ShopfloorPilot prototype for product routing, task dependencies and runtime formulas.</p>
-        </div>
-        <div class="workflow-head__meta">
-            <span class="chip chip--info">Product <span class="mono">ROLLER_STD</span></span>
-            <a class="workflow-open-link" href="prototypes/shopfloor-workflow-editor-prototype.html" target="_blank" rel="noopener noreferrer">
-                Open prototype
-            </a>
-        </div>
-    </section>
-
-    <section class="workflow-embed-shell" aria-label="Workflow editor prototype">
-        <iframe class="workflow-embed"
-                src="prototypes/shopfloor-workflow-editor-prototype.html"
-                title="Shopfloor workflow editor prototype"></iframe>
-    </section>
+    <iframe class="workflow-embed"
+            src="prototypes/shopfloor-workflow-editor-prototype.html"
+            title="Shopfloor workflow editor prototype"></iframe>
 </main>

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/css/shopfloor.css
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/css/shopfloor.css
@@ -576,74 +576,24 @@ body {
 
 .workflow-page--embed {
   display: flex;
-  min-height: calc(100vh - 48px);
+  width: 100%;
+  max-width: none;
+  height: 100%;
+  min-height: calc(100vh - 92px);
   flex-direction: column;
-}
-
-.workflow-embed-shell {
-  flex: 1;
-  min-height: 720px;
+  margin: 0;
+  padding: 0;
   overflow: hidden;
-  border: 1px solid var(--n-200);
-  border-radius: var(--r-lg);
-  background: var(--n-0);
-  box-shadow: 0 1px 2px rgb(15 23 42 / 4%);
 }
 
 .workflow-embed {
   display: block;
+  flex: 1;
   width: 100%;
   height: 100%;
-  min-height: 720px;
+  min-height: calc(100vh - 92px);
   border: 0;
   background: var(--n-0);
-}
-
-.workflow-open-link {
-  display: inline-flex;
-  align-items: center;
-  min-height: 28px;
-  padding: 4px 10px;
-  border: 1px solid var(--n-200);
-  border-radius: var(--r-sm);
-  background: var(--n-0);
-  color: var(--accent-700);
-  font-size: 12px;
-  font-weight: 700;
-  text-decoration: none;
-}
-
-.workflow-page {
-  max-width: var(--content-max, 1600px);
-  margin: 0 auto;
-  padding: 24px clamp(18px, 2vw, 32px) 44px;
-}
-
-.workflow-head {
-  display: flex;
-  align-items: flex-end;
-  justify-content: space-between;
-  gap: 20px;
-  margin-bottom: 14px;
-}
-
-.workflow-head h1 {
-  margin: 4px 0 6px;
-  font-size: 26px;
-  line-height: 1.15;
-}
-
-.workflow-head p {
-  margin: 0;
-  color: var(--n-600);
-  font-size: 14px;
-}
-
-.workflow-head__meta {
-  display: flex;
-  flex-wrap: wrap;
-  justify-content: flex-end;
-  gap: 8px;
 }
 
 @media (max-width: 960px) {
@@ -658,19 +608,10 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .workflow-head {
-    align-items: stretch;
-    flex-direction: column;
-  }
-
-  .workflow-head__meta {
-    justify-content: flex-start;
-  }
 }
 
 @media (max-width: 640px) {
-  .shopfloor-page,
-  .workflow-page {
+  .shopfloor-page {
     padding: 16px 12px 32px;
   }
 
@@ -678,7 +619,6 @@ body {
     grid-template-columns: 1fr;
   }
 
-  .workflow-embed-shell,
   .workflow-embed {
     min-height: 620px;
   }


### PR DESCRIPTION
## Summary
- remove the extra Workflow Editor wrapper header/card around the embedded prototype
- let the working prototype iframe fill the Shopfloor module content area from sidebar to the right edge
- remove stale workflow mock CSS that was constraining the page width and adding padding

## Verification
- dotnet build src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/LKvitai.MES.Modules.Shopfloor.WebUI.csproj -c Release
- git diff --check
- local HTTP smoke: /workflow-editor and /prototypes/shopfloor-workflow-editor-prototype.html returned 200