### PR TITLE
Add available stock metadata filters

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
@@ -35,6 +35,11 @@ public sealed class StockController : ControllerBase
         [FromQuery] string? warehouse = null,
         [FromQuery] string? location = null,
         [FromQuery] string? sku = null,
+        [FromQuery] string? item = null,
+        [FromQuery] string? itemName = null,
+        [FromQuery] string? tag = null,
+        [FromQuery] string? supplier = null,
+        [FromQuery] string? supplierCountry = null,
         [FromQuery] int? itemId = null,
         [FromQuery] int? locationId = null,
         [FromQuery] int? categoryId = null,
@@ -53,6 +58,11 @@ public sealed class StockController : ControllerBase
                           !exportCsv &&
                           string.IsNullOrWhiteSpace(location) &&
                           string.IsNullOrWhiteSpace(sku) &&
+                          string.IsNullOrWhiteSpace(item) &&
+                          string.IsNullOrWhiteSpace(itemName) &&
+                          string.IsNullOrWhiteSpace(tag) &&
+                          string.IsNullOrWhiteSpace(supplier) &&
+                          string.IsNullOrWhiteSpace(supplierCountry) &&
                           !categoryId.HasValue &&
                           !expiringBefore.HasValue &&
                           pageNumber == 1 &&
@@ -101,6 +111,33 @@ public sealed class StockController : ControllerBase
             .ToDictionaryAsync(x => x.InternalSKU, cancellationToken);
 
         var itemIds = itemMap.Values.Select(x => x.Id).Distinct().ToList();
+        var metadataFilters = new AvailableStockMetadataFilters(item, itemName, tag, supplier, supplierCountry);
+        HashSet<int>? metadataFilteredItemIds = null;
+
+        if (metadataFilters.HasAny)
+        {
+            IReadOnlyList<SupplierItemMapping> supplierMappings = metadataFilters.NeedsSupplierData
+                ? await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(
+                    _dbContext.SupplierItemMappings
+                        .AsNoTracking()
+                        .Include(x => x.Supplier)
+                        .Where(x => itemIds.Contains(x.ItemId)),
+                    cancellationToken)
+                : Array.Empty<SupplierItemMapping>();
+
+            IReadOnlyList<ItemPhoto> taggedPhotos = metadataFilters.NeedsTagData
+                ? await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(
+                    _dbContext.ItemPhotos
+                        .AsNoTracking()
+                        .Where(x => itemIds.Contains(x.ItemId) && x.Tags != null && x.Tags != ""),
+                    cancellationToken)
+                : Array.Empty<ItemPhoto>();
+
+            metadataFilteredItemIds = StockMetadataFilter
+                .FilterItemIds(itemMap.Values, supplierMappings, taggedPhotos, metadataFilters)
+                .ToHashSet();
+        }
+
         var primaryPhotoByItemId = await _dbContext.ItemPhotos
             .AsNoTracking()
             .Where(x => itemIds.Contains(x.ItemId) && x.IsPrimary)
@@ -151,6 +188,11 @@ public sealed class StockController : ControllerBase
         if (categoryId.HasValue)
         {
             mapped = mapped.Where(x => x.CategoryId == categoryId.Value);
+        }
+
+        if (metadataFilteredItemIds is not null)
+        {
+            mapped = mapped.Where(x => x.ItemId.HasValue && metadataFilteredItemIds.Contains(x.ItemId.Value));
         }
 
         if (!includeVirtualLocations)
@@ -523,4 +565,184 @@ public sealed class StockController : ControllerBase
         int TotalCount,
         int PageNumber,
         int PageSize);
+}
+
+public sealed record AvailableStockMetadataFilters(
+    string? Item,
+    string? ItemName,
+    string? Tag,
+    string? Supplier,
+    string? SupplierCountry)
+{
+    public string ItemFilter { get; } = Item?.Trim() ?? string.Empty;
+    public string ItemNameFilter { get; } = ItemName?.Trim() ?? string.Empty;
+    public string TagFilter { get; } = Tag?.Trim() ?? string.Empty;
+    public string SupplierFilter { get; } = Supplier?.Trim() ?? string.Empty;
+    public string SupplierCountryFilter { get; } = SupplierCountry?.Trim() ?? string.Empty;
+
+    public bool HasAny =>
+        !string.IsNullOrWhiteSpace(ItemFilter) ||
+        !string.IsNullOrWhiteSpace(ItemNameFilter) ||
+        !string.IsNullOrWhiteSpace(TagFilter) ||
+        !string.IsNullOrWhiteSpace(SupplierFilter) ||
+        !string.IsNullOrWhiteSpace(SupplierCountryFilter);
+
+    public bool NeedsSupplierData =>
+        !string.IsNullOrWhiteSpace(SupplierFilter) ||
+        !string.IsNullOrWhiteSpace(SupplierCountryFilter);
+
+    public bool NeedsTagData => !string.IsNullOrWhiteSpace(TagFilter);
+}
+
+public static class StockMetadataFilter
+{
+    public static IReadOnlyCollection<int> FilterItemIds(
+        IEnumerable<Item> items,
+        IEnumerable<SupplierItemMapping> supplierMappings,
+        IEnumerable<ItemPhoto> itemPhotos,
+        AvailableStockMetadataFilters filters)
+    {
+        var itemList = items.ToList();
+        var result = itemList.Select(x => x.Id).ToHashSet();
+
+        if (!string.IsNullOrWhiteSpace(filters.ItemFilter))
+        {
+            IntersectWith(result, itemList
+                .Where(x =>
+                    MatchesPattern(x.InternalSKU, filters.ItemFilter) ||
+                    MatchesPattern(x.Name, filters.ItemFilter) ||
+                    MatchesPattern(x.ProductConfigId, filters.ItemFilter))
+                .Select(x => x.Id));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters.ItemNameFilter))
+        {
+            IntersectWith(result, itemList
+                .Where(x => MatchesPattern(x.Name, filters.ItemNameFilter))
+                .Select(x => x.Id));
+        }
+
+        if (!string.IsNullOrWhiteSpace(filters.TagFilter))
+        {
+            IntersectWith(result, itemPhotos
+                .Where(x => MatchesTag(x.Tags, filters.TagFilter))
+                .Select(x => x.ItemId)
+                .Distinct());
+        }
+
+        if (filters.NeedsSupplierData)
+        {
+            IntersectWith(result, supplierMappings
+                .Where(x => MatchesSupplier(x, filters.SupplierFilter) &&
+                            MatchesSupplierCountry(x, filters.SupplierCountryFilter))
+                .Select(x => x.ItemId)
+                .Distinct());
+        }
+
+        return result;
+    }
+
+    public static bool MatchesPattern(string? value, string pattern)
+    {
+        if (string.IsNullOrWhiteSpace(pattern))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return false;
+        }
+
+        var normalizedPattern = pattern.Trim();
+        if (normalizedPattern == "*")
+        {
+            return true;
+        }
+
+        var isPrefix = normalizedPattern.EndsWith('*');
+        var isSuffix = normalizedPattern.StartsWith('*');
+        var token = normalizedPattern.Trim('*');
+        if (string.IsNullOrEmpty(token))
+        {
+            return true;
+        }
+
+        var comparison = StringComparison.OrdinalIgnoreCase;
+        if (isPrefix && isSuffix)
+        {
+            return value.Contains(token, comparison);
+        }
+
+        if (isPrefix)
+        {
+            return value.StartsWith(token, comparison);
+        }
+
+        if (isSuffix)
+        {
+            return value.EndsWith(token, comparison);
+        }
+
+        return value.Contains(token, comparison);
+    }
+
+    private static void IntersectWith(HashSet<int> current, IEnumerable<int> next)
+    {
+        current.IntersectWith(next);
+    }
+
+    private static bool MatchesSupplier(SupplierItemMapping mapping, string supplierFilter)
+    {
+        if (string.IsNullOrWhiteSpace(supplierFilter))
+        {
+            return true;
+        }
+
+        return MatchesPattern(mapping.SupplierSKU, supplierFilter) ||
+               MatchesPattern(mapping.Supplier?.Code, supplierFilter) ||
+               MatchesPattern(mapping.Supplier?.Name, supplierFilter) ||
+               MatchesPattern(mapping.Supplier?.ShortName, supplierFilter) ||
+               MatchesPattern(mapping.Supplier?.CompanyCode, supplierFilter);
+    }
+
+    private static bool MatchesSupplierCountry(SupplierItemMapping mapping, string supplierCountryFilter)
+    {
+        if (string.IsNullOrWhiteSpace(supplierCountryFilter))
+        {
+            return true;
+        }
+
+        return MatchesPattern(mapping.Supplier?.Country, supplierCountryFilter);
+    }
+
+    private static bool MatchesTag(string? tags, string tagFilter)
+    {
+        if (string.IsNullOrWhiteSpace(tagFilter))
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return false;
+        }
+
+        var normalizedFilter = NormalizeTag(tagFilter);
+        if (string.IsNullOrWhiteSpace(normalizedFilter))
+        {
+            return true;
+        }
+
+        if (MatchesPattern(tags, normalizedFilter) || MatchesPattern(tags, "#" + normalizedFilter))
+        {
+            return true;
+        }
+
+        var tokens = tags.Split([',', ';', '|', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+        return tokens.Any(token => string.Equals(NormalizeTag(token), normalizedFilter, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static string NormalizeTag(string value)
+        => value.Trim().TrimStart('#');
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Components/Stock/StockFilters.razor
@@ -2,9 +2,11 @@
     <MudPaper Outlined="true" Elevation="0" Class="panel stock-filter-panel">
         <div class="lk-toolbar stock-filter-toolbar">
             <div class="lk-field--filter stock-field stock-filter__warehouse" data-testid="stock-warehouse">
+                <span class="stock-field__label">Warehouse</span>
                 <MudSelect T="string"
                            Variant="Variant.Outlined"
                            Margin="Margin.Dense"
+                           Placeholder="All warehouses"
                            @bind-Value="_warehouse"
                            InputAttributes="@WarehouseAttributes">
                     <MudSelectItem T="string" Value="@string.Empty">All warehouses</MudSelectItem>
@@ -16,6 +18,7 @@
             </div>
 
             <div class="lk-field--filter stock-field stock-filter__location" data-testid="stock-location">
+                <span class="stock-field__label">Location</span>
                 <MudTextField T="string"
                               Variant="Variant.Outlined"
                               Margin="Margin.Dense"
@@ -25,18 +28,69 @@
             </div>
 
             <div class="lk-field--filter stock-field stock-filter__sku" data-testid="stock-search">
+                <span class="stock-field__label">SKU</span>
                 <MudTextField T="string"
                               Variant="Variant.Outlined"
                               Margin="Margin.Dense"
                               @bind-Value="_sku"
-                              Placeholder="SKU e.g. SKU*"
+                              Placeholder="SKU e.g. RM-*"
                               InputAttributes="@SkuAttributes" />
+            </div>
+
+            <div class="lk-field--filter stock-field stock-filter__item" data-testid="stock-item">
+                <span class="stock-field__label">Product / item</span>
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_item"
+                              Placeholder="Product code or name"
+                              InputAttributes="@ItemAttributes" />
+            </div>
+
+            <div class="lk-field--filter stock-field stock-filter__item-name" data-testid="stock-item-name">
+                <span class="stock-field__label">Name</span>
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_itemName"
+                              Placeholder="Item name"
+                              InputAttributes="@ItemNameAttributes" />
+            </div>
+
+            <div class="lk-field--filter stock-field stock-filter__tag" data-testid="stock-tag">
+                <span class="stock-field__label">Tag</span>
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_tag"
+                              Placeholder="#tag"
+                              InputAttributes="@TagAttributes" />
+            </div>
+
+            <div class="lk-field--filter stock-field stock-filter__supplier" data-testid="stock-supplier">
+                <span class="stock-field__label">Supplier</span>
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_supplier"
+                              Placeholder="Supplier code or name"
+                              InputAttributes="@SupplierAttributes" />
+            </div>
+
+            <div class="lk-field--filter stock-field stock-filter__supplier-country" data-testid="stock-supplier-country">
+                <span class="stock-field__label">Supplier country</span>
+                <MudTextField T="string"
+                              Variant="Variant.Outlined"
+                              Margin="Margin.Dense"
+                              @bind-Value="_supplierCountry"
+                              Placeholder="Country"
+                              InputAttributes="@SupplierCountryAttributes" />
             </div>
 
             <div class="stock-filter__toggle" data-testid="stock-include-virtual">
                 <MudCheckBox T="bool"
                              Dense="true"
-                             Label="Virtual"
+                             Label="Include virtual"
                              @bind-Checked="_includeVirtual" />
             </div>
 
@@ -76,19 +130,34 @@
     private string? _warehouse;
     private string _location = string.Empty;
     private string _sku = string.Empty;
+    private string _item = string.Empty;
+    private string _itemName = string.Empty;
+    private string _tag = string.Empty;
+    private string _supplier = string.Empty;
+    private string _supplierCountry = string.Empty;
     private bool _includeVirtual;
     private string? _validationError;
     private static readonly Dictionary<string, object> WarehouseAttributes = new() { ["aria-label"] = "Warehouse" };
     private static readonly Dictionary<string, object> LocationAttributes = new() { ["aria-label"] = "Location" };
     private static readonly Dictionary<string, object> SkuAttributes = new() { ["aria-label"] = "SKU" };
+    private static readonly Dictionary<string, object> ItemAttributes = new() { ["aria-label"] = "Product or item" };
+    private static readonly Dictionary<string, object> ItemNameAttributes = new() { ["aria-label"] = "Item name" };
+    private static readonly Dictionary<string, object> TagAttributes = new() { ["aria-label"] = "Tag" };
+    private static readonly Dictionary<string, object> SupplierAttributes = new() { ["aria-label"] = "Supplier" };
+    private static readonly Dictionary<string, object> SupplierCountryAttributes = new() { ["aria-label"] = "Supplier country" };
     private static readonly Dictionary<string, object> SearchButtonAttributes = new() { ["data-testid"] = "stock-search-btn" };
     private static readonly Dictionary<string, object> ClearButtonAttributes = new() { ["data-testid"] = "stock-clear" };
 
     protected override void OnParametersSet()
     {
-        _warehouse = Filters.Warehouse;
+        _warehouse = Filters.Warehouse ?? string.Empty;
         _location = Filters.Location;
         _sku = Filters.Sku;
+        _item = Filters.Item;
+        _itemName = Filters.ItemName;
+        _tag = Filters.Tag;
+        _supplier = Filters.Supplier;
+        _supplierCountry = Filters.SupplierCountry;
         _includeVirtual = Filters.IncludeVirtual;
     }
 
@@ -96,15 +165,20 @@
     {
         var next = new AvailableStockSearchFilters
         {
-            Warehouse = _warehouse,
+            Warehouse = string.IsNullOrWhiteSpace(_warehouse) ? null : _warehouse,
             Location = _location.Trim(),
             Sku = _sku.Trim(),
+            Item = _item.Trim(),
+            ItemName = _itemName.Trim(),
+            Tag = _tag.Trim(),
+            Supplier = _supplier.Trim(),
+            SupplierCountry = _supplierCountry.Trim(),
             IncludeVirtual = _includeVirtual
         };
 
         if (!next.HasAtLeastOneFilter)
         {
-            _validationError = "Provide at least one filter: warehouse, location, or SKU.";
+            _validationError = "Provide at least one filter: warehouse, location, SKU, item, name, tag, supplier, or country.";
             return;
         }
 
@@ -118,9 +192,14 @@
 
     private async Task ResetAsync()
     {
-        _warehouse = null;
+        _warehouse = string.Empty;
         _location = string.Empty;
         _sku = string.Empty;
+        _item = string.Empty;
+        _itemName = string.Empty;
+        _tag = string.Empty;
+        _supplier = string.Empty;
+        _supplierCountry = string.Empty;
         _includeVirtual = false;
         _validationError = null;
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AvailableStockSearchFilters.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AvailableStockSearchFilters.cs
@@ -5,10 +5,20 @@ public record AvailableStockSearchFilters
     public string? Warehouse { get; init; }
     public string Location { get; init; } = string.Empty;
     public string Sku { get; init; } = string.Empty;
+    public string Item { get; init; } = string.Empty;
+    public string ItemName { get; init; } = string.Empty;
+    public string Tag { get; init; } = string.Empty;
+    public string Supplier { get; init; } = string.Empty;
+    public string SupplierCountry { get; init; } = string.Empty;
     public bool IncludeVirtual { get; init; }
 
     public bool HasAtLeastOneFilter =>
         !string.IsNullOrWhiteSpace(Warehouse) ||
         !string.IsNullOrWhiteSpace(Location) ||
-        !string.IsNullOrWhiteSpace(Sku);
+        !string.IsNullOrWhiteSpace(Sku) ||
+        !string.IsNullOrWhiteSpace(Item) ||
+        !string.IsNullOrWhiteSpace(ItemName) ||
+        !string.IsNullOrWhiteSpace(Tag) ||
+        !string.IsNullOrWhiteSpace(Supplier) ||
+        !string.IsNullOrWhiteSpace(SupplierCountry);
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
@@ -4,8 +4,12 @@
 
 <PageTitle>Available Stock - Cikada.MES</PageTitle>
 
-<div data-testid="stock-page">
-<h3>Available Stock</h3>
+<div class="stock-page" data-testid="stock-page">
+<header class="page-head stock-page-head">
+    <div>
+        <h1>Available Stock</h1>
+    </div>
+</header>
 
 <StockFilters Warehouses="@_warehouses"
               Filters="@_filters"
@@ -90,18 +94,6 @@
                         </div>
                     </NoRecordsContent>
                     <Columns>
-                        <TemplateColumn Title="">
-                            <CellTemplate>
-                                @if (!string.IsNullOrWhiteSpace(context.Item.PrimaryThumbnailUrl))
-                                {
-                                    <img class="stock-thumb" src="@context.Item.PrimaryThumbnailUrl" alt="@context.Item.SKU" loading="lazy" />
-                                }
-                                else
-                                {
-                                    <span class="stock-thumb stock-thumb--empty">-</span>
-                                }
-                            </CellTemplate>
-                        </TemplateColumn>
                         <PropertyColumn Property="x => x.WarehouseId" Title="Warehouse" />
                         <PropertyColumn Property="x => x.Location" Title="Location" />
                         <TemplateColumn Title="SKU">
@@ -111,7 +103,7 @@
                         </TemplateColumn>
                         <PropertyColumn Property="x => x.ItemName" Title="Name" />
                         <TemplateColumn Title="Physical">
-                            <CellTemplate><span class="is-num">@FormatQty(context.Item.PhysicalQty)</span></CellTemplate>
+                            <CellTemplate><span class="@GetQtyClass(context.Item.PhysicalQty)">@FormatQty(context.Item.PhysicalQty)</span></CellTemplate>
                         </TemplateColumn>
                         <TemplateColumn Title="Reserved">
                             <CellTemplate><span class="is-num">@FormatQty(context.Item.ReservedQty)</span></CellTemplate>
@@ -122,7 +114,6 @@
                         <TemplateColumn Title="Last Updated">
                             <CellTemplate>
                                 <span class="mono">@context.Item.LastUpdated.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss")</span>
-                                <span class="stock-stale"><StaleBadge LastUpdated="context.Item.LastUpdated" /></span>
                             </CellTemplate>
                         </TemplateColumn>
                     </Columns>
@@ -134,20 +125,12 @@
                     @foreach (var row in _items)
                     {
                         <div class="stock-list-row">
-                            @if (!string.IsNullOrWhiteSpace(row.PrimaryThumbnailUrl))
-                            {
-                                <img class="stock-list-row__thumb" src="@row.PrimaryThumbnailUrl" alt="@row.SKU" loading="lazy" />
-                            }
-                            else
-                            {
-                                <span class="stock-list-row__thumb stock-thumb--empty">-</span>
-                            }
                             <div class="stock-list-row__main">
                                 <div><span class="sku-link">@row.SKU</span> @row.ItemName</div>
                                 <div class="stock-list-row__meta">@row.WarehouseId / @row.Location</div>
                             </div>
                             <div class="stock-list-row__qty">
-                                <div>On hand: <span class="mono">@FormatQty(row.PhysicalQty)</span></div>
+                                <div>On hand: <span class="@GetQtyClass(row.PhysicalQty)">@FormatQty(row.PhysicalQty)</span></div>
                                 <div>Available: <strong class="mono">@FormatQty(row.AvailableQty)</strong></div>
                             </div>
                         </div>
@@ -301,13 +284,18 @@
         try
         {
             var result = await StockApiClient.SearchAvailableStockAsync(
-                _filters.Warehouse,
-                _filters.Location,
-                _filters.Sku,
-                _filters.IncludeVirtual,
-                page,
-                pageSize,
-                _disposeCts.Token);
+                warehouse: _filters.Warehouse,
+                location: _filters.Location,
+                sku: _filters.Sku,
+                item: _filters.Item,
+                itemName: _filters.ItemName,
+                tag: _filters.Tag,
+                supplier: _filters.Supplier,
+                supplierCountry: _filters.SupplierCountry,
+                includeVirtual: _filters.IncludeVirtual,
+                page: page,
+                pageSize: pageSize,
+                cancellationToken: _disposeCts.Token);
 
             _items = result.Items;
             _totalCount = result.TotalCount;
@@ -359,11 +347,16 @@
         try
         {
             await StockApiClient.ExportAvailableStockCsvAsync(
-                _filters.Warehouse,
-                _filters.Location,
-                _filters.Sku,
-                _filters.IncludeVirtual,
-                _disposeCts.Token);
+                warehouse: _filters.Warehouse,
+                location: _filters.Location,
+                sku: _filters.Sku,
+                item: _filters.Item,
+                itemName: _filters.ItemName,
+                tag: _filters.Tag,
+                supplier: _filters.Supplier,
+                supplierCountry: _filters.SupplierCountry,
+                includeVirtual: _filters.IncludeVirtual,
+                cancellationToken: _disposeCts.Token);
         }
         catch (ApiException ex)
         {
@@ -395,6 +388,9 @@
 
     private static string FormatQty(decimal value)
         => value.ToString("0.###");
+
+    private static string GetQtyClass(decimal value)
+        => value < 0m ? "is-num stock-qty stock-qty--negative" : "is-num stock-qty";
 
     private static string BuildErrorMessage(ApiException ex)
     {

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/StockClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/StockClient.cs
@@ -27,6 +27,11 @@ public class StockClient
         string? warehouse,
         string? location,
         string? sku,
+        string? item = null,
+        string? itemName = null,
+        string? tag = null,
+        string? supplier = null,
+        string? supplierCountry = null,
         bool includeVirtual = false,
         int page = 1,
         int pageSize = 50,
@@ -50,6 +55,12 @@ public class StockClient
             query.Append("&sku=").Append(Uri.EscapeDataString(sku));
         }
 
+        AppendOptionalQuery(query, "item", item);
+        AppendOptionalQuery(query, "itemName", itemName);
+        AppendOptionalQuery(query, "tag", tag);
+        AppendOptionalQuery(query, "supplier", supplier);
+        AppendOptionalQuery(query, "supplierCountry", supplierCountry);
+
         return SearchCoreAsync(query.ToString(), cancellationToken);
     }
 
@@ -57,6 +68,11 @@ public class StockClient
         string? warehouse,
         string? location,
         string? sku,
+        string? item = null,
+        string? itemName = null,
+        string? tag = null,
+        string? supplier = null,
+        string? supplierCountry = null,
         bool includeVirtual = false,
         CancellationToken cancellationToken = default)
     {
@@ -77,6 +93,12 @@ public class StockClient
         {
             query.Append("&sku=").Append(Uri.EscapeDataString(sku));
         }
+
+        AppendOptionalQuery(query, "item", item);
+        AppendOptionalQuery(query, "itemName", itemName);
+        AppendOptionalQuery(query, "tag", tag);
+        AppendOptionalQuery(query, "supplier", supplier);
+        AppendOptionalQuery(query, "supplierCountry", supplierCountry);
 
         var client = _factory.CreateClient("WarehouseApi");
         var response = await client.GetAsync(query.ToString(), cancellationToken);
@@ -153,6 +175,19 @@ public class StockClient
             Page = payload.PageNumber,
             PageSize = payload.PageSize
         };
+    }
+
+    private static void AppendOptionalQuery(StringBuilder query, string name, string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return;
+        }
+
+        query.Append('&')
+            .Append(name)
+            .Append('=')
+            .Append(Uri.EscapeDataString(value.Trim()));
     }
 
     private async Task<T> GetAsync<T>(string relativeUrl, CancellationToken cancellationToken = default)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -590,6 +590,294 @@ td.is-num strong { font-weight: 700; }
 .lk-grid .mud-table-pagination button.mud-selected { background: var(--accent-600) !important; color: #fff !important; }
 .lk-grid .mud-progress-linear .mud-progress-linear-bar { background: var(--accent-500) !important; }
 
+/* Available Stock */
+.stock-page {
+  display: grid;
+  gap: 12px;
+}
+
+.stock-page-head {
+  margin-bottom: 0;
+}
+
+.stock-filter-panel,
+.stock-results-panel {
+  overflow: hidden;
+}
+
+.stock-filter-toolbar {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(140px, 1fr));
+  align-items: end;
+  gap: 8px 10px;
+  padding: 10px 12px;
+  border-bottom: 0;
+  background: var(--n-25);
+}
+
+.stock-field {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.stock-field__label {
+  color: var(--n-600);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 800;
+  letter-spacing: 0.5px;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.stock-filter__toggle {
+  display: flex;
+  align-items: center;
+  min-height: var(--control-h);
+  padding: 0 4px;
+  white-space: nowrap;
+}
+
+.stock-filter__toggle .mud-checkbox {
+  margin: 0;
+}
+
+.stock-filter__actions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  justify-content: flex-end;
+  min-width: 180px;
+}
+
+.stock-filter__actions .mud-button-root {
+  min-width: 86px;
+}
+
+.stock-filter__validation {
+  margin: 0 12px 10px;
+}
+
+.stock-grid-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--n-150);
+  background: var(--n-25);
+}
+
+.stock-grid-head__summary {
+  color: var(--n-600);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.stock-grid-head__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.stock-view-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.stock-view-toggle .mud-button-root {
+  min-width: 66px;
+}
+
+.stock-page-size {
+  width: 78px;
+}
+
+.stock-grid .mud-table-container {
+  max-height: calc(100vh - 350px);
+}
+
+.stock-grid .mud-table-cell {
+  white-space: nowrap;
+}
+
+.stock-grid .mud-table-cell:nth-child(4) {
+  white-space: normal;
+  min-width: 260px;
+}
+
+.stock-qty {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.stock-qty--negative {
+  color: var(--danger-fg);
+  font-weight: 800;
+}
+
+.stock-grid__empty {
+  display: grid;
+  place-items: center;
+  gap: 3px;
+  min-height: 132px;
+  padding: 28px;
+  color: var(--n-500);
+  text-align: center;
+}
+
+.stock-grid__empty-title {
+  color: var(--n-800);
+  font-weight: 700;
+}
+
+.stock-list {
+  display: grid;
+}
+
+.stock-list-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 12px;
+  align-items: center;
+  min-height: 44px;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--n-100);
+}
+
+.stock-list-row:hover {
+  background: var(--n-25);
+}
+
+.stock-list-row__main {
+  min-width: 0;
+}
+
+.stock-list-row__main > div:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.stock-list-row__meta {
+  margin-top: 2px;
+  color: var(--n-500);
+  font-family: var(--font-mono);
+  font-size: 11.5px;
+}
+
+.stock-list-row__qty {
+  display: grid;
+  gap: 2px;
+  min-width: 150px;
+  color: var(--n-700);
+  font-size: 12px;
+  text-align: right;
+}
+
+.stock-gallery {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(210px, 1fr));
+  gap: 10px;
+  padding: 12px;
+}
+
+.stock-gallery-card {
+  overflow: hidden;
+  border: 1px solid var(--n-150);
+  border-radius: var(--r-md);
+  background: var(--n-0);
+}
+
+.stock-gallery-card__image {
+  display: block;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  object-fit: cover;
+  border-bottom: 1px solid var(--n-150);
+  background: var(--n-50);
+}
+
+.stock-thumb--empty {
+  display: grid;
+  place-items: center;
+  color: var(--n-400);
+  font-size: 11px;
+}
+
+.stock-gallery-card__body {
+  display: grid;
+  gap: 3px;
+  padding: 10px;
+  font-size: 12px;
+}
+
+.stock-grid-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border-top: 1px solid var(--n-150);
+  background: var(--n-25);
+  color: var(--n-600);
+}
+
+.stock-grid-footer__actions {
+  display: flex;
+  gap: 8px;
+}
+
+@media (max-width: 1100px) {
+  .stock-filter-toolbar {
+    grid-template-columns: repeat(3, minmax(180px, 1fr));
+  }
+
+  .stock-filter__actions {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  .stock-filter-toolbar,
+  .stock-grid-head,
+  .stock-grid-head__actions,
+  .stock-grid-footer {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+    flex-direction: column;
+  }
+
+  .stock-view-toggle,
+  .stock-filter__actions,
+  .stock-grid-footer__actions {
+    width: 100%;
+  }
+
+  .stock-view-toggle .mud-button-root,
+  .stock-filter__actions .mud-button-root,
+  .stock-grid-footer__actions .mud-button-root {
+    flex: 1 1 0;
+  }
+
+  .stock-page-size {
+    width: 100%;
+  }
+
+  .stock-list-row {
+    grid-template-columns: 1fr;
+  }
+
+  .stock-list-row__qty {
+    min-width: 0;
+    text-align: left;
+  }
+}
+
 .lots-list-panel {
   margin-bottom: 16px;
 }

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AvailableStockMetadataFilterTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AvailableStockMetadataFilterTests.cs
@@ -1,0 +1,68 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Warehouse.Api.Controllers;
+using LKvitai.MES.Modules.Warehouse.Domain.Entities;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Warehouse.Unit;
+
+public class AvailableStockMetadataFilterTests
+{
+    [Fact]
+    public void FilterItemIds_WhenSupplierCountryTagAndNameProvided_ReturnsIntersection()
+    {
+        // Arrange
+        var target = new Item
+        {
+            Id = 10,
+            InternalSKU = "WOOD-001",
+            Name = "Oak board",
+            ProductConfigId = "PRD-OAK"
+        };
+        var wrongCountry = new Item
+        {
+            Id = 20,
+            InternalSKU = "WOOD-002",
+            Name = "Oak board premium"
+        };
+        var wrongTag = new Item
+        {
+            Id = 30,
+            InternalSKU = "WOOD-003",
+            Name = "Oak board reserve"
+        };
+
+        var supplierLt = new Supplier { Id = 1, Code = "SUP-LT", Name = "Baltic Wood", Country = "Lithuania" };
+        var supplierPl = new Supplier { Id = 2, Code = "SUP-PL", Name = "Baltic Wood PL", Country = "Poland" };
+
+        var mappings = new[]
+        {
+            new SupplierItemMapping { ItemId = target.Id, SupplierId = supplierLt.Id, SupplierSKU = "BW-001", Supplier = supplierLt },
+            new SupplierItemMapping { ItemId = wrongCountry.Id, SupplierId = supplierPl.Id, SupplierSKU = "BW-002", Supplier = supplierPl },
+            new SupplierItemMapping { ItemId = wrongTag.Id, SupplierId = supplierLt.Id, SupplierSKU = "BW-003", Supplier = supplierLt }
+        };
+
+        var photos = new[]
+        {
+            new ItemPhoto { ItemId = target.Id, Tags = "#oak, surfaced" },
+            new ItemPhoto { ItemId = wrongCountry.Id, Tags = "#oak" },
+            new ItemPhoto { ItemId = wrongTag.Id, Tags = "#pine" }
+        };
+
+        var filters = new AvailableStockMetadataFilters(
+            Item: "WOOD*",
+            ItemName: "Oak",
+            Tag: "#oak",
+            Supplier: "Baltic",
+            SupplierCountry: "Lithuania");
+
+        // Act
+        var result = StockMetadataFilter.FilterItemIds(
+            [target, wrongCountry, wrongTag],
+            mappings,
+            photos,
+            filters);
+
+        // Assert
+        result.Should().Equal(target.Id);
+    }
+}

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/StockClientTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/StockClientTests.cs
@@ -42,6 +42,11 @@ public class StockClientTests
             warehouse: "WH-1",
             location: "A*",
             sku: "SKU*",
+            item: "Product 42",
+            itemName: "Lenta",
+            tag: "#oak",
+            supplier: "SUP*",
+            supplierCountry: "Lithuania",
             includeVirtual: false,
             page: 2,
             pageSize: 25);
@@ -55,6 +60,11 @@ public class StockClientTests
         capturedPathAndQuery.Should().Contain("warehouse=WH-1");
         capturedPathAndQuery.Should().Contain("location=A%2A");
         capturedPathAndQuery.Should().Contain("sku=SKU%2A");
+        capturedPathAndQuery.Should().Contain("item=Product%2042");
+        capturedPathAndQuery.Should().Contain("itemName=Lenta");
+        capturedPathAndQuery.Should().Contain("tag=%23oak");
+        capturedPathAndQuery.Should().Contain("supplier=SUP%2A");
+        capturedPathAndQuery.Should().Contain("supplierCountry=Lithuania");
     }
 
     [Fact]


### PR DESCRIPTION
Closes #192

## Summary
- add supplier, product/item, item name, tag, and supplier country filters to Warehouse Available Stock
- pass the same metadata filters through CSV export
- clean up Available Stock layout: compact filter grid, no empty thumbnail column, no row-level stale badge, negative quantities highlighted
- add unit coverage for metadata filter intersection and StockClient query generation

## Validation
- dotnet build src/LKvitai.MES.sln
- dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/LKvitai.MES.Tests.Warehouse.Unit.csproj --filter "StockClientTests|AvailableStockMetadataFilterTests"

Notes: build/test still report existing package vulnerability warnings for Marten, OpenTelemetry.Exporter.Jaeger, and SixLabors.ImageSharp.