### PR TITLE
Add item-level tags to warehouse items

### DIFF
--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/ItemsController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/ItemsController.cs
@@ -61,7 +61,8 @@ public sealed class ItemsController : ControllerBase
             var normalized = search.Trim().ToLowerInvariant();
             query = query.Where(i =>
                 i.InternalSKU.ToLower().Contains(normalized) ||
-                i.Name.ToLower().Contains(normalized));
+                i.Name.ToLower().Contains(normalized) ||
+                (i.Tags != null && i.Tags.ToLower().Contains(normalized.TrimStart('#'))));
         }
 
         if (categoryId.HasValue)
@@ -93,6 +94,7 @@ public sealed class ItemsController : ControllerBase
                 i.Weight,
                 i.Volume,
                 i.ProductConfigId,
+                SplitTags(i.Tags),
                 i.CreatedAt,
                 i.UpdatedAt,
                 null,
@@ -170,7 +172,8 @@ public sealed class ItemsController : ControllerBase
             RequiresQC = request.RequiresQC,
             Status = string.IsNullOrWhiteSpace(request.Status) ? "Active" : request.Status.Trim(),
             PrimaryBarcode = request.PrimaryBarcode?.Trim(),
-            ProductConfigId = request.ProductConfigId?.Trim()
+            ProductConfigId = request.ProductConfigId?.Trim(),
+            Tags = SerializeTags(request.Tags)
         };
 
         _dbContext.Items.Add(item);
@@ -231,6 +234,7 @@ public sealed class ItemsController : ControllerBase
             item.Status,
             item.PrimaryBarcode,
             item.ProductConfigId,
+            SplitTags(item.Tags),
             item.CreatedAt,
             item.UpdatedAt,
             primaryPhoto?.ThumbUrl,
@@ -284,11 +288,39 @@ public sealed class ItemsController : ControllerBase
         item.Status = string.IsNullOrWhiteSpace(request.Status) ? item.Status : request.Status.Trim();
         item.PrimaryBarcode = request.PrimaryBarcode?.Trim();
         item.ProductConfigId = request.ProductConfigId?.Trim();
+        item.Tags = SerializeTags(request.Tags);
 
         await _dbContext.SaveChangesAsync(cancellationToken);
         await Cache.RemoveAsync($"item:{id}", cancellationToken);
 
         return Ok(new ItemUpdatedDto(item.Id, item.InternalSKU, item.Name, item.Status, item.UpdatedAt));
+    }
+
+    [HttpGet("tags")]
+    [Authorize(Policy = WarehousePolicies.OperatorOrAbove)]
+    public async Task<IActionResult> GetTagsAsync(
+        [FromQuery] string? search = null,
+        [FromQuery] int limit = 30,
+        CancellationToken cancellationToken = default)
+    {
+        limit = Math.Clamp(limit, 1, 100);
+        var normalizedSearch = NormalizeTag(search);
+        var values = await _dbContext.Items
+            .AsNoTracking()
+            .Where(x => x.Tags != null && x.Tags != "")
+            .Select(x => x.Tags!)
+            .ToListAsync(cancellationToken);
+
+        var tags = values
+            .SelectMany(SplitTags)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Where(x => string.IsNullOrWhiteSpace(normalizedSearch) ||
+                        x.Contains(normalizedSearch, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .Take(limit)
+            .ToList();
+
+        return Ok(new ItemTagsResponse(tags));
     }
 
     [HttpPost("{id:int}/deactivate")]
@@ -603,6 +635,44 @@ public sealed class ItemsController : ControllerBase
         };
     }
 
+    private static IReadOnlyList<string> NormalizeTags(IEnumerable<string>? tags)
+    {
+        if (tags is null)
+        {
+            return Array.Empty<string>();
+        }
+
+        return tags
+            .SelectMany(SplitTagInput)
+            .Select(NormalizeTag)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static string? SerializeTags(IEnumerable<string>? tags)
+    {
+        var normalized = NormalizeTags(tags);
+        return normalized.Count == 0 ? null : string.Join(",", normalized);
+    }
+
+    private static IReadOnlyList<string> SplitTags(string? tags)
+        => NormalizeTags(SplitTagInput(tags));
+
+    private static IEnumerable<string> SplitTagInput(string? tags)
+    {
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return Array.Empty<string>();
+        }
+
+        return tags.Split([',', ';', '|', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    private static string NormalizeTag(string? value)
+        => value?.Trim().TrimStart('#').Trim() ?? string.Empty;
+
     public sealed record CreateItemRequestDto(
         string? InternalSKU,
         string Name,
@@ -615,7 +685,8 @@ public sealed class ItemsController : ControllerBase
         bool RequiresQC,
         string? Status,
         string? PrimaryBarcode,
-        string? ProductConfigId);
+        string? ProductConfigId,
+        IReadOnlyList<string>? Tags);
 
     public sealed record UpdateItemRequestDto(
         string Name,
@@ -628,7 +699,8 @@ public sealed class ItemsController : ControllerBase
         bool RequiresQC,
         string? Status,
         string? PrimaryBarcode,
-        string? ProductConfigId);
+        string? ProductConfigId,
+        IReadOnlyList<string>? Tags);
 
     public sealed record ItemCreatedDto(int Id, string InternalSKU, string Name, DateTimeOffset CreatedAt);
     public sealed record ItemUpdatedDto(int Id, string InternalSKU, string Name, string Status, DateTimeOffset? UpdatedAt);
@@ -647,6 +719,7 @@ public sealed class ItemsController : ControllerBase
         decimal? Weight,
         decimal? Volume,
         string? ProductConfigId,
+        IReadOnlyList<string> Tags,
         DateTimeOffset CreatedAt,
         DateTimeOffset? UpdatedAt,
         string? PrimaryThumbnailUrl,
@@ -666,6 +739,7 @@ public sealed class ItemsController : ControllerBase
         string Status,
         string? PrimaryBarcode,
         string? ProductConfigId,
+        IReadOnlyList<string> Tags,
         DateTimeOffset CreatedAt,
         DateTimeOffset? UpdatedAt,
         string? PrimaryThumbnailUrl,
@@ -676,6 +750,7 @@ public sealed class ItemsController : ControllerBase
     public sealed record ItemBarcodeDto(int Id, string Barcode, string BarcodeType, bool IsPrimary);
     public sealed record ItemBarcodesResponse(int ItemId, string InternalSKU, IReadOnlyList<ItemBarcodeDto> Barcodes);
     public sealed record ItemPhotosResponse(int ItemId, IReadOnlyList<ItemPhotoDto> Photos);
+    public sealed record ItemTagsResponse(IReadOnlyList<string> Tags);
     public sealed record ImageSearchResponse(IReadOnlyList<ItemImageSearchResultDto> Results);
 
     public sealed record PagedResponse<T>(

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Api/Api/Controllers/StockController.cs
@@ -125,16 +125,8 @@ public sealed class StockController : ControllerBase
                     cancellationToken)
                 : Array.Empty<SupplierItemMapping>();
 
-            IReadOnlyList<ItemPhoto> taggedPhotos = metadataFilters.NeedsTagData
-                ? await Microsoft.EntityFrameworkCore.EntityFrameworkQueryableExtensions.ToListAsync(
-                    _dbContext.ItemPhotos
-                        .AsNoTracking()
-                        .Where(x => itemIds.Contains(x.ItemId) && x.Tags != null && x.Tags != ""),
-                    cancellationToken)
-                : Array.Empty<ItemPhoto>();
-
             metadataFilteredItemIds = StockMetadataFilter
-                .FilterItemIds(itemMap.Values, supplierMappings, taggedPhotos, metadataFilters)
+                .FilterItemIds(itemMap.Values, supplierMappings, metadataFilters)
                 .ToHashSet();
         }
 
@@ -170,6 +162,7 @@ public sealed class StockController : ControllerBase
                 row.LastUpdated,
                 item?.CategoryId,
                 location?.IsVirtual ?? false,
+                StockMetadataFilter.SplitTags(item?.Tags),
                 item is not null && primaryPhotoByItemId.TryGetValue(item.Id, out var photoUrl)
                     ? photoUrl
                     : null);
@@ -254,6 +247,7 @@ public sealed class StockController : ControllerBase
                 x.AvailableQty,
                 x.BaseUom,
                 x.LastUpdated,
+                x.Tags,
                 x.PrimaryThumbnailUrl)).ToList(),
             totalCount,
             pageNumber,
@@ -369,12 +363,13 @@ public sealed class StockController : ControllerBase
     private static string BuildAvailableCsv(IReadOnlyCollection<AvailableStockRow> rows)
     {
         var sb = new StringBuilder();
-        sb.AppendLine("ItemId,InternalSKU,ItemName,LocationId,LocationCode,LotNumber,ExpiryDate,Qty,ReservedQty,AvailableQty,BaseUoM,LastUpdated");
+        sb.AppendLine("ItemId,InternalSKU,ItemName,Tags,LocationId,LocationCode,LotNumber,ExpiryDate,Qty,ReservedQty,AvailableQty,BaseUoM,LastUpdated");
         foreach (var row in rows)
         {
             sb.Append(row.ItemId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty).Append(',');
             sb.Append(EscapeCsv(row.InternalSku)).Append(',');
             sb.Append(EscapeCsv(row.ItemName)).Append(',');
+            sb.Append(EscapeCsv(string.Join(' ', row.Tags.Select(tag => "#" + tag)))).Append(',');
             sb.Append(row.LocationId?.ToString(CultureInfo.InvariantCulture) ?? string.Empty).Append(',');
             sb.Append(EscapeCsv(row.LocationCode)).Append(',');
             sb.Append(EscapeCsv(row.LotNumber)).Append(',');
@@ -524,6 +519,7 @@ public sealed class StockController : ControllerBase
         DateTime LastUpdated,
         int? CategoryId,
         bool IsVirtualLocation,
+        IReadOnlyList<string> Tags,
         string? PrimaryThumbnailUrl);
 
     public sealed record AvailableStockItemDto(
@@ -539,6 +535,7 @@ public sealed class StockController : ControllerBase
         decimal AvailableQty,
         string BaseUom,
         DateTime LastUpdated,
+        IReadOnlyList<string> Tags,
         string? PrimaryThumbnailUrl);
 
     public sealed record PagedStockResponse<T>(
@@ -591,7 +588,6 @@ public sealed record AvailableStockMetadataFilters(
         !string.IsNullOrWhiteSpace(SupplierFilter) ||
         !string.IsNullOrWhiteSpace(SupplierCountryFilter);
 
-    public bool NeedsTagData => !string.IsNullOrWhiteSpace(TagFilter);
 }
 
 public static class StockMetadataFilter
@@ -599,7 +595,6 @@ public static class StockMetadataFilter
     public static IReadOnlyCollection<int> FilterItemIds(
         IEnumerable<Item> items,
         IEnumerable<SupplierItemMapping> supplierMappings,
-        IEnumerable<ItemPhoto> itemPhotos,
         AvailableStockMetadataFilters filters)
     {
         var itemList = items.ToList();
@@ -624,10 +619,9 @@ public static class StockMetadataFilter
 
         if (!string.IsNullOrWhiteSpace(filters.TagFilter))
         {
-            IntersectWith(result, itemPhotos
+            IntersectWith(result, itemList
                 .Where(x => MatchesTag(x.Tags, filters.TagFilter))
-                .Select(x => x.ItemId)
-                .Distinct());
+                .Select(x => x.Id));
         }
 
         if (filters.NeedsSupplierData)
@@ -716,6 +710,22 @@ public static class StockMetadataFilter
         return MatchesPattern(mapping.Supplier?.Country, supplierCountryFilter);
     }
 
+    public static IReadOnlyList<string> SplitTags(string? tags)
+    {
+        if (string.IsNullOrWhiteSpace(tags))
+        {
+            return Array.Empty<string>();
+        }
+
+        return tags
+            .Split([',', ';', '|', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(NormalizeTag)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
     private static bool MatchesTag(string? tags, string tagFilter)
     {
         if (string.IsNullOrWhiteSpace(tagFilter))
@@ -734,13 +744,10 @@ public static class StockMetadataFilter
             return true;
         }
 
-        if (MatchesPattern(tags, normalizedFilter) || MatchesPattern(tags, "#" + normalizedFilter))
-        {
-            return true;
-        }
-
-        var tokens = tags.Split([',', ';', '|', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries);
-        return tokens.Any(token => string.Equals(NormalizeTag(token), normalizedFilter, StringComparison.OrdinalIgnoreCase));
+        var hasWildcard = normalizedFilter.Contains('*');
+        return SplitTags(tags).Any(token => hasWildcard
+            ? MatchesPattern(token, normalizedFilter)
+            : string.Equals(token, normalizedFilter, StringComparison.OrdinalIgnoreCase));
     }
 
     private static string NormalizeTag(string value)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/MasterDataEntities.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Domain/Entities/MasterDataEntities.cs
@@ -26,6 +26,7 @@ public sealed class Item : AuditableEntity
     public string Status { get; set; } = "Active";
     public string? PrimaryBarcode { get; set; }
     public string? ProductConfigId { get; set; }
+    public string? Tags { get; set; }
 
     public ItemCategory? Category { get; set; }
     public UnitOfMeasure? BaseUnit { get; set; }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260614152503_AddItemTags.Designer.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260614152503_AddItemTags.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
 {
     [DbContext(typeof(WarehouseDbContext))]
-    partial class WarehouseDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260614152503_AddItemTags")]
+    partial class AddItemTags
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260614152503_AddItemTags.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/Migrations/20260614152503_AddItemTags.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace LKvitai.MES.Modules.Warehouse.Infrastructure.Persistence.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddItemTags : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "Tags",
+                schema: "public",
+                table: "items",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Tags",
+                schema: "public",
+                table: "items");
+        }
+    }
+}

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.Infrastructure/Persistence/WarehouseDbContext.cs
@@ -217,6 +217,7 @@ public class WarehouseDbContext : DbContext
             entity.Property(e => e.Status).HasMaxLength(20).IsRequired().HasDefaultValue("Active");
             entity.Property(e => e.PrimaryBarcode).HasMaxLength(100);
             entity.Property(e => e.ProductConfigId).HasMaxLength(50);
+            entity.Property(e => e.Tags).HasMaxLength(500);
             entity.HasIndex(e => e.InternalSKU).IsUnique();
             entity.HasIndex(e => e.CategoryId).HasDatabaseName("idx_items_category_id");
             entity.HasIndex(e => e.BaseUoM);

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AvailableStockItemDto.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/AvailableStockItemDto.cs
@@ -11,5 +11,6 @@ public record AvailableStockItemDto
     public decimal ReservedQty { get; init; }
     public decimal AvailableQty { get; init; }
     public DateTime LastUpdated { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
     public string? PrimaryThumbnailUrl { get; init; }
 }

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/MasterDataDtos.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Models/MasterDataDtos.cs
@@ -23,6 +23,7 @@ public record AdminItemDto
     public decimal? Weight { get; init; }
     public decimal? Volume { get; init; }
     public string? ProductConfigId { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
     public DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset? UpdatedAt { get; init; }
     public string? PrimaryThumbnailUrl { get; init; }
@@ -57,6 +58,7 @@ public record ItemDetailsDto
     public string Status { get; init; } = string.Empty;
     public string? PrimaryBarcode { get; init; }
     public string? ProductConfigId { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
     public DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset? UpdatedAt { get; init; }
     public string? PrimaryThumbnailUrl { get; init; }
@@ -98,6 +100,12 @@ public record CreateOrUpdateItemRequest
     public string? Status { get; init; }
     public string? PrimaryBarcode { get; init; }
     public string? ProductConfigId { get; init; }
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
+}
+
+public record ItemTagsResponseDto
+{
+    public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
 }
 
 public record AdminSupplierDto

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItemDetail.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItemDetail.razor
@@ -63,6 +63,22 @@
                 <AdminItemFieldBlock Label="Volume" Value="@FormatDecimal(_item.Volume)" IsMono="true" />
                 <AdminItemFieldBlock Label="Primary Barcode" Value="@FormatNullable(_item.PrimaryBarcode)" IsMono="true" />
                 <AdminItemFieldBlock Label="Product Config" Value="@FormatNullable(_item.ProductConfigId)" IsMono="true" />
+                <div class="items-detail-field">
+                    <span>Tags</span>
+                    <div class="item-tags item-tags--detail">
+                        @if (_item.Tags.Count == 0)
+                        {
+                            <strong>-</strong>
+                        }
+                        else
+                        {
+                            @foreach (var tag in _item.Tags)
+                            {
+                                <span class="chip chip--reserved item-tag-chip">#@tag</span>
+                            }
+                        }
+                    </div>
+                </div>
                 <AdminItemFieldBlock Label="Lot Tracking" Value="@(_item.RequiresLotTracking ? "Required" : "Not required")" />
                 <AdminItemFieldBlock Label="QC" Value="@(_item.RequiresQC ? "Required" : "Not required")" />
                 <AdminItemFieldBlock Label="Created" Value="@FormatDateTime(_item.CreatedAt)" IsMono="true" />
@@ -293,7 +309,7 @@
 
     private void BackToList()
     {
-        NavigationManager.NavigateTo("/admin/items");
+        NavigationManager.NavigateTo("admin/items");
     }
 
     private static string StatusChipClass(string status) => status switch

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItemEditorDialog.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItemEditorDialog.razor
@@ -92,6 +92,52 @@
                           Margin="Margin.Dense"
                           @bind-Value="_model.ProductConfigId" />
 
+            <div class="admin-item-dialog__tags">
+                <div class="admin-item-tag-entry">
+                    <MudAutocomplete T="string"
+                                     Label="Tags"
+                                     Variant="Variant.Outlined"
+                                     Margin="Margin.Dense"
+                                     Value="@_tagInput"
+                                     ValueChanged="OnTagInputChanged"
+                                     SearchFunc="SearchTagsAsync"
+                                     CoerceText="true"
+                                     CoerceValue="true"
+                                     ResetValueOnEmptyText="true"
+                                     MinCharacters="0"
+                                     MaxItems="12"
+                                     Placeholder="#tag" />
+                    <MudButton Variant="Variant.Outlined"
+                               Color="Color.Primary"
+                               Disabled="@string.IsNullOrWhiteSpace(_tagInput)"
+                               OnClick="AddTagAsync">
+                        Add
+                    </MudButton>
+                </div>
+
+                <div class="item-tags" data-testid="admin-item-tags">
+                    @if (_model.Tags.Count == 0)
+                    {
+                        <span class="item-tags__empty">No tags</span>
+                    }
+                    else
+                    {
+                        @foreach (var tag in _model.Tags)
+                        {
+                            <span class="chip chip--reserved item-tag-chip">
+                                #@tag
+                                <button type="button"
+                                        class="item-tag-chip__remove"
+                                        aria-label="@($"Remove tag {tag}")"
+                                        @onclick="@(() => RemoveTag(tag))">
+                                    x
+                                </button>
+                            </span>
+                        }
+                    }
+                </div>
+            </div>
+
             <div class="admin-item-dialog__checks">
                 <MudCheckBox T="bool" @bind-Checked="_model.RequiresLotTracking" Label="Requires lot tracking" />
                 <MudCheckBox T="bool" @bind-Checked="_model.RequiresQC" Label="Requires QC" />
@@ -119,9 +165,11 @@
     [Parameter] public ItemDetailsDto? Item { get; set; }
     [Parameter] public IReadOnlyList<AdminCategoryDto> Categories { get; set; } = Array.Empty<AdminCategoryDto>();
     [Parameter] public IReadOnlyList<UnitOfMeasureDto> Units { get; set; } = Array.Empty<UnitOfMeasureDto>();
+    [Parameter] public IReadOnlyList<string> ExistingTags { get; set; } = Array.Empty<string>();
 
     private readonly ItemFormModel _model = new();
     private string? _validationMessage;
+    private string? _tagInput;
 
     protected override void OnInitialized()
     {
@@ -139,6 +187,8 @@
             _model.Status = Item.Status;
             _model.PrimaryBarcode = Item.PrimaryBarcode;
             _model.ProductConfigId = Item.ProductConfigId;
+            _model.Tags.Clear();
+            _model.Tags.AddRange(Item.Tags.Select(NormalizeTag).Where(x => !string.IsNullOrWhiteSpace(x)));
             return;
         }
 
@@ -192,6 +242,65 @@
 
     private void Cancel() => MudDialog.Cancel();
 
+    private Task<IEnumerable<string>> SearchTagsAsync(string value)
+    {
+        var normalized = NormalizeTag(value);
+        var selected = _model.Tags.ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var result = ExistingTags
+            .Select(NormalizeTag)
+            .Where(x => !string.IsNullOrWhiteSpace(x))
+            .Where(x => !selected.Contains(x))
+            .Where(x => string.IsNullOrWhiteSpace(normalized) ||
+                        x.Contains(normalized, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(x => x, StringComparer.OrdinalIgnoreCase);
+
+        return Task.FromResult<IEnumerable<string>>(result);
+    }
+
+    private Task OnTagInputChanged(string value)
+    {
+        _tagInput = value;
+        return Task.CompletedTask;
+    }
+
+    private Task AddTagAsync()
+    {
+        var additions = SplitTags(_tagInput).ToList();
+        foreach (var tag in additions)
+        {
+            if (!_model.Tags.Contains(tag, StringComparer.OrdinalIgnoreCase))
+            {
+                _model.Tags.Add(tag);
+            }
+        }
+
+        _model.Tags.Sort(StringComparer.OrdinalIgnoreCase);
+        _tagInput = string.Empty;
+        return Task.CompletedTask;
+    }
+
+    private void RemoveTag(string tag)
+    {
+        _model.Tags.RemoveAll(x => string.Equals(x, tag, StringComparison.OrdinalIgnoreCase));
+    }
+
+    private static IEnumerable<string> SplitTags(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            return Array.Empty<string>();
+        }
+
+        return value
+            .Split([',', ';', '|', ' ', '\t', '\r', '\n'], StringSplitOptions.RemoveEmptyEntries)
+            .Select(NormalizeTag)
+            .Where(x => !string.IsNullOrWhiteSpace(x));
+    }
+
+    private static string NormalizeTag(string? value)
+        => value?.Trim().TrimStart('#').Trim() ?? string.Empty;
+
     private sealed class ItemFormModel
     {
         public string? InternalSKU { get; set; }
@@ -206,6 +315,7 @@
         public string Status { get; set; } = "Active";
         public string? PrimaryBarcode { get; set; }
         public string? ProductConfigId { get; set; }
+        public List<string> Tags { get; } = [];
 
         public CreateOrUpdateItemRequest ToRequest(bool isEdit) => new()
         {
@@ -220,7 +330,8 @@
             RequiresQC = RequiresQC,
             Status = string.IsNullOrWhiteSpace(Status) ? "Active" : Status.Trim(),
             PrimaryBarcode = Normalize(PrimaryBarcode),
-            ProductConfigId = Normalize(ProductConfigId)
+            ProductConfigId = Normalize(ProductConfigId),
+            Tags = Tags.ToArray()
         };
 
         private static string? Normalize(string? value)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItems.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AdminItems.razor
@@ -144,6 +144,20 @@
                         <span class="items-name" title="@context.Item.Name">@context.Item.Name</span>
                     </CellTemplate>
                 </TemplateColumn>
+                <TemplateColumn Title="Tags" Sortable="false">
+                    <CellTemplate>
+                        <div class="item-tags item-tags--compact">
+                            @foreach (var tag in context.Item.Tags.Take(3))
+                            {
+                                <span class="chip chip--reserved item-tag-chip">#@tag</span>
+                            }
+                            @if (context.Item.Tags.Count > 3)
+                            {
+                                <span class="chip chip--locked item-tag-chip">+@(context.Item.Tags.Count - 3)</span>
+                            }
+                        </div>
+                    </CellTemplate>
+                </TemplateColumn>
                 <PropertyColumn Property="x => x.CategoryName" Title="Category" />
                 <PropertyColumn Property="x => x.BaseUoM" Title="UoM" />
                 <TemplateColumn Title="Status">
@@ -237,6 +251,7 @@
     private MudDataGrid<AdminItemDto>? _grid;
     private readonly List<AdminCategoryDto> _categories = [];
     private readonly List<UnitOfMeasureDto> _units = [];
+    private readonly List<string> _itemTags = [];
 
     private string _search = string.Empty;
     private string _status = string.Empty;
@@ -302,13 +317,17 @@
             _apiError = null;
             var categoriesTask = AdminClient.GetCategoriesAsync();
             var unitsTask = UomClient.GetUnitsAsync(null, null);
-            await Task.WhenAll(categoriesTask, unitsTask);
+            var tagsTask = AdminClient.GetItemTagsAsync(limit: 100);
+            await Task.WhenAll(categoriesTask, unitsTask, tagsTask);
 
             _categories.Clear();
             _categories.AddRange(categoriesTask.Result.OrderBy(x => x.Code, StringComparer.OrdinalIgnoreCase));
 
             _units.Clear();
             _units.AddRange(unitsTask.Result.OrderBy(x => x.Code, StringComparer.OrdinalIgnoreCase));
+
+            _itemTags.Clear();
+            _itemTags.AddRange(tagsTask.Result.OrderBy(x => x, StringComparer.OrdinalIgnoreCase));
         }
         catch (ApiException ex)
         {
@@ -417,7 +436,8 @@
         {
             ["IsEdit"] = false,
             ["Categories"] = _categories,
-            ["Units"] = _units
+            ["Units"] = _units,
+            ["ExistingTags"] = _itemTags
         };
 
         var dialog = await DialogService.ShowAsync<AdminItemEditorDialog>("Create item", parameters, ItemDialogOptions);
@@ -432,6 +452,7 @@
             _apiError = null;
             await AdminClient.CreateItemAsync(request);
             ToastService.ShowSuccess("Item created.");
+            await LoadLookupsAsync();
             await RefreshAsync();
         }
         catch (ApiException ex)
@@ -452,7 +473,8 @@
                 ["IsEdit"] = true,
                 ["Item"] = item,
                 ["Categories"] = _categories,
-                ["Units"] = _units
+                ["Units"] = _units,
+                ["ExistingTags"] = _itemTags
             };
 
             var dialog = await DialogService.ShowAsync<AdminItemEditorDialog>("Edit item", parameters, ItemDialogOptions);
@@ -464,6 +486,7 @@
 
             await AdminClient.UpdateItemAsync(row.Id, request);
             ToastService.ShowSuccess("Item updated.");
+            await LoadLookupsAsync();
             await RefreshAsync();
         }
         catch (ApiException ex)
@@ -521,7 +544,7 @@
 
     private void OpenDetails(int itemId)
     {
-        NavigationManager.NavigateTo($"/admin/items/{itemId}");
+        NavigationManager.NavigateTo($"admin/items/{itemId}");
     }
 
     private static bool IsDiscontinued(AdminItemDto item)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/AvailableStock.razor
@@ -102,6 +102,20 @@
                             </CellTemplate>
                         </TemplateColumn>
                         <PropertyColumn Property="x => x.ItemName" Title="Name" />
+                        <TemplateColumn Title="Tags" Sortable="false">
+                            <CellTemplate>
+                                <div class="item-tags item-tags--compact">
+                                    @foreach (var tag in context.Item.Tags.Take(3))
+                                    {
+                                        <span class="chip chip--reserved item-tag-chip">#@tag</span>
+                                    }
+                                    @if (context.Item.Tags.Count > 3)
+                                    {
+                                        <span class="chip chip--locked item-tag-chip">+@(context.Item.Tags.Count - 3)</span>
+                                    }
+                                </div>
+                            </CellTemplate>
+                        </TemplateColumn>
                         <TemplateColumn Title="Physical">
                             <CellTemplate><span class="@GetQtyClass(context.Item.PhysicalQty)">@FormatQty(context.Item.PhysicalQty)</span></CellTemplate>
                         </TemplateColumn>
@@ -127,6 +141,15 @@
                         <div class="stock-list-row">
                             <div class="stock-list-row__main">
                                 <div><span class="sku-link">@row.SKU</span> @row.ItemName</div>
+                                @if (row.Tags.Count > 0)
+                                {
+                                    <div class="item-tags item-tags--compact">
+                                        @foreach (var tag in row.Tags.Take(3))
+                                        {
+                                            <span class="chip chip--reserved item-tag-chip">#@tag</span>
+                                        }
+                                    </div>
+                                }
                                 <div class="stock-list-row__meta">@row.WarehouseId / @row.Location</div>
                             </div>
                             <div class="stock-list-row__qty">
@@ -154,6 +177,15 @@
                             <div class="stock-gallery-card__body">
                                 <div><span class="sku-link">@row.SKU</span></div>
                                 <div class="stock-list-row__meta">@row.ItemName</div>
+                                @if (row.Tags.Count > 0)
+                                {
+                                    <div class="item-tags">
+                                        @foreach (var tag in row.Tags.Take(4))
+                                        {
+                                            <span class="chip chip--reserved item-tag-chip">#@tag</span>
+                                        }
+                                    </div>
+                                }
                                 <div>@row.WarehouseId / @row.Location</div>
                                 <div>On hand: <span class="mono">@FormatQty(row.PhysicalQty)</span></div>
                                 <div>Available: <strong class="mono">@FormatQty(row.AvailableQty)</strong></div>

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SearchByImage.razor
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Pages/SearchByImage.razor
@@ -168,7 +168,7 @@
 
     private void OpenItem(int itemId)
     {
-        NavigationManager.NavigateTo($"/admin/items/{itemId}");
+        NavigationManager.NavigateTo($"admin/items/{itemId}");
     }
 
     private static string BuildErrorMessage(ApiException error)

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/MasterDataAdminClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/MasterDataAdminClient.cs
@@ -66,6 +66,24 @@ public sealed class MasterDataAdminClient
     public Task UpdateItemAsync(int id, CreateOrUpdateItemRequest request, CancellationToken cancellationToken = default)
         => SendNoContentAsync(HttpMethod.Put, $"/api/warehouse/v1/items/{id}", request, cancellationToken);
 
+    public async Task<IReadOnlyList<string>> GetItemTagsAsync(
+        string? search = null,
+        int limit = 30,
+        CancellationToken cancellationToken = default)
+    {
+        var query = new List<string> { $"limit={limit}" };
+        if (!string.IsNullOrWhiteSpace(search))
+        {
+            query.Add($"search={Uri.EscapeDataString(search)}");
+        }
+
+        var response = await GetAsync<ItemTagsResponseDto>(
+            $"/api/warehouse/v1/items/tags?{string.Join("&", query)}",
+            cancellationToken);
+
+        return response.Tags;
+    }
+
     public Task DeactivateItemAsync(int id, CancellationToken cancellationToken = default)
         => SendNoContentAsync(HttpMethod.Post, $"/api/warehouse/v1/items/{id}/deactivate", null, cancellationToken);
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/StockClient.cs
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/Services/StockClient.cs
@@ -165,6 +165,7 @@ public class StockClient
             ReservedQty = row.ReservedQty,
             AvailableQty = row.AvailableQty,
             LastUpdated = row.LastUpdated,
+            Tags = row.Tags,
             PrimaryThumbnailUrl = row.PrimaryThumbnailUrl
         }).ToList();
 
@@ -230,6 +231,7 @@ public class StockClient
         public decimal ReservedQty { get; init; }
         public decimal AvailableQty { get; init; }
         public DateTime LastUpdated { get; init; }
+        public IReadOnlyList<string> Tags { get; init; } = Array.Empty<string>();
         public string? PrimaryThumbnailUrl { get; init; }
     }
 

--- a/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
+++ b/src/Modules/Warehouse/LKvitai.MES.Modules.Warehouse.WebUI/wwwroot/css/site.css
@@ -1156,6 +1156,7 @@ td.is-num strong { font-weight: 700; }
 }
 
 .admin-item-dialog__checks,
+.admin-item-dialog__tags,
 .admin-item-dialog__description {
   grid-column: 1 / -1;
 }
@@ -1164,6 +1165,68 @@ td.is-num strong { font-weight: 700; }
   display: flex;
   align-items: center;
   gap: 14px;
+}
+
+.admin-item-dialog__tags {
+  display: grid;
+  gap: 8px;
+}
+
+.admin-item-tag-entry {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 8px;
+}
+
+.item-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  min-width: 0;
+}
+
+.item-tags--compact {
+  max-width: 190px;
+}
+
+.item-tags--detail {
+  align-items: center;
+}
+
+.item-tags__empty {
+  color: var(--n-500);
+  font-size: 12px;
+}
+
+.item-tag-chip {
+  max-width: 140px;
+  gap: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.item-tag-chip__remove {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 14px;
+  height: 14px;
+  margin-left: 2px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: currentColor;
+  cursor: pointer;
+  font: inherit;
+  line-height: 1;
+  opacity: 0.65;
+}
+
+.item-tag-chip__remove:hover {
+  opacity: 1;
 }
 
 .admin-item-photos-dialog__toolbar {
@@ -1266,6 +1329,19 @@ td.is-num strong { font-weight: 700; }
   font-size: 12.5px;
   font-weight: 650;
   overflow-wrap: anywhere;
+}
+
+.items-detail-field .item-tags {
+  min-height: 20px;
+}
+
+.items-detail-field .item-tag-chip {
+  color: var(--info-fg);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 800;
+  letter-spacing: 0.3px;
+  text-transform: none;
 }
 
 .items-detail-field--wide {

--- a/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AvailableStockMetadataFilterTests.cs
+++ b/tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/AvailableStockMetadataFilterTests.cs
@@ -16,19 +16,22 @@ public class AvailableStockMetadataFilterTests
             Id = 10,
             InternalSKU = "WOOD-001",
             Name = "Oak board",
-            ProductConfigId = "PRD-OAK"
+            ProductConfigId = "PRD-OAK",
+            Tags = "oak,surfaced"
         };
         var wrongCountry = new Item
         {
             Id = 20,
             InternalSKU = "WOOD-002",
-            Name = "Oak board premium"
+            Name = "Oak board premium",
+            Tags = "oak"
         };
         var wrongTag = new Item
         {
             Id = 30,
             InternalSKU = "WOOD-003",
-            Name = "Oak board reserve"
+            Name = "Oak board reserve",
+            Tags = "pine"
         };
 
         var supplierLt = new Supplier { Id = 1, Code = "SUP-LT", Name = "Baltic Wood", Country = "Lithuania" };
@@ -39,13 +42,6 @@ public class AvailableStockMetadataFilterTests
             new SupplierItemMapping { ItemId = target.Id, SupplierId = supplierLt.Id, SupplierSKU = "BW-001", Supplier = supplierLt },
             new SupplierItemMapping { ItemId = wrongCountry.Id, SupplierId = supplierPl.Id, SupplierSKU = "BW-002", Supplier = supplierPl },
             new SupplierItemMapping { ItemId = wrongTag.Id, SupplierId = supplierLt.Id, SupplierSKU = "BW-003", Supplier = supplierLt }
-        };
-
-        var photos = new[]
-        {
-            new ItemPhoto { ItemId = target.Id, Tags = "#oak, surfaced" },
-            new ItemPhoto { ItemId = wrongCountry.Id, Tags = "#oak" },
-            new ItemPhoto { ItemId = wrongTag.Id, Tags = "#pine" }
         };
 
         var filters = new AvailableStockMetadataFilters(
@@ -59,7 +55,6 @@ public class AvailableStockMetadataFilterTests
         var result = StockMetadataFilter.FilterItemIds(
             [target, wrongCountry, wrongTag],
             mappings,
-            photos,
             filters);
 
         // Assert


### PR DESCRIPTION
## Summary
- add item-level tags with an EF migration and expose them through item list/detail create/update APIs
- add tag chips and existing-tag autocomplete to the Admin Items editor
- switch Available Stock tag filtering from photo tags to item tags and show/export item tags
- fix item detail navigation so warehouse routes keep the /warehouse prefix

## Validation
- dotnet build src/LKvitai.MES.sln
- dotnet test tests/Modules/Warehouse/LKvitai.MES.Tests.Warehouse.Unit/LKvitai.MES.Tests.Warehouse.Unit.csproj --filter "StockClientTests|AvailableStockMetadataFilterTests"

Notes: validation still reports existing package vulnerability warnings for Marten, OpenTelemetry.Exporter.Jaeger, and SixLabors.ImageSharp, plus an existing XML cref warning in SalesDevAuthenticationHandler.