### PR TITLE
[codex] add Shopfloor architecture and operator queue demo

### DIFF
--- a/docs/shopfloor/shopfloor-00-architecture.md
+++ b/docs/shopfloor/shopfloor-00-architecture.md
@@ -1,0 +1,281 @@
+# LKvitai.MES — Shopfloor Module · Architecture Foundation
+
+**Module:** Shopfloor (ShopfloorPilot)
+**Version:** 0.1 — Architecture baseline
+**Date:** 2026-06-15
+**Status:** Draft — basis for implementation blueprints
+**Supersedes:** internal `CONTEXT_ShopfloorPilot.md` / "Technical Specification Draft v0.1"
+
+> This document is **architecture only**. It locks module boundaries, ownership,
+> integration contracts, and the major engines. Detailed domain schemas, APIs, and
+> UI specs are produced as separate numbered blueprints (`shopfloor-01..NN`). Do not
+> add table columns, endpoint shapes, or formula grammars here.
+
+---
+
+## 1. Purpose
+
+Shopfloor turns **customer orders** into **production tasks for line operators**, routes
+those tasks through a configurable per-product workflow, and keeps the warehouse stock
+in sync with what is actually consumed.
+
+Today the workshop runs on paper: every morning yesterday's orders are released, printed,
+grouped by product type (blinds, rollers, nets…) and handed to workers as paper packs.
+Shopfloor replaces those paper packs with a **digital, auto-sorted work queue per line**,
+and replaces the manual "done / stopped" feedback with tracked events.
+
+What we sell is not a "node-and-arrow editor" — it is a **smart production orchestration
+engine**: the system decides which task is most valuable to do next, balances WIP so
+assembly never starves, and shows a live digital twin of the floor.
+
+---
+
+## 2. Reconciliation with Draft v0.1 (what changed)
+
+The original spec assumed a standalone stack. It must align with the **existing modular
+monolith**. The concepts survive; the technology is the repo's.
+
+| Concern | Draft v0.1 | This architecture (repo reality) |
+|---|---|---|
+| Topology | .NET microservices | **Modular monolith** under `src/Modules/Shopfloor/*` |
+| Frontend | Vue + Vite + Rete.js + Monaco + Tailwind | **Blazor Server + MudBlazor**; workflow editor is a self-contained HTML/JS canvas embedded in WebUI |
+| Database | MS SQL + Dapper + DbUp | **PostgreSQL**; Marten (event-sourced) + EF Core (state) — same split as Warehouse |
+| Messaging | (unspecified) | **MassTransit + RabbitMQ** (already in stack) |
+| Naming | `weblb_sf_*` MSSQL prefix | repo naming conventions (see `CLAUDE.md`) |
+| Product types | own master data | **stay in the legacy system** — Shopfloor receives a product-type *code*, does not own the catalog |
+
+The four "engines" from the pitch (Flow, Formula, Prioritization, Digital Twin) are kept
+as first-class architectural capabilities — see §7.
+
+---
+
+## 3. Scope
+
+**Phase 1 (in scope)**
+- Ingest "order released to production" from the legacy system (poll + translate).
+- `WorkflowTemplate` per product type, authored in the existing Workflow Editor.
+- Generate `WorkItem`s per order from the template (split by workstation, with dependencies).
+- Per-line work **queue** with automatic ordering (Take-Next prioritization).
+- Operator complete / stop with **actual quantity** capture.
+- Material reservation on release, **actual consumption** write-off to Warehouse on completion.
+- Push completion status **back** to the legacy system.
+- Semi-finished + finished **label printing** hooks.
+
+**Phase 1 (out of scope / deferred)**
+- AI scheduling beyond weighted coefficients.
+- Machine/PLC integration (scanners + printers only).
+- 3D visualization.
+- Offline operation on operator notebooks (network is assumed present).
+- Native product-type catalog inside MES (legacy remains source of truth).
+
+---
+
+## 4. Where Shopfloor fits
+
+```
+                 ┌──────────────────────── Legacy system (MS Access + MS SQL) ────────────────────────┐
+                 │  Orders · product types · "released to production" · "manufactured/stopped" status   │
+                 └───────────────▲───────────────────────────────────────────────┬──────────────────────┘
+                                 │ poll (read)                      write status  │ (back)
+                                 │                                                │
+                 ┌───────────────┴────────────────────────────────────────────────┴──────────────┐
+                 │  Integration.LegacyOrders  (Anti-Corruption Layer)                              │
+                 └───────────────┬─────────────────────────────────────────────────────────────────┘
+                                 │ ProductionOrderReleased / OrderStatusChanged   (via RabbitMQ)
+                                 ▼
+   ┌─────────────────────────────────────────── Shopfloor module ───────────────────────────────────────────┐
+   │  WorkflowTemplate · ProductionOrder · WorkItem · WorkStation(queue) · execution lifecycle               │
+   │  Engines:  Flow · Formula · Prioritization (Take-Next) · Digital Twin                                    │
+   └───────────────┬───────────────────────────────────────────────────────────────────┬─────────────────────┘
+                   │ MaterialReservationRequested / MaterialConsumed (events/commands)   │ queue UI
+                   ▼                                                                     ▼
+   ┌──────────────────────────── Warehouse module ───────────────────────┐    Operator notebooks (per line)
+   │  StockLedger (sole owner of movements) · Reservation · AvailableStock │
+   └──────────────────────────────────────────────────────────────────────┘
+```
+
+Sibling modules already scaffolded: `Sales`, `Frontline`, `Scanning`, `Portal`. Shopfloor
+reuses Portal auth and the Cikada.MES design system, exactly like the other WebUIs.
+
+---
+
+## 5. Mandatory Architectural Decisions
+
+These are locked. Blueprints must not relitigate them.
+
+| # | Decision | Rule |
+|---|----------|------|
+| **S-1** | Product types live in legacy | Shopfloor stores `productTypeCode` as an opaque string. It never owns the 400-type catalog. A native `ProductCatalog` module is revisited only when Sales moves into MES. |
+| **S-2** | Legacy integration is one-directional read + status write-back | MES **polls** legacy MS SQL (no webhooks/CDC — Access/SQL can't push). Status flows back as a write to a legacy table/proc. Both directions cross the ACL only. |
+| **S-3** | Warehouse owns all stock truth | Shopfloor never writes stock. It emits intent (`MaterialReservationRequested`, `MaterialConsumed`); Warehouse applies it via existing commands. Honors Warehouse **Decision 1** (StockLedger is sole movement owner). |
+| **S-4** | Reserve on release, consume on completion | Reservation (SOFT) is placed when an order is released. Real write-off happens only when an operator completes a task and enters the **actual** quantity. A stopped task consumes nothing — the reservation simply remains. |
+| **S-5** | Two material sources per task | A task's materials are either **order-bound** (SKU comes from the order, e.g. fabric `R432`) or **template-fixed** (SKU is set in the template, e.g. screws, ribbon). Both resolve to concrete Warehouse SKUs at WorkItem creation. |
+| **S-6** | Workstation queue is auto-ordered | Operators do not get a "Take Next" lottery in isolation — each line shows a **prioritized queue** computed by the engine. Assignment to a line is automatic from the workflow; operators may switch between lines they own. |
+| **S-7** | Configuration over code | New/changed product workflows and formulas are authored in the UI and stored as data. No recompilation, no developer in the loop to onboard a product type. |
+
+---
+
+## 6. Bounded Context & Core Aggregates (conceptual)
+
+Names are conceptual; fields are defined later in `shopfloor-01-domain-model.md`.
+
+| Aggregate | Responsibility | Persistence (proposed) |
+|-----------|----------------|------------------------|
+| **WorkflowTemplate** | The flow for one product type: nodes (operations), edges (dependencies), per-node formulas + material lines. Authored in Workflow Editor. | State-based (changes rarely; versioned) |
+| **ProductionOrder** | One legacy order released to production. Carries `productTypeCode` + `params` (width, height, fabric SKU, qty…) verbatim. Lifecycle: `Released → InProgress → Done / Stopped`. | Event-sourced (auditable lifecycle) |
+| **WorkItem** | One atomic task instance = (ProductionOrder × WorkflowTemplate node). Bound to a WorkStation, carries resolved materials and dependency links. Lifecycle: `Blocked → Pending → InProgress → Done / Stopped`. | Event-sourced (traceability + actual qty) |
+| **WorkStation** | A physical workplace (fabric cutting, aluminium saw, steel saw, assembly, semi-assembly, profile cutting). Holds the ordered queue of its WorkItems; has a WIP/CONWIP limit. | State-based |
+
+Supporting concepts (not necessarily their own aggregates in Phase 1):
+- **Release batch** — the morning grouping of orders. Modeled as an ingestion grouping key,
+  not a rigid aggregate. The "packs by product type" behavior emerges from queue ordering
+  (SetupGain), not from a hard batch entity.
+- **Label** — semi-finished + finished print artifacts, attached to WorkItem / ProductionOrder.
+
+**Parallel branches** in a workflow (e.g. the pliss-blind example: `ATSVARO PJOVIMAS`,
+`VELENO PJOVIMAS`, `AUDINIO PJOVIMAS` → `AUDINIO KLIJAVIMAS` → finish) become independent
+WorkItems on possibly different WorkStations. A downstream WorkItem stays `Blocked` until
+its `dependsOn` predecessors are `Done`. One operator covering several stations simply sees
+those WorkItems across the queues they own.
+
+---
+
+## 7. The Four Engines (architectural placement)
+
+These are the product's differentiators. Each is a capability with a clear home; depth is
+specced in its own blueprint.
+
+**7.1 Flow Engine** — `WorkflowTemplate` interpretation. Already prototyped as the
+Workflow Editor (DAG of nodes/edges, cycle-safe, exportable JSON). Architecturally: the
+template is data; a runtime expander turns `order × template` into WorkItems + dependencies.
+
+**7.2 Formula Engine** — Excel-like expressions per task (`fabric_length_mm = CEILING((height_mm+20)*1.01, 1)`).
+Evaluated server-side at WorkItem creation against the order's `params`, producing concrete
+quantities and cut dimensions. Inputs are the order params + upstream results; outputs feed
+material resolution and operator instructions. (Engine choice — e.g. NCalc-class — is a
+blueprint decision, not an architecture one.)
+
+**7.3 Prioritization Engine (Take-Next)** — orders each WorkStation queue by a weighted score.
+This is the headline selling point. Conceptual score:
+
+```
+Score(workItem) =
+      KitImpact      // how much this moves an order toward final assembly (highest weight)
+    + DueSoon        // urgency vs. due date
+    + SetupGain      // bonus when it matches the current batch (same size/colour/material) → fewer changeovers
+    + QueuePressure  // de-prioritize overloaded downstream stations (WIP/CONWIP gate)
+    + Fairness       // prevent cherry-picking only easy tasks ("Sąžiningumo taisyklė")
+    + CustomRules     // configurable per deployment
+```
+
+Weights and the exact function are configuration (S-7), tuned without redeploy. The engine
+is pure/deterministic over a queue snapshot so it can be tested and audited.
+
+**7.4 Digital Twin & Monitoring** — read-model projection of live floor state for the
+dashboard: per node (current task, operator, elapsed, WIP, throughput) and per edge (queue
+length, mean/P90 wait, throughput), rendered as colour = bottleneck severity, thickness =
+load, animation = flow. Built from WorkItem lifecycle events; exported to Prometheus/Grafana.
+
+---
+
+## 8. Integration — Legacy System (ACL)
+
+New project: `Integration.LegacyOrders` (Anti-Corruption Layer).
+
+- **Inbound (read):** a polling worker queries legacy MS SQL on the same subnet
+  (username/password connection) for orders newly flagged "released to production".
+  It translates each into a domain message and publishes to RabbitMQ
+  (`ProductionOrderReleased`). Translation isolates all legacy schema quirks here.
+- **Outbound (status write-back):** when a `ProductionOrder` reaches `Done` or `Stopped`,
+  the ACL consumes the internal event and writes the status back to the legacy
+  table/stored procedure ("manufactured" / "stopped").
+- **Idempotency:** polling must be safe to re-run; the ACL dedups by legacy order id +
+  release marker so the same order is not ingested twice.
+
+Direct DB access (not API) is acceptable for Phase 1 given the same-subnet trust boundary;
+the ACL is the single seam, so a future API/CDC swap touches only this module.
+
+---
+
+## 9. Integration — Warehouse
+
+All stock interaction respects Warehouse's existing contracts and Decision 1.
+
+| Shopfloor event | Warehouse reaction | Existing command |
+|---|---|---|
+| Order released → reserve materials | SOFT reservation across resolved WorkItem materials | `AllocateReservationCommand` |
+| WorkItem completed (actual qty entered) | Write-off the **actual** quantity from stock | `RecordStockMovementCommand` (→ PRODUCTION) |
+| WorkItem stopped | nothing consumed — reservation persists | — |
+| Order stopped / cancelled | release reservation | (reservation cancel) |
+
+Material resolution (`fabric_sku` from order, or template-fixed SKU) maps directly onto a
+Warehouse `Item.InternalSKU`. Note the seam already anticipated in master data:
+`Item.ProductConfigId -- FK to Product Config module`.
+
+**Edge case — material not on hand at start:** treated as a stop condition for that
+WorkItem / order, surfaced to the operator and back to legacy as "stopped". Not a happy path.
+
+---
+
+## 10. End-to-End Flow (happy path)
+
+```
+1. Morning poll: legacy orders flagged "released"  ──▶  Integration.LegacyOrders
+2. ACL publishes ProductionOrderReleased {legacyId, productTypeCode, params}  ──▶ RabbitMQ
+3. Shopfloor creates ProductionOrder; loads WorkflowTemplate[productTypeCode]
+4. Flow Engine expands order × template  ──▶  WorkItems (+ dependencies, + resolved materials)
+5. Formula Engine computes cut sizes / quantities from params
+6. Reservation: MaterialReservationRequested  ──▶  Warehouse AllocateReservation (SOFT)
+7. Each WorkStation queue is ordered by the Prioritization Engine
+8. Operator opens their line queue, works the top item, presses "Complete"
+9. Popup: operator enters ACTUAL quantity used (scrap / offcut aware)
+10. WorkItemCompleted  ──▶  MaterialConsumed  ──▶  Warehouse RecordStockMovement (actual)
+11. Dependent WorkItems unblock; Digital Twin + Grafana update
+12. When all WorkItems Done  ──▶  ProductionOrderCompleted
+13. ACL writes "manufactured" back to legacy
+```
+
+---
+
+## 11. Open Questions
+
+**Legacy contract**
+- Which legacy table/column marks an order "released to production", and which to update on
+  "manufactured/stopped"? Is it the same source the polling reads?
+- Are orders released individually or as a daily batch row? Poll cadence (30–60s acceptable)?
+- Exact `params` available per order (confirm fabric SKU, cut dimensions, qty multiplier).
+
+**Domain**
+- Is WorkItem lifecycle event-sourced (Marten) or state + audit log? (Architecture leans
+  event-sourced for traceability — confirm in domain blueprint.)
+- Queue ordering authority: pure engine score, or may a foreman manually reorder/override?
+- Do we need an explicit `ReleaseBatch` aggregate, or is grouping just a queue concern?
+
+**Execution**
+- Label format: plain barcode vs GS1-128/QR for semi-finished traceability?
+- WorkStation ↔ operator assignment model (a worker owning multiple stations — switch vs.
+  smart single-queue ordering).
+
+**Stock**
+- Reservation on release when stock is insufficient: create order as `MaterialShortage`, or
+  block creation?
+- Unit/rounding policy alignment with Warehouse `BaseUoM` (mm vs m for fabric).
+
+---
+
+## 12. Blueprint Roadmap (next documents)
+
+This file is the umbrella. Implementation blueprints follow, each self-contained:
+
+| # | Blueprint | Covers |
+|---|-----------|--------|
+| `shopfloor-01-domain-model` | Aggregates, events, lifecycle states, persistence split |
+| `shopfloor-02-legacy-integration` | ACL: poll query, message contracts, status write-back, idempotency |
+| `shopfloor-03-workflow-and-formula` | Template storage/versioning, formula grammar + evaluation |
+| `shopfloor-04-warehouse-integration` | Reservation + consumption contracts, SKU resolution |
+| `shopfloor-05-prioritization-engine` | Score model, coefficients, configuration, tests |
+| `shopfloor-06-operator-queue-ui` | Per-line queue UI, complete/stop + actual-qty flow |
+| `shopfloor-07-digital-twin` | Live projection, dashboard, Prometheus/Grafana export |
+
+**Build order:** 01 → 02 → 04 → 06 deliver the core loop (order → tasks → queue → consume →
+status back). 03/05/07 layer on the differentiators.

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/OperatorWorkQueue.razor
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/OperatorWorkQueue.razor
@@ -1,0 +1,9 @@
+@page "/operator-work-queue"
+
+<PageTitle>Cikada.MES · Operator Work Queue</PageTitle>
+
+<main class="workflow-page workflow-page--embed">
+    <iframe class="workflow-embed"
+            src="prototypes/operator-work-queue.html"
+            title="Shopfloor operator work queue prototype"></iframe>
+</main>

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Shared/NavMenu.razor
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Shared/NavMenu.razor
@@ -64,7 +64,7 @@
     {
         _currentPath = TrimPath(Navigation.ToBaseRelativePath(Navigation.Uri));
         Navigation.LocationChanged += OnLocationChanged;
-        _openSection = FindSectionForPath(_currentPath) ?? "engineering";
+        _openSection = FindSectionForPath(_currentPath) ?? "execution";
     }
 
     private void OnLocationChanged(object? sender, Microsoft.AspNetCore.Components.Routing.LocationChangedEventArgs e)
@@ -111,6 +111,9 @@
 
     private static readonly NavSection[] _sections =
     [
+        new("execution", "Execution", "bi-kanban", [
+            new("operator-work-queue", "bi-list-check", "Operator Queue"),
+        ]),
         new("engineering", "Engineering", "bi-diagram-3", [
             new("workflow-editor", "bi-diagram-3", "Workflow Editor"),
         ]),

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/operator-work-queue.html
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/operator-work-queue.html
@@ -1,0 +1,1053 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>LAURESTA · ShopfloorPilot — AUDINIO PJOVIMAS</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+<style>
+/* ── LKvitai.MES tokens (inlined for standalone drop-in) ─────────── */
+:root{
+  --n-0:#fff;--n-25:#fbfcfd;--n-50:#f5f6f8;--n-100:#eef1f4;--n-150:#e2e7ec;
+  --n-200:#d5dce4;--n-300:#b9c3ce;--n-400:#8996a4;--n-500:#66717f;--n-600:#4e5966;
+  --n-700:#323b45;--n-800:#1f2632;--n-900:#151922;
+  --accent-50:#eaf8f7;--accent-100:#d1eeec;--accent-400:#56aaa7;
+  --accent-500:#2f8f8b;--accent-600:#257773;--accent-700:#1d5d5a;
+  --sand-25:#faf6ee;--sand-50:#f7f1e5;--sand-100:#ede2c8;--sand-150:#e4dbc5;
+  --sand-300:#daceb7;--sand-500:#c79f63;--sand-600:#b08a4a;--sand-700:#7c5f2a;
+  --ok-fg:#19744a;--ok-bg:#e6f4ec;--ok-bd:#bfe0cd;--ok-dot:#1f9d61;
+  --warn-fg:#7c5f2a;--warn-bg:#f7eed5;--warn-bd:#e2cf9a;--warn-dot:#b08a4a;
+  --info-fg:#1d5d5a;--info-bg:#e3f2f1;--info-bd:#b4dad7;--info-dot:#2f8f8b;
+  --slate-fg:#3a4554;--slate-bg:#eaeef3;--slate-bd:#cdd5de;--slate-dot:#66717f;
+  --danger-fg:#8a1f12;--danger-bg:#fbe7e3;--danger-bd:#f0c2b8;--danger-dot:#c0392b;
+  --done-fg:#2a4a3a;--done-bg:#e3eee7;--done-bd:#bdd2c4;--done-dot:#4a7a5d;
+  --dark:#20242c;--dark-2:#171b22;--dark-line:#3a404c;
+  --dark-fg:#fff;--dark-fg-muted:#a5adb8;--dark-fg-dim:#9ba4b0;
+  --page-wash:#f0eee9;
+  --font-ui:Inter,"Segoe UI",system-ui,-apple-system,sans-serif;
+  --font-mono:"JetBrains Mono","SF Mono",Consolas,monospace;
+  --r-xs:3px;--r-sm:5px;--r-md:7px;--r-lg:10px;--r-pill:999px;
+  --shadow-xs:0 1px 0 rgba(15,23,35,.04);
+  --shadow-sm:0 1px 2px rgba(15,23,35,.06),0 0 0 1px rgba(15,23,35,.03);
+  --shadow-md:0 6px 18px rgba(15,23,42,.08);
+  --shadow-lg:0 14px 30px rgba(15,23,42,.12);
+}
+*{box-sizing:border-box}
+html,body{margin:0;height:100%}
+body{
+  font-family:var(--font-ui);font-size:12.5px;line-height:1.45;color:var(--n-900);
+  background:var(--page-wash);-webkit-font-smoothing:antialiased;
+}
+button,input,select{font:inherit;color:inherit}
+.mono{font-family:var(--font-mono);font-feature-settings:"zero";font-variant-numeric:tabular-nums}
+
+/* ── App shell ───────────────────────────────────────────────────── */
+.app{display:flex;flex-direction:column;height:100vh;max-width:1680px;margin:0 auto;
+  background:var(--n-50);box-shadow:0 0 40px rgba(0,0,0,.05);overflow:hidden}
+
+/* ── Topbar ──────────────────────────────────────────────────────── */
+.topbar{display:flex;align-items:center;gap:18px;padding:11px 22px;background:var(--dark);
+  color:var(--n-0);border-bottom:1px solid var(--dark-line);flex:0 0 auto}
+.brand{display:flex;align-items:center;gap:11px}
+.brand__mark{display:grid;place-items:center;width:34px;height:34px;flex:0 0 auto;
+  border:1px solid var(--dark-line);border-radius:6px;background:var(--dark-2);
+  color:var(--accent-400);font-family:var(--font-mono);font-size:13px;font-weight:700}
+.brand__name{font-size:14px;font-weight:700;line-height:1.1;white-space:nowrap}
+.brand__name span{color:var(--dark-fg-dim);font-weight:400}
+.brand__tag{margin-top:1px;color:var(--dark-fg-muted);font-family:var(--font-mono);
+  font-size:9.5px;letter-spacing:1.4px;text-transform:uppercase}
+.tsep{width:1px;height:30px;background:var(--dark-line);flex:0 0 auto}
+
+/* Station pill + switcher */
+.station{display:flex;align-items:center;gap:10px;position:relative}
+.station-pill{display:flex;align-items:center;gap:11px;padding:6px 12px;border-radius:var(--r-md);
+  background:#1b2028;border:1px solid var(--dark-line)}
+.station-pill__ico{display:grid;place-items:center;width:26px;height:26px;border-radius:var(--r-sm);
+  background:rgba(47,143,139,.16);color:var(--accent-400);font-family:var(--font-mono);font-size:13px;font-weight:700}
+.station-pill__code{font-family:var(--font-mono);font-size:12px;font-weight:700;letter-spacing:.4px;color:var(--n-0)}
+.station-pill__sub{color:var(--dark-fg-muted);font-size:10.5px}
+.switch-btn{display:grid;place-items:center;width:30px;height:30px;border-radius:var(--r-sm);
+  border:1px solid var(--dark-line);background:#1b2028;color:var(--dark-fg-muted);cursor:pointer;font-size:11px}
+.switch-btn:hover{color:var(--n-0);border-color:var(--n-500)}
+.switch-menu{position:absolute;top:46px;left:0;z-index:40;min-width:330px;padding:6px;
+  background:var(--n-0);border:1px solid var(--n-200);border-radius:var(--r-md);box-shadow:var(--shadow-lg);display:none}
+.switch-menu.open{display:block}
+.switch-menu__lbl{padding:7px 9px 5px;color:var(--n-500);font-family:var(--font-mono);
+  font-size:9.5px;font-weight:800;letter-spacing:1.2px;text-transform:uppercase}
+.switch-row{display:flex;align-items:center;gap:11px;padding:9px;border-radius:var(--r-sm);cursor:pointer}
+.switch-row:hover{background:var(--n-50)}
+.switch-row.is-current{background:var(--accent-50)}
+.switch-row__ico{display:grid;place-items:center;width:30px;height:30px;border-radius:var(--r-sm);
+  background:var(--n-100);color:var(--n-600);font-family:var(--font-mono);font-size:12px;font-weight:700;flex:0 0 auto}
+.switch-row.is-current .switch-row__ico{background:var(--accent-100);color:var(--accent-700)}
+.switch-row__code{font-family:var(--font-mono);font-size:12px;font-weight:700;color:var(--n-800)}
+.switch-row__sub{color:var(--n-500);font-size:11px}
+.switch-row__depth{margin-left:auto;text-align:right}
+.switch-row__depth b{font-family:var(--font-mono);font-size:14px;font-weight:800;color:var(--n-800)}
+.switch-row__depth span{display:block;color:var(--n-400);font-family:var(--font-mono);
+  font-size:8.5px;font-weight:700;letter-spacing:.8px;text-transform:uppercase}
+
+.spacer{flex:1}
+.env-badge{display:flex;border:1px solid var(--dark-line);border-radius:var(--r-sm);overflow:hidden;background:#1b2028}
+.env-badge div{display:flex;align-items:center;gap:7px;padding:5px 10px}
+.env-badge div+div{border-left:1px solid var(--dark-line)}
+.env-badge span{color:var(--dark-fg-dim);font-family:var(--font-mono);font-size:9.5px}
+.env-badge strong{color:var(--n-0);font-family:var(--font-mono);font-size:11px}
+.env-badge .warn-text{color:#dfc07a}
+.op-chip{display:flex;align-items:center;gap:9px;padding-left:16px;border-left:1px solid var(--dark-line)}
+.op-chip__avatar{display:grid;place-items:center;width:30px;height:30px;border-radius:50%;
+  background:var(--dark-line);color:var(--accent-400);font-family:var(--font-mono);font-size:11px;font-weight:700}
+.op-chip__name{font-size:12px;font-weight:700}
+.op-chip__role{color:var(--dark-fg-dim);font-size:10px}
+
+/* ── Stats strip ─────────────────────────────────────────────────── */
+.stats{display:flex;align-items:stretch;gap:0;padding:0 22px;background:var(--n-0);
+  border-bottom:1px solid var(--n-150);flex:0 0 auto}
+.stat{display:flex;flex-direction:column;justify-content:center;gap:2px;padding:11px 26px 11px 0;margin-right:26px;
+  border-right:1px solid var(--n-150)}
+.stat:last-of-type{border-right:0}
+.stat__lbl{display:flex;align-items:center;gap:6px;color:var(--n-500);font-family:var(--font-mono);
+  font-size:9.5px;font-weight:800;letter-spacing:1.1px;text-transform:uppercase}
+.stat__lbl::before{content:"";width:7px;height:7px;border-radius:50%;background:var(--n-300)}
+.stat--done .stat__lbl::before{background:var(--done-dot)}
+.stat--rem .stat__lbl::before{background:var(--accent-500)}
+.stat--cph .stat__lbl::before{background:var(--info-dot)}
+.stat--wip .stat__lbl::before{background:var(--warn-dot)}
+.stat__val{font-family:var(--font-mono);font-size:23px;font-weight:800;color:var(--n-900);line-height:1;letter-spacing:-.5px}
+.stat__val small{font-size:12px;font-weight:600;color:var(--n-400);margin-left:3px}
+.stats__right{margin-left:auto;display:flex;align-items:center;gap:14px}
+.target-pill{display:flex;align-items:center;gap:9px;padding:6px 12px;border:1px solid var(--n-200);
+  border-radius:var(--r-pill);background:var(--n-25);font-size:11.5px;color:var(--n-600)}
+.target-pill b{font-family:var(--font-mono);color:var(--n-800);font-weight:800}
+.target-pill .bar{width:90px;height:6px;border-radius:99px;background:var(--n-150);overflow:hidden}
+.target-pill .bar i{display:block;height:100%;border-radius:99px;background:var(--accent-500)}
+
+/* ── Workspace (queue + detail) ──────────────────────────────────── */
+.work{display:grid;grid-template-columns:minmax(0,1fr) 484px;gap:0;flex:1 1 auto;min-height:0}
+.queue-col{display:flex;flex-direction:column;min-width:0;border-right:1px solid var(--n-150);background:var(--n-50)}
+.detail-col{display:flex;flex-direction:column;min-width:0;background:var(--n-25);overflow-y:auto}
+
+/* Queue toolbar */
+.qtoolbar{display:flex;align-items:center;gap:10px;padding:10px 18px;background:var(--n-0);
+  border-bottom:1px solid var(--n-150);flex:0 0 auto}
+.qtitle{display:flex;flex-direction:column;gap:1px;margin-right:6px}
+.qtitle b{font-size:13px;font-weight:800;color:var(--n-900)}
+.qtitle span{display:flex;align-items:center;gap:5px;color:var(--n-500);font-size:10.5px}
+.qtitle span::before{content:"";width:5px;height:5px;border-radius:50%;background:var(--accent-500);
+  box-shadow:0 0 0 3px var(--accent-50)}
+.field{display:flex;align-items:center;gap:7px;min-height:30px;padding:0 9px;border:1px solid var(--n-200);
+  border-radius:var(--r-sm);background:var(--n-50);color:var(--n-600)}
+.field:focus-within{border-color:var(--accent-500);box-shadow:0 0 0 3px var(--accent-50);background:var(--n-0)}
+.field--search{flex:1 1 200px;max-width:300px}
+.field input{border:0;outline:0;background:transparent;color:var(--n-900);font-size:12px;width:100%}
+.field__ico{width:12px;height:12px;border:1.7px solid var(--n-400);border-radius:50%;position:relative;flex:0 0 auto}
+.field__ico::after{content:"";position:absolute;right:-4px;bottom:-3px;width:5px;height:1.7px;background:var(--n-400);transform:rotate(45deg);transform-origin:left}
+.toggle{display:inline-flex;align-items:center;gap:8px;padding:5px 11px 5px 9px;border:1px solid var(--n-200);
+  border-radius:var(--r-pill);background:var(--n-0);cursor:pointer;font-size:11.5px;color:var(--n-600);white-space:nowrap}
+.toggle.on{border-color:var(--accent-500);background:var(--accent-50);color:var(--accent-700);font-weight:700}
+.toggle__sw{width:26px;height:15px;border-radius:99px;background:var(--n-200);position:relative;transition:background .15s}
+.toggle.on .toggle__sw{background:var(--accent-500)}
+.toggle__sw::after{content:"";position:absolute;top:2px;left:2px;width:11px;height:11px;border-radius:50%;
+  background:#fff;transition:transform .15s}
+.toggle.on .toggle__sw::after{transform:translateX(11px)}
+.engine-note{display:flex;align-items:center;gap:7px;margin-left:auto;padding:5px 11px;border-radius:var(--r-pill);
+  background:var(--info-bg);border:1px solid var(--info-bd);color:var(--info-fg);font-size:11px;font-weight:600}
+.engine-note .dot{width:6px;height:6px;border-radius:50%;background:var(--info-dot)}
+
+/* Queue scroll body */
+.qscroll{flex:1 1 auto;overflow-y:auto;min-height:0}
+.qtable{width:100%;border-collapse:collapse}
+.qtable thead th{position:sticky;top:0;z-index:3;background:var(--n-50);color:var(--n-600);
+  border-bottom:1px solid var(--n-200);padding:8px 12px;text-align:left;white-space:nowrap;
+  font-family:var(--font-mono);font-size:9.5px;font-weight:800;letter-spacing:.6px;text-transform:uppercase}
+.qtable thead th.num{text-align:right}
+.qtable thead th.cut-h{color:var(--accent-700)}
+
+/* group header */
+.grp-row td{position:sticky;top:33px;z-index:2;padding:6px 12px 6px 16px;
+  background:var(--sand-25);border-bottom:1px solid var(--sand-150);border-top:1px solid var(--sand-150)}
+.grp{display:flex;align-items:center;gap:10px}
+.grp__band{width:8px;height:8px;border-radius:2px;flex:0 0 auto}
+.grp__sku{font-family:var(--font-mono);font-size:11.5px;font-weight:800;color:var(--sand-700);letter-spacing:.4px}
+.grp__name{color:var(--n-600);font-size:11px}
+.grp__meta{margin-left:auto;display:flex;align-items:center;gap:8px;color:var(--sand-700);font-size:10.5px}
+.grp__save{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:var(--r-pill);
+  background:var(--info-bg);border:1px solid var(--info-bd);color:var(--info-fg);
+  font-family:var(--font-mono);font-size:9.5px;font-weight:700;letter-spacing:.3px}
+
+/* item rows */
+.qrow{cursor:pointer;border-bottom:1px solid var(--n-100)}
+.qrow td{padding:9px 12px;vertical-align:middle;white-space:nowrap;background:var(--n-0)}
+.qrow:hover td{background:var(--n-25)}
+.qrow.sel td{background:var(--accent-50)}
+.qrow.sel td:first-child{box-shadow:inset 4px 0 0 var(--accent-500)}
+.qrow.done td{opacity:.62}
+.qrow.stopped td{background:#fdf3f1}
+.qrow.stopped:hover td{background:#fbe7e3}
+.qrow td.clband{width:6px;padding:0}
+.clband i{display:block;width:4px;height:38px;border-radius:2px;margin-left:6px}
+
+.ord{font-family:var(--font-mono);font-size:12px;font-weight:800;color:var(--accent-700);letter-spacing:.2px}
+.prod{color:var(--n-500);font-size:11px;margin-top:1px;max-width:230px;overflow:hidden;text-overflow:ellipsis}
+.flip-tag{display:inline-block;margin-left:6px;padding:1px 6px;border-radius:var(--r-xs);
+  background:var(--slate-bg);border:1px solid var(--slate-bd);color:var(--slate-fg);
+  font-family:var(--font-mono);font-size:9px;font-weight:700;letter-spacing:.4px;vertical-align:middle}
+.sku-chip{display:inline-flex;align-items:center;padding:3px 9px;border-radius:var(--r-sm);
+  background:var(--n-800);color:#fff;font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.5px}
+.cut-cell{text-align:right}
+.cut-val{font-family:var(--font-mono);font-size:18px;font-weight:800;color:var(--n-900);
+  font-variant-numeric:tabular-nums;letter-spacing:-.5px;line-height:1}
+.cut-val small{font-size:10px;font-weight:600;color:var(--n-400);margin-left:2px}
+.cut-cell.zero .cut-val{color:var(--n-300)}
+.qty{font-family:var(--font-mono);font-size:12.5px;font-weight:700;color:var(--n-700);text-align:right}
+.qty b{display:inline-block;padding:2px 7px;border-radius:var(--r-sm);background:var(--warn-bg);
+  border:1px solid var(--warn-bd);color:var(--warn-fg);font-weight:800}
+.due{font-family:var(--font-mono);font-size:12px;font-weight:700;font-variant-numeric:tabular-nums}
+.due--today{color:var(--danger-fg)}
+.due--soon{color:var(--sand-700)}
+.due--later{color:var(--n-500)}
+.due small{display:block;font-size:9px;font-weight:700;letter-spacing:.4px;text-transform:uppercase;opacity:.85}
+
+/* chips */
+.chip{display:inline-flex;align-items:center;gap:6px;padding:3px 9px;border:1px solid transparent;
+  border-radius:var(--r-pill);font-family:var(--font-mono);font-size:10px;font-weight:700;
+  letter-spacing:.4px;text-transform:uppercase;line-height:1;white-space:nowrap}
+.chip::before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor;flex:0 0 auto}
+.chip--slate{background:var(--slate-bg);color:var(--slate-fg);border-color:var(--slate-bd)}
+.chip--warn{background:var(--warn-bg);color:var(--warn-fg);border-color:var(--warn-bd)}
+.chip--danger{background:var(--danger-bg);color:var(--danger-fg);border-color:var(--danger-bd)}
+.chip--done{background:var(--done-bg);color:var(--done-fg);border-color:var(--done-bd)}
+.chip--info{background:var(--info-bg);color:var(--info-fg);border-color:var(--info-bd)}
+.chip--ok{background:var(--ok-bg);color:var(--ok-fg);border-color:var(--ok-bd)}
+.chip--sm{padding:2px 7px;font-size:9px}
+
+/* reason chip */
+.reason{display:inline-flex;align-items:center;gap:5px;padding:2px 8px;border-radius:var(--r-sm);
+  font-family:var(--font-mono);font-size:9.5px;font-weight:700;letter-spacing:.2px;border:1px solid transparent}
+.reason::before{content:"";width:5px;height:5px;border-radius:50%;background:currentColor}
+.reason--due{background:var(--danger-bg);color:var(--danger-fg);border-color:var(--danger-bd)}
+.reason--batch{background:var(--info-bg);color:var(--info-fg);border-color:var(--info-bd)}
+.reason--kit{background:var(--ok-bg);color:var(--ok-fg);border-color:var(--ok-bd)}
+.reason--fair{background:var(--slate-bg);color:var(--slate-fg);border-color:var(--slate-bd)}
+
+/* action buttons in row */
+.act{display:flex;gap:6px;justify-content:flex-end}
+.btn{display:inline-flex;align-items:center;justify-content:center;gap:6px;min-height:30px;padding:6px 13px;
+  border:1px solid var(--n-200);border-radius:var(--r-sm);background:var(--n-0);color:var(--n-700);
+  font-size:12px;font-weight:700;cursor:pointer;white-space:nowrap}
+.btn:hover{background:var(--n-25)}
+.btn--primary{border-color:var(--accent-700);background:var(--accent-600);color:#fff}
+.btn--primary:hover{background:var(--accent-700)}
+.btn--danger{border-color:var(--danger-bd);background:var(--n-0);color:var(--danger-fg)}
+.btn--danger:hover{background:var(--danger-bg)}
+.btn--sm{min-height:27px;padding:4px 11px;font-size:11.5px}
+.btn:disabled{border-style:dashed;background:var(--n-50);color:var(--n-300);cursor:not-allowed}
+.btn--block{width:100%}
+
+/* ── Detail card ─────────────────────────────────────────────────── */
+.detail{padding:16px 18px 22px;display:flex;flex-direction:column;gap:14px}
+.detail__crumb{display:flex;align-items:center;gap:6px;color:var(--n-500);font-size:11px}
+.detail__crumb b{color:var(--n-700);font-family:var(--font-mono)}
+.dhead{padding:14px 15px;border:1px solid var(--n-200);border-radius:var(--r-md);background:var(--n-0)}
+.dhead__top{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}
+.dhead__id{color:var(--accent-700);font-family:var(--font-mono);font-size:11px;font-weight:800;letter-spacing:.4px}
+.dhead h2{margin:4px 0 0;font-size:19px;font-weight:800;color:var(--n-900)}
+.dhead__dims{font-family:var(--font-mono)}
+.dhead__sub{display:flex;flex-wrap:wrap;gap:6px 14px;margin-top:8px;color:var(--n-600);font-size:11.5px}
+.dhead__sub b{color:var(--n-800)}
+
+/* spec strip */
+.spec{display:grid;grid-template-columns:1.3fr 1fr 1fr;gap:1px;background:var(--n-200);
+  border:1px solid var(--n-200);border-radius:var(--r-md);overflow:hidden}
+.spec__cell{background:var(--n-0);padding:11px 13px;display:flex;flex-direction:column;gap:3px}
+.spec__cell--hero{background:linear-gradient(180deg,var(--accent-50),#fff)}
+.spec__lbl{color:var(--n-500);font-family:var(--font-mono);font-size:9px;font-weight:800;letter-spacing:1px;text-transform:uppercase}
+.spec__val{font-family:var(--font-mono);font-size:17px;font-weight:800;color:var(--n-900);font-variant-numeric:tabular-nums;line-height:1.05}
+.spec__val small{font-size:10px;font-weight:600;color:var(--n-400)}
+.spec__cell--hero .spec__val{font-size:28px;color:var(--accent-700);letter-spacing:-1px}
+.spec__cell--hero .spec__lbl{color:var(--accent-600)}
+
+/* section */
+.dsection{display:flex;flex-direction:column;gap:9px}
+.dsection__lbl{display:flex;align-items:center;gap:8px;color:var(--n-700);font-size:12px;font-weight:800}
+.dsection__lbl span{color:var(--n-400);font-weight:500;font-size:11px}
+
+/* materials */
+.matgroup{border:1px solid var(--n-200);border-radius:var(--r-md);overflow:hidden;background:var(--n-0)}
+.matgroup__head{display:flex;align-items:center;gap:8px;padding:7px 12px;border-bottom:1px solid var(--n-150)}
+.matgroup--order .matgroup__head{background:var(--accent-50);border-bottom-color:var(--accent-100)}
+.matgroup--tpl .matgroup__head{background:var(--sand-25);border-bottom-color:var(--sand-150)}
+.matgroup__tag{font-family:var(--font-mono);font-size:9px;font-weight:800;letter-spacing:.8px;text-transform:uppercase;
+  padding:2px 7px;border-radius:var(--r-xs)}
+.matgroup--order .matgroup__tag{background:var(--accent-600);color:#fff}
+.matgroup--tpl .matgroup__tag{background:var(--sand-600);color:#fff}
+.matgroup__title{font-size:11.5px;font-weight:700;color:var(--n-700)}
+.matgroup__note{margin-left:auto;color:var(--n-500);font-size:10.5px}
+.matrow{display:flex;align-items:center;gap:11px;padding:8px 12px;border-bottom:1px solid var(--n-100)}
+.matrow:last-child{border-bottom:0}
+.matrow__sku{display:inline-flex;align-items:center;padding:3px 8px;border-radius:var(--r-sm);
+  background:var(--n-800);color:#fff;font-family:var(--font-mono);font-size:10.5px;font-weight:700;flex:0 0 auto}
+.matrow__name{font-size:12px;color:var(--n-800);min-width:0}
+.matrow__name small{display:block;color:var(--n-500);font-size:10.5px}
+.matrow__bin{margin-left:auto;text-align:right;flex:0 0 auto}
+.matrow__bin b{font-family:var(--font-mono);font-size:11px;font-weight:700;color:var(--n-700)}
+.matrow__bin span{display:block;color:var(--n-400);font-family:var(--font-mono);font-size:8.5px;font-weight:700;letter-spacing:.6px;text-transform:uppercase}
+.matrow__req{font-family:var(--font-mono);font-size:13px;font-weight:800;color:var(--accent-700);flex:0 0 auto;text-align:right;min-width:78px}
+.matrow__req small{font-size:9px;color:var(--n-400);font-weight:600}
+
+/* label preview */
+.label-prev{display:flex;align-items:stretch;gap:12px;padding:12px;border:1px dashed var(--n-300);
+  border-radius:var(--r-md);background:repeating-linear-gradient(45deg,#fcfcfa,#fcfcfa 6px,#f7f7f4 6px,#f7f7f4 12px)}
+.label-card{flex:1 1 auto;background:#fff;border:1px solid var(--n-300);border-radius:var(--r-sm);padding:9px 11px;box-shadow:var(--shadow-xs)}
+.label-card__top{display:flex;align-items:center;justify-content:space-between;border-bottom:1px solid var(--n-150);padding-bottom:5px;margin-bottom:6px}
+.label-card__tag{font-family:var(--font-mono);font-size:10px;font-weight:800;letter-spacing:1px;color:var(--n-800)}
+.label-card__semi{font-family:var(--font-mono);font-size:9px;font-weight:800;letter-spacing:1px;
+  padding:2px 7px;border-radius:var(--r-xs);background:var(--n-900);color:#fff}
+.label-card__grid{display:grid;grid-template-columns:1fr 1fr;gap:3px 12px;font-family:var(--font-mono);font-size:10.5px}
+.label-card__grid div{display:flex;justify-content:space-between;gap:8px}
+.label-card__grid span{color:var(--n-500)}
+.label-card__grid b{color:var(--n-900);font-weight:700}
+.label-card__bars{display:flex;gap:1.5px;height:26px;margin-top:7px;align-items:flex-end}
+.label-card__bars i{flex:1;background:var(--n-900)}
+.label-side{display:flex;flex-direction:column;justify-content:center;gap:8px;flex:0 0 96px}
+.label-side .btn{width:100%}
+
+/* primary actions */
+.dactions{display:grid;grid-template-columns:1fr 1fr;gap:9px}
+.dactions .btn{min-height:42px;font-size:13px}
+.dactions .btn--block{grid-column:1 / -1}
+
+/* queue-depth ahead footer of detail */
+.depth-ahead{display:flex;align-items:center;gap:10px;padding:10px 13px;border:1px solid var(--n-200);
+  border-radius:var(--r-md);background:var(--n-0)}
+.depth-ahead__n{font-family:var(--font-mono);font-size:20px;font-weight:800;color:var(--n-800)}
+.depth-ahead__txt{font-size:11px;color:var(--n-500);line-height:1.3}
+.depth-ahead__txt b{color:var(--n-700)}
+.depth-ahead__spark{margin-left:auto;display:flex;align-items:flex-end;gap:2px;height:26px}
+.depth-ahead__spark i{width:5px;background:var(--accent-100);border-radius:1px}
+.depth-ahead__spark i.hot{background:var(--accent-500)}
+
+/* empty detail */
+.detail-empty{flex:1;display:flex;flex-direction:column;align-items:center;justify-content:center;gap:10px;
+  padding:40px;text-align:center;color:var(--n-400)}
+.detail-empty b{color:var(--n-600);font-size:14px}
+
+/* ── Modal ───────────────────────────────────────────────────────── */
+.scrim{position:fixed;inset:0;z-index:100;background:rgba(20,24,32,.42);display:none;
+  align-items:center;justify-content:center;padding:24px}
+.scrim.open{display:flex}
+.modal{width:520px;max-width:100%;max-height:92vh;overflow:auto;background:var(--n-0);
+  border:1px solid var(--n-200);border-radius:var(--r-lg);box-shadow:var(--shadow-lg);
+  animation:pop .16s ease-out}
+@keyframes pop{from{transform:translateY(8px) scale(.985);opacity:0}to{transform:none;opacity:1}}
+.modal__head{display:flex;align-items:flex-start;justify-content:space-between;gap:14px;padding:16px 18px;
+  border-bottom:1px solid var(--n-150)}
+.modal__head .eyebrow{color:var(--accent-700);font-family:var(--font-mono);font-size:10px;font-weight:800;
+  letter-spacing:1.4px;text-transform:uppercase;margin-bottom:5px}
+.modal__head h3{margin:0;font-size:18px;font-weight:800}
+.modal__head .ord{font-size:11px}
+.modal__x{border:1px solid var(--n-200);background:var(--n-0);width:30px;height:30px;border-radius:var(--r-sm);
+  cursor:pointer;color:var(--n-500);font-size:15px;flex:0 0 auto}
+.modal__x:hover{background:var(--n-50)}
+.modal__body{padding:18px}
+.modal__foot{display:flex;align-items:center;gap:10px;padding:14px 18px;border-top:1px solid var(--n-150);background:var(--n-25)}
+.modal__foot .grow{flex:1}
+
+/* complete modal: planned vs actual */
+.consume{display:grid;grid-template-columns:1fr auto 1fr;align-items:stretch;gap:12px;margin-bottom:16px}
+.consume__col{border:1px solid var(--n-200);border-radius:var(--r-md);padding:13px;background:var(--n-25)}
+.consume__col--actual{border-color:var(--accent-500);background:linear-gradient(180deg,var(--accent-50),#fff)}
+.consume__lbl{color:var(--n-500);font-family:var(--font-mono);font-size:9.5px;font-weight:800;letter-spacing:1px;text-transform:uppercase;margin-bottom:8px}
+.consume__col--actual .consume__lbl{color:var(--accent-700)}
+.consume__big{font-family:var(--font-mono);font-size:24px;font-weight:800;color:var(--n-900);font-variant-numeric:tabular-nums}
+.consume__big small{font-size:12px;color:var(--n-400);font-weight:600}
+.consume__calc{margin-top:5px;color:var(--n-500);font-family:var(--font-mono);font-size:10.5px}
+.consume__arrow{display:flex;align-items:center;color:var(--n-300);font-size:20px;font-weight:700}
+.consume__input{display:flex;align-items:baseline;gap:6px}
+.consume__input input{width:96px;border:1px solid var(--accent-500);border-radius:var(--r-sm);
+  padding:6px 8px;font-family:var(--font-mono);font-size:22px;font-weight:800;color:var(--accent-700);
+  background:#fff;outline:none;font-variant-numeric:tabular-nums}
+.consume__input input:focus{box-shadow:0 0 0 3px var(--accent-50)}
+.consume__input span{font-family:var(--font-mono);font-size:12px;color:var(--n-500);font-weight:600}
+.delta{display:inline-flex;align-items:center;gap:6px;margin-top:7px;padding:2px 8px;border-radius:var(--r-pill);
+  font-family:var(--font-mono);font-size:10px;font-weight:700}
+.delta--match{background:var(--ok-bg);color:var(--ok-fg)}
+.delta--over{background:var(--warn-bg);color:var(--warn-fg)}
+.delta--under{background:var(--info-bg);color:var(--info-fg)}
+.fl{display:flex;flex-direction:column;gap:6px;margin-top:14px}
+.fl__lbl{color:var(--n-600);font-size:11.5px;font-weight:700}
+.fl__lbl small{color:var(--n-400);font-weight:500}
+.fl select,.fl textarea,.fl input{border:1px solid var(--n-200);border-radius:var(--r-sm);padding:8px 10px;
+  font-size:12.5px;background:var(--n-0);color:var(--n-900);outline:none;resize:vertical;width:100%;font-family:var(--font-ui)}
+.fl select:focus,.fl textarea:focus,.fl input:focus{border-color:var(--accent-500);box-shadow:0 0 0 3px var(--accent-50)}
+.reason-pills{display:flex;flex-wrap:wrap;gap:7px}
+.reason-pills button{padding:6px 12px;border:1px solid var(--n-200);border-radius:var(--r-pill);background:var(--n-0);
+  color:var(--n-600);font-size:11.5px;font-weight:600;cursor:pointer}
+.reason-pills button.on{border-color:var(--accent-500);background:var(--accent-50);color:var(--accent-700);font-weight:700}
+.modal-note{display:flex;gap:9px;padding:10px 12px;border-radius:var(--r-md);background:var(--info-bg);
+  border:1px solid var(--info-bd);color:var(--info-fg);font-size:11.5px;line-height:1.4}
+.modal-note.warn{background:var(--warn-bg);border-color:var(--warn-bd);color:var(--warn-fg)}
+
+/* success toast */
+.toast{position:fixed;left:50%;bottom:30px;transform:translateX(-50%) translateY(20px);z-index:120;
+  display:flex;align-items:center;gap:11px;padding:13px 18px;border-radius:var(--r-md);
+  background:var(--n-900);color:#fff;box-shadow:var(--shadow-lg);opacity:0;pointer-events:none;
+  transition:opacity .25s,transform .25s}
+.toast.show{opacity:1;transform:translateX(-50%) translateY(0)}
+.toast__ico{display:grid;place-items:center;width:26px;height:26px;border-radius:50%;background:var(--ok-dot);
+  color:#fff;font-size:14px;font-weight:800}
+.toast b{font-weight:700}
+.toast span{color:var(--dark-fg-muted);font-size:11.5px}
+
+/* unblock pulse */
+@keyframes unblockPulse{0%{background:var(--ok-bg)}100%{background:var(--n-0)}}
+.qrow.unblocking td{animation:unblockPulse 1.6s ease-out}
+@keyframes doneFlash{0%{background:var(--ok-bg)}60%{background:var(--ok-bg)}100%{background:var(--n-0)}}
+.qrow.done-flash td{animation:doneFlash 1.1s ease-out}
+.collapse{animation:collapseRow .5s ease forwards}
+@keyframes collapseRow{to{opacity:0;transform:translateX(14px)}}
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- TOPBAR -->
+  <header class="topbar">
+    <div class="brand">
+      <div class="brand__mark">LK</div>
+      <div>
+        <div class="brand__name">LAURESTA<span> · ShopfloorPilot</span></div>
+        <div class="brand__tag">LKvitai · MES · Shopfloor</div>
+      </div>
+    </div>
+    <div class="tsep"></div>
+    <div class="station">
+      <div class="station-pill">
+        <div class="station-pill__ico">✂</div>
+        <div>
+          <div class="station-pill__code">AUDINIO PJOVIMAS</div>
+          <div class="station-pill__sub">Fabric cutting · Line A · Vilnius</div>
+        </div>
+      </div>
+      <button class="switch-btn" id="switchBtn" title="Switch station">▾</button>
+      <div class="switch-menu" id="switchMenu">
+        <div class="switch-menu__lbl">Your stations · queue depth ahead</div>
+        <div class="switch-row is-current">
+          <div class="switch-row__ico">✂</div>
+          <div><div class="switch-row__code">AUDINIO PJOVIMAS</div><div class="switch-row__sub">Fabric cutting · Line A</div></div>
+          <div class="switch-row__depth"><b id="swDepthA">12</b><span>ahead</span></div>
+        </div>
+        <div class="switch-row">
+          <div class="switch-row__ico">⬗</div>
+          <div><div class="switch-row__code">VELENO PJOVIMAS</div><div class="switch-row__sub">Shaft cutting · Line A</div></div>
+          <div class="switch-row__depth"><b>7</b><span>ahead</span></div>
+        </div>
+        <div class="switch-row">
+          <div class="switch-row__ico">⊟</div>
+          <div><div class="switch-row__code">AUDINIO KLIJAVIMAS</div><div class="switch-row__sub">Fabric→shaft gluing · Line A</div></div>
+          <div class="switch-row__depth"><b>19</b><span>ahead</span></div>
+        </div>
+      </div>
+    </div>
+    <div class="spacer"></div>
+    <div class="env-badge">
+      <div><span>ENV</span><strong class="warn-text">TEST</strong></div>
+      <div><span>VER</span><strong>0.4.1</strong></div>
+    </div>
+    <div class="op-chip">
+      <div class="op-chip__avatar">DG</div>
+      <div><div class="op-chip__name">Darius G.</div><div class="op-chip__role">Operator · badge 2041</div></div>
+    </div>
+  </header>
+
+  <!-- STATS STRIP -->
+  <div class="stats">
+    <div class="stat stat--done"><div class="stat__lbl">Done today</div><div class="stat__val" id="stDone">6</div></div>
+    <div class="stat stat--rem"><div class="stat__lbl">Remaining</div><div class="stat__val" id="stRem">12</div></div>
+    <div class="stat stat--cph"><div class="stat__lbl">CPH · cuts / hr</div><div class="stat__val" id="stCph">11.4</div></div>
+    <div class="stat stat--wip"><div class="stat__lbl">WIP · this station</div><div class="stat__val" id="stWip">1<small>active</small></div></div>
+    <div class="stats__right">
+      <div class="target-pill">Shift target <b id="tgN">6</b>/40 <div class="bar"><i id="tgBar" style="width:15%"></i></div></div>
+    </div>
+  </div>
+
+  <!-- WORKSPACE -->
+  <div class="work">
+    <!-- QUEUE -->
+    <section class="queue-col">
+      <div class="qtoolbar">
+        <div class="qtitle">
+          <b>Work queue</b>
+          <span>Auto-ordered by prioritization engine</span>
+        </div>
+        <label class="field field--search"><span class="field__ico"></span><input type="search" placeholder="Filter order / fabric / product…" id="qSearch"></label>
+        <div class="toggle" id="doneToggle"><span class="toggle__sw"></span>Include done today</div>
+        <div class="engine-note"><span class="dot"></span>Ranked: due · changeover · kit impact · fairness</div>
+      </div>
+      <div class="qscroll">
+        <table class="qtable">
+          <thead>
+            <tr>
+              <th class="clband"></th>
+              <th>Order · Product</th>
+              <th>Fabric</th>
+              <th class="cut-h num">Cut length</th>
+              <th class="num">Qty</th>
+              <th>Due</th>
+              <th>Reason</th>
+              <th>Status</th>
+              <th class="num">Action</th>
+            </tr>
+          </thead>
+          <tbody id="qbody"></tbody>
+        </table>
+      </div>
+    </section>
+
+    <!-- DETAIL -->
+    <aside class="detail-col" id="detailCol"></aside>
+  </div>
+</div>
+
+<!-- COMPLETE MODAL -->
+<div class="scrim" id="completeScrim">
+  <div class="modal">
+    <div class="modal__head">
+      <div>
+        <div class="eyebrow">Complete cut · log consumption</div>
+        <h3 id="cmTitle">VEGA 593×1467</h3>
+        <div class="ord" id="cmOrd">RL-8144-25-M</div>
+      </div>
+      <button class="modal__x" data-close>✕</button>
+    </div>
+    <div class="modal__body">
+      <div class="consume">
+        <div class="consume__col">
+          <div class="consume__lbl">Planned</div>
+          <div class="consume__big" id="cmPlanVal">580<small> mm</small></div>
+          <div class="consume__calc" id="cmCalc">580 mm × 7 = 4 060 mm</div>
+        </div>
+        <div class="consume__arrow">→</div>
+        <div class="consume__col consume__col--actual">
+          <div class="consume__lbl">Actual cut</div>
+          <div class="consume__input"><input type="number" id="cmActual" value="580"><span>mm / unit</span></div>
+          <span class="delta delta--match" id="cmDelta">● matches plan</span>
+        </div>
+      </div>
+      <div class="fl">
+        <div class="fl__lbl">Reason for difference <small>· optional — workers may use an offcut or hit scrap</small></div>
+        <div class="reason-pills" id="cmReasons">
+          <button data-r="As planned" class="on">As planned</button>
+          <button data-r="Used remnant / offcut">Used remnant / offcut</button>
+          <button data-r="Fabric flaw — scrap">Fabric flaw — scrap</button>
+          <button data-r="Miscut">Miscut</button>
+          <button data-r="Other">Other</button>
+        </div>
+      </div>
+      <div class="fl">
+        <div class="fl__lbl">Note <small>· optional</small></div>
+        <textarea id="cmNote" rows="2" placeholder="e.g. used 1.9 m remnant from R432 batch, 40 mm trimmed off edge fray"></textarea>
+      </div>
+      <div class="modal-note" id="cmConsumeNote"><span>This logs <b id="cmTotalNote">4 060 mm</b> of fabric R432 consumed, prints label <b>SEMI_06</b>, and unblocks the downstream gluing task.</span></div>
+    </div>
+    <div class="modal__foot">
+      <span class="grow"></span>
+      <button class="btn" data-close>Cancel</button>
+      <button class="btn btn--primary" id="cmConfirm">Confirm complete</button>
+    </div>
+  </div>
+</div>
+
+<!-- STOP MODAL -->
+<div class="scrim" id="stopScrim">
+  <div class="modal" style="width:460px">
+    <div class="modal__head">
+      <div>
+        <div class="eyebrow" style="color:var(--danger-fg)">Stop job · no consumption</div>
+        <h3 id="smTitle">VEGA 593×1467</h3>
+        <div class="ord" id="smOrd">RL-8144-25-M</div>
+      </div>
+      <button class="modal__x" data-close>✕</button>
+    </div>
+    <div class="modal__body">
+      <div class="fl" style="margin-top:0">
+        <div class="fl__lbl">Reason to stop <small>· required</small></div>
+        <div class="reason-pills" id="smReasons">
+          <button data-r="Material missing" class="on">Material missing</button>
+          <button data-r="Fabric not in bin">Fabric not in bin</button>
+          <button data-r="Machine issue">Machine issue</button>
+          <button data-r="Waiting on predecessor">Waiting on predecessor</button>
+          <button data-r="Quality hold">Quality hold</button>
+        </div>
+      </div>
+      <div class="fl">
+        <div class="fl__lbl">Note <small>· optional</small></div>
+        <textarea id="smNote" rows="2" placeholder="e.g. R432 roll empty, replacement not yet received from warehouse"></textarea>
+      </div>
+      <div class="modal-note warn"><span>Marks the item <b>Stopped</b>. No fabric is consumed and no label prints. It leaves the active queue and is flagged for the shift lead.</span></div>
+    </div>
+    <div class="modal__foot">
+      <span class="grow"></span>
+      <button class="btn" data-close>Cancel</button>
+      <button class="btn btn--danger" id="smConfirm">Mark stopped</button>
+    </div>
+  </div>
+</div>
+
+<div class="toast" id="toast">
+  <div class="toast__ico">✓</div>
+  <div><b id="toastMain">Cut completed</b><br><span id="toastSub"></span></div>
+</div>
+
+<script>
+/* ── Cluster colors (per fabric SKU) ─────────────────────────────── */
+const CLUSTER_COLORS = {
+  R432:'#2f8f8b', R207:'#b08a4a', R712:'#66717f', R58:'#1d5d5a',
+  R662:'#56aaa7', R681:'#8996a4', R436:'#c79f63', _solo:'#b9c3ce'
+};
+const TODAY = '2025-03-07';
+
+/* ── Test data — fabric-cutting queue ───────────────────────────── */
+/* template materials per product family (TEMPLATE-FIXED, from workflow) */
+const TPL = {
+  roller:[
+    {sku:'VEL-32',  name:'Aliuminio velenas Ø32',  sub:'shaft · cut to width', bin:'A2-04'},
+    {sku:'ANTG-32', name:'Antgaliai (galinukai) ×2',sub:'end caps · pair',      bin:'C1-11'},
+    {sku:'JUOST-25',name:'Apsauginė juosta 25 mm',  sub:'ribbon · per unit',    bin:'C3-02'}
+  ]
+};
+
+let items = [
+  // ── Cluster R432 (Same fabric batch) ──
+  {id:'RL-8144-25-M', prod:'VEGA', dims:'593×1467', fabric:'R432', fabricName:'Šviesi smėlio · matinė',
+   cut:580, qty:7, due:'2025-03-07', flip:false, status:'inprogress', reason:'due',
+   reqLen:'4 060 mm', bin:'R-A14', cluster:'R432'},
+  {id:'RL-8151-25-M', prod:'VEGA', dims:'560×1400', fabric:'R432', fabricName:'Šviesi smėlio · matinė',
+   cut:547, qty:2, due:'2025-03-07', flip:false, status:'pending', reason:'batch',
+   reqLen:'1 094 mm', bin:'R-A14', cluster:'R432'},
+  {id:'RL-8155-25-M', prod:'VEGA', dims:'610×1500', fabric:'R432', fabricName:'Šviesi smėlio · matinė',
+   cut:597, qty:1, due:'2025-03-08', flip:false, status:'pending', reason:'batch',
+   reqLen:'597 mm', bin:'R-A14', cluster:'R432'},
+
+  // ── R712 verstas (Flipped) — due today ──
+  {id:'RL-8148-25-M', prod:'R38 verstas', dims:'2015×3330', fabric:'R712', fabricName:'Pilka · Furnitura seraja',
+   cut:1965, qty:1, due:'2025-03-07', flip:true, status:'pending', reason:'due',
+   reqLen:'1 965 mm', bin:'R-B07', cluster:'R712', note:'cepochka = 2700 mm'},
+
+  // ── Cluster R207 / R32 (Same fabric batch · kit) ──
+  {id:'AB-7331-26', prod:'R32', dims:'1560×2040', fabric:'R207', fabricName:'Antracitas · Stena',
+   cut:1525, qty:4, due:'2025-03-08', flip:false, status:'pending', reason:'kit',
+   reqLen:'6 100 mm', bin:'R-C03', cluster:'R207', note:'skubus montuosime 08.03 d'},
+  {id:'AB-7331-26', prod:'R32', dims:'1560×1960', fabric:'R207', fabricName:'Antracitas · Stena',
+   cut:1525, qty:4, due:'2025-03-08', flip:false, status:'pending', reason:'batch',
+   reqLen:'6 100 mm', bin:'R-C03', cluster:'R207'},
+  {id:'AB-7331-26', prod:'R32', dims:'1560×2030', fabric:'R207', fabricName:'Antracitas · Stena',
+   cut:1525, qty:2, due:'2025-03-08', flip:false, status:'pending', reason:'batch',
+   reqLen:'3 050 mm', bin:'R-C03', cluster:'R207'},
+
+  // ── R58 verstas (Flipped) — Blocked on shaft cut ──
+  {id:'RL-8149-25-M', prod:'R32 verstas', dims:'1760×2400', fabric:'R58', fabricName:'Tamsi pilka · verstas',
+   cut:1725, qty:1, due:'2025-03-09', flip:true, status:'blocked', reason:'kit',
+   reqLen:'1 725 mm', bin:'R-B12', cluster:'R58', blockedBy:'VELENO PJOVIMAS · RL-8149'},
+
+  // ── Solo fairness items ──
+  {id:'RL-8462-25-M', prod:'VEGA', dims:'535×1150', fabric:'R662', fabricName:'Kreminė · matinė',
+   cut:522, qty:1, due:'2025-03-11', flip:false, status:'pending', reason:'fair',
+   reqLen:'522 mm', bin:'R-A21', cluster:'R662'},
+  {id:'RL-8472-25-M', prod:'R32 · Stena', dims:'2100×2520', fabric:'R681', fabricName:'Smėlio · Stena',
+   cut:2065, qty:1, due:'2025-03-12', flip:false, status:'pending', reason:'fair',
+   reqLen:'2 065 mm', bin:'R-D08', cluster:'R681'},
+  {id:'RL-8581-26-M', prod:'R32', dims:'1400×2000', fabric:'R436', fabricName:'Ruda · matinė',
+   cut:1365, qty:1, due:'2025-03-14', flip:false, status:'pending', reason:'fair',
+   reqLen:'1 365 mm', bin:'R-D02', cluster:'R436'},
+
+  // ── Done today (only with toggle) ──
+  {id:'RL-8140-25-M', prod:'VEGA', dims:'500×1200', fabric:'R432', fabricName:'Šviesi smėlio · matinė',
+   cut:489, qty:3, due:'2025-03-07', flip:false, status:'done', reason:'due',
+   reqLen:'1 467 mm', actual:489, bin:'R-A14', cluster:'R432'},
+];
+items.forEach((it,i)=>it._uid='w'+i);
+
+const REASON_META = {
+  due:  {cls:'reason--due',  txt:'Due today'},
+  batch:{cls:'reason--batch',txt:'Same fabric batch'},
+  kit:  {cls:'reason--kit',  txt:'Unblocks assembly'},
+  fair: {cls:'reason--fair', txt:'Fairness'}
+};
+const STATUS_META = {
+  pending:   {cls:'chip--slate', txt:'Pending'},
+  inprogress:{cls:'chip--warn',  txt:'In progress'},
+  blocked:   {cls:'chip--danger',txt:'Blocked'},
+  done:      {cls:'chip--done',  txt:'Done'},
+  stopped:   {cls:'chip--danger',txt:'Stopped'}
+};
+
+let selectedUid = items[0]._uid;
+let showDone = false;
+let searchTerm = '';
+let doneToday = 6, cphBase = 11.4;
+
+/* ── Helpers ─────────────────────────────────────────────────────── */
+function fmt(n){ return n.toLocaleString('lt-LT').replace(/,/g,' '); }
+function dueClass(d){
+  if(d<=TODAY) return 'due--today';
+  const dt=new Date(d), t=new Date(TODAY);
+  const diff=(dt-t)/86400000;
+  return diff<=2 ? 'due--soon' : 'due--later';
+}
+function dueLabel(d){
+  if(d===TODAY) return 'Today';
+  if(d<TODAY) return 'Overdue';
+  const diff=(new Date(d)-new Date(TODAY))/86400000;
+  if(diff===1) return 'Tomorrow';
+  if(diff<=4) return '+'+diff+' d';
+  return '';
+}
+
+/* ── Render queue (grouped by cluster, engine order preserved) ───── */
+function visibleItems(){
+  return items.filter(it=>{
+    if(it.status==='done' && !showDone) return false;
+    if(searchTerm){
+      const hay=(it.id+' '+it.prod+' '+it.dims+' '+it.fabric+' '+it.fabricName).toLowerCase();
+      if(!hay.includes(searchTerm)) return false;
+    }
+    return true;
+  });
+}
+
+function renderQueue(){
+  const body=document.getElementById('qbody');
+  const vis=visibleItems();
+  let html='';
+  let lastCluster=null;
+  vis.forEach(it=>{
+    if(it.cluster!==lastCluster){
+      lastCluster=it.cluster;
+      const same=vis.filter(x=>x.cluster===it.cluster);
+      const color=CLUSTER_COLORS[it.cluster]||CLUSTER_COLORS._solo;
+      const isBatch=same.length>1;
+      html+=`<tr class="grp-row"><td colspan="9"><div class="grp">
+        <span class="grp__band" style="background:${color}"></span>
+        <span class="grp__sku">${it.cluster}</span>
+        <span class="grp__name">${it.fabricName}</span>
+        <span class="grp__meta">
+          ${isBatch?`<span class="grp__save">⇄ same batch · ${same.length} cuts · saves 1 changeover</span>`:`<span style="color:var(--n-400)">single cut</span>`}
+        </span>
+      </div></td></tr>`;
+    }
+    const color=CLUSTER_COLORS[it.cluster]||CLUSTER_COLORS._solo;
+    const rm=REASON_META[it.reason], sm=STATUS_META[it.status];
+    const sel=it._uid===selectedUid?'sel':'';
+    const extraCls=it.status==='done'?'done':(it.status==='stopped'?'stopped':'');
+    html+=`<tr class="qrow ${sel} ${extraCls}" data-uid="${it._uid}">
+      <td class="clband"><i style="background:${color}"></i></td>
+      <td>
+        <div class="ord">${it.id}</div>
+        <div class="prod">${it.prod} ${it.dims}${it.flip?'<span class="flip-tag">Flipped</span>':''}</div>
+      </td>
+      <td><span class="sku-chip">${it.fabric}</span></td>
+      <td class="cut-cell ${it.cut===0?'zero':''}"><span class="cut-val">${it.cut}<small>mm</small></span></td>
+      <td class="qty">${it.qty>1?`<b>×${it.qty}</b>`:'×'+it.qty}</td>
+      <td><span class="due ${dueClass(it.due)}">${it.due}<small>${dueLabel(it.due)}</small></span></td>
+      <td><span class="reason ${rm.cls}">${rm.txt}</span></td>
+      <td><span class="chip ${sm.cls}">${sm.txt}</span></td>
+      <td><div class="act">${rowAction(it)}</div></td>
+    </tr>`;
+  });
+  body.innerHTML=html;
+  // wire
+  body.querySelectorAll('.qrow').forEach(r=>{
+    r.addEventListener('click',()=>{ selectedUid=r.dataset.uid; renderQueue(); renderDetail(); });
+  });
+  body.querySelectorAll('[data-act]').forEach(b=>{
+    b.addEventListener('click',e=>{
+      e.stopPropagation();
+      const uid=b.closest('.qrow').dataset.uid;
+      const it=items.find(x=>x._uid===uid);
+      selectedUid=uid;
+      if(b.dataset.act==='start') startJob(it);
+      else if(b.dataset.act==='complete') openComplete(it);
+    });
+  });
+}
+function rowAction(it){
+  if(it.status==='pending') return `<button class="btn btn--sm" data-act="start">Start</button>`;
+  if(it.status==='inprogress') return `<button class="btn btn--sm btn--primary" data-act="complete">Complete</button>`;
+  if(it.status==='blocked') return `<button class="btn btn--sm" disabled>Blocked</button>`;
+  if(it.status==='done') return `<span class="chip chip--done chip--sm">✓ Done</span>`;
+  if(it.status==='stopped') return `<button class="btn btn--sm" data-act="start">Resume</button>`;
+  return '';
+}
+
+/* ── Render detail card ──────────────────────────────────────────── */
+function renderDetail(){
+  const col=document.getElementById('detailCol');
+  const it=items.find(x=>x._uid===selectedUid);
+  if(!it){ col.innerHTML='<div class="detail-empty"><b>No job selected</b><div>Pick a row from the queue to see its cut spec.</div></div>'; return; }
+  const sm=STATUS_META[it.status];
+  const total=it.cut*it.qty;
+  const aheadCount=visibleItems().filter(x=>['pending','inprogress'].includes(x.status)).length;
+  col.innerHTML=`
+  <div class="detail">
+    <nav class="detail__crumb">Queue<span>/</span>${it.fabric} batch<span>/</span><b>${it.id}</b></nav>
+
+    <div class="dhead">
+      <div class="dhead__top">
+        <div>
+          <div class="dhead__id">${it.id}</div>
+          <h2>${it.prod} <span class="dhead__dims">${it.dims}</span></h2>
+        </div>
+        <span class="chip ${sm.cls}">${sm.txt}</span>
+      </div>
+      <div class="dhead__sub">
+        <span>Fabric <span class="sku-chip" style="vertical-align:middle">${it.fabric}</span></span>
+        <span><b>${it.fabricName}</b></span>
+        <span>Due <b class="mono">${it.due}</b></span>
+        ${it.note?`<span style="color:var(--sand-700)">⚑ ${it.note}</span>`:''}
+        ${it.blockedBy?`<span style="color:var(--danger-fg)">⛔ Blocked by ${it.blockedBy}</span>`:''}
+      </div>
+    </div>
+
+    <div class="dsection">
+      <div class="dsection__lbl">Computed cut spec <span>· engine formula result — the number to act on</span></div>
+      <div class="spec">
+        <div class="spec__cell spec__cell--hero">
+          <div class="spec__lbl">Cut length</div>
+          <div class="spec__val">${it.cut}<small> mm</small></div>
+        </div>
+        <div class="spec__cell">
+          <div class="spec__lbl">Orientation</div>
+          <div class="spec__val" style="font-size:15px">${it.flip?'Flipped':'Regular'}</div>
+        </div>
+        <div class="spec__cell">
+          <div class="spec__lbl">Quantity</div>
+          <div class="spec__val">×${it.qty}</div>
+        </div>
+      </div>
+      <div style="display:flex;gap:8px;font-family:var(--font-mono);font-size:11px;color:var(--n-500)">
+        <span>Width <b style="color:var(--n-800)">${it.dims.split('×')[0]} mm</b></span>·
+        <span>Total fabric <b style="color:var(--accent-700)">${fmt(total)} mm</b> (${it.cut} × ${it.qty})</span>
+      </div>
+    </div>
+
+    <div class="dsection">
+      <div class="dsection__lbl">Materials to use <span>· order-bound + template-fixed</span></div>
+      <div class="matgroup matgroup--order">
+        <div class="matgroup__head"><span class="matgroup__tag">Order-bound</span><span class="matgroup__title">Fabric from the sales order</span><span class="matgroup__note">SKU follows the order</span></div>
+        <div class="matrow">
+          <span class="matrow__sku">${it.fabric}</span>
+          <div class="matrow__name">${it.fabricName}<small>roll fabric · cut to length</small></div>
+          <div class="matrow__bin"><b>${it.bin}</b><span>bin</span></div>
+          <div class="matrow__req">${it.reqLen}<br><small>required</small></div>
+        </div>
+      </div>
+      <div class="matgroup matgroup--tpl">
+        <div class="matgroup__head"><span class="matgroup__tag">Template-fixed</span><span class="matgroup__title">Fixed SKUs from the workflow</span><span class="matgroup__note">same every unit</span></div>
+        ${TPL.roller.map(m=>`<div class="matrow">
+          <span class="matrow__sku">${m.sku}</span>
+          <div class="matrow__name">${m.name}<small>${m.sub}</small></div>
+          <div class="matrow__bin"><b>${m.bin}</b><span>bin</span></div>
+        </div>`).join('')}
+      </div>
+    </div>
+
+    <div class="dsection">
+      <div class="dsection__lbl">Label to print <span>· semi-finished</span></div>
+      <div class="label-prev">
+        <div class="label-card">
+          <div class="label-card__top"><span class="label-card__tag">${it.id}</span><span class="label-card__semi">SEMI_06</span></div>
+          <div class="label-card__grid">
+            <div><span>Fabric</span><b>${it.fabric}</b></div>
+            <div><span>Cut</span><b>${it.cut} mm</b></div>
+            <div><span>Qty</span><b>×${it.qty}</b></div>
+            <div><span>Orient</span><b>${it.flip?'Flip':'Reg'}</b></div>
+          </div>
+          <div class="label-card__bars">${barcode(it.id)}</div>
+        </div>
+        <div class="label-side">
+          <div style="font-size:10px;color:var(--n-500);line-height:1.3">Prints on <b style="color:var(--n-700)">Complete</b>, travels with the cut to gluing.</div>
+          <button class="btn btn--sm" onclick="event.stopPropagation()">Preview</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="dactions">
+      ${detailActions(it)}
+    </div>
+
+    <div class="depth-ahead">
+      <div class="depth-ahead__n">${aheadCount}</div>
+      <div class="depth-ahead__txt"><b>cuts queued ahead</b> at this station after the current job</div>
+      <div class="depth-ahead__spark">${spark(aheadCount)}</div>
+    </div>
+  </div>`;
+
+  // wire detail actions
+  col.querySelectorAll('[data-dact]').forEach(b=>{
+    b.addEventListener('click',()=>{
+      if(b.dataset.dact==='start') startJob(it);
+      else if(b.dataset.dact==='complete') openComplete(it);
+      else if(b.dataset.dact==='stop') openStop(it);
+    });
+  });
+}
+function detailActions(it){
+  if(it.status==='pending') return `
+    <button class="btn btn--primary btn--block" data-dact="start">▶ Start job</button>
+    <button class="btn btn--danger" data-dact="stop">Stop</button>
+    <button class="btn" data-dact="complete">Complete…</button>`;
+  if(it.status==='inprogress') return `
+    <button class="btn btn--primary" data-dact="complete">✓ Complete</button>
+    <button class="btn btn--danger" data-dact="stop">⏹ Stop</button>`;
+  if(it.status==='blocked') return `
+    <button class="btn btn--block" disabled>Blocked — waiting on predecessor</button>`;
+  if(it.status==='done') return `
+    <button class="btn btn--block" disabled>✓ Completed${it.actual?` · logged ${it.actual} mm × ${it.qty}`:''}</button>`;
+  if(it.status==='stopped') return `
+    <button class="btn btn--primary btn--block" data-dact="start">▶ Resume job</button>`;
+  return '';
+}
+function barcode(seed){
+  let s=0; for(const c of seed) s=(s*31+c.charCodeAt(0))&0xffff;
+  let out='';
+  for(let i=0;i<40;i++){ s=(s*1103515245+12345)&0x7fffffff; const h=8+((s>>i)&1?14:6); out+=`<i style="height:${h}px;opacity:${(s>>3&1)?1:.78}"></i>`; }
+  return out;
+}
+function spark(n){
+  const base=[3,5,4,7,6,9,8,11,10,n];
+  return base.map((h,i)=>`<i class="${i===base.length-1?'hot':''}" style="height:${Math.min(24,h*2)}px"></i>`).join('');
+}
+
+/* ── Stats ───────────────────────────────────────────────────────── */
+function renderStats(){
+  const rem=items.filter(x=>['pending','inprogress','blocked'].includes(x.status)).length;
+  const wip=items.filter(x=>x.status==='inprogress').length;
+  document.getElementById('stDone').textContent=doneToday;
+  document.getElementById('stRem').textContent=rem;
+  document.getElementById('stCph').textContent=cphBase.toFixed(1);
+  document.getElementById('stWip').innerHTML=wip+'<small>active</small>';
+  document.getElementById('tgN').textContent=doneToday;
+  document.getElementById('tgBar').style.width=Math.min(100,doneToday/40*100)+'%';
+  document.getElementById('swDepthA').textContent=rem;
+}
+
+/* ── Actions ─────────────────────────────────────────────────────── */
+function startJob(it){
+  if(it.status==='blocked') return;
+  // only one WIP at a time — bump existing inprogress back to pending
+  items.forEach(x=>{ if(x.status==='inprogress' && x._uid!==it._uid) x.status='pending'; });
+  it.status='inprogress';
+  selectedUid=it._uid;
+  renderQueue(); renderDetail(); renderStats();
+}
+
+/* COMPLETE */
+let completeTarget=null;
+function openComplete(it){
+  completeTarget=it;
+  document.getElementById('cmTitle').textContent=`${it.prod} ${it.dims}`;
+  document.getElementById('cmOrd').textContent=it.id;
+  document.getElementById('cmPlanVal').innerHTML=`${it.cut}<small> mm</small>`;
+  document.getElementById('cmCalc').textContent=`${it.cut} mm × ${it.qty} = ${fmt(it.cut*it.qty)} mm`;
+  const inp=document.getElementById('cmActual'); inp.value=it.cut;
+  // reset reasons
+  document.querySelectorAll('#cmReasons button').forEach((b,i)=>b.classList.toggle('on',i===0));
+  document.getElementById('cmNote').value='';
+  updateDelta();
+  document.getElementById('completeScrim').classList.add('open');
+  setTimeout(()=>inp.focus(),60);
+}
+function updateDelta(){
+  const it=completeTarget; if(!it) return;
+  const a=parseFloat(document.getElementById('cmActual').value)||0;
+  const d=a-it.cut;
+  const el=document.getElementById('cmDelta');
+  if(d===0){ el.className='delta delta--match'; el.innerHTML='● matches plan'; }
+  else if(d>0){ el.className='delta delta--over'; el.innerHTML=`● +${d} mm / unit over`; }
+  else { el.className='delta delta--under'; el.innerHTML=`● ${d} mm / unit under`; }
+  document.getElementById('cmTotalNote').textContent=fmt(a*it.qty)+' mm';
+}
+document.getElementById('cmActual').addEventListener('input',updateDelta);
+document.querySelectorAll('#cmReasons button').forEach(b=>{
+  b.addEventListener('click',()=>{ document.querySelectorAll('#cmReasons button').forEach(x=>x.classList.remove('on')); b.classList.add('on'); });
+});
+document.getElementById('cmConfirm').addEventListener('click',()=>{
+  const it=completeTarget; if(!it) return;
+  const actual=parseFloat(document.getElementById('cmActual').value)||it.cut;
+  it.actual=actual; it.status='done';
+  doneToday++; cphBase=Math.min(14,cphBase+0.2);
+  closeModals();
+  // unblock downstream
+  const wasBlocking=items.filter(x=>x.status==='blocked');
+  let unblocked=null;
+  if(wasBlocking.length){ wasBlocking[0].status='pending'; unblocked=wasBlocking[0]; }
+  // move selection to next actionable
+  const next=items.find(x=>['inprogress','pending'].includes(x.status));
+  if(next) selectedUid=next._uid;
+  renderQueue(); renderDetail(); renderStats();
+  // animations: flash the just-done row if visible, pulse unblocked
+  requestAnimationFrame(()=>{
+    if(showDone){ const r=document.querySelector(`.qrow[data-uid="${it._uid}"]`); if(r) r.classList.add('done-flash'); }
+    if(unblocked){ const r=document.querySelector(`.qrow[data-uid="${unblocked._uid}"]`); if(r) r.classList.add('unblocking'); }
+  });
+  showToast('Cut completed', `${it.id} · logged ${fmt(actual*it.qty)} mm of ${it.fabric}${unblocked?` · unblocked ${unblocked.id}`:''}`);
+});
+
+/* STOP */
+let stopTarget=null;
+function openStop(it){
+  stopTarget=it;
+  document.getElementById('smTitle').textContent=`${it.prod} ${it.dims}`;
+  document.getElementById('smOrd').textContent=it.id;
+  document.querySelectorAll('#smReasons button').forEach((b,i)=>b.classList.toggle('on',i===0));
+  document.getElementById('smNote').value='';
+  document.getElementById('stopScrim').classList.add('open');
+}
+document.querySelectorAll('#smReasons button').forEach(b=>{
+  b.addEventListener('click',()=>{ document.querySelectorAll('#smReasons button').forEach(x=>x.classList.remove('on')); b.classList.add('on'); });
+});
+document.getElementById('smConfirm').addEventListener('click',()=>{
+  const it=stopTarget; if(!it) return;
+  const reason=document.querySelector('#smReasons button.on').dataset.r;
+  it.status='stopped'; it.stopReason=reason;
+  closeModals();
+  renderQueue(); renderDetail(); renderStats();
+  showToast('Job stopped', `${it.id} · ${reason} · flagged for shift lead`, true);
+});
+
+/* ── Modal infra ─────────────────────────────────────────────────── */
+function closeModals(){ document.querySelectorAll('.scrim').forEach(s=>s.classList.remove('open')); }
+document.querySelectorAll('[data-close]').forEach(b=>b.addEventListener('click',closeModals));
+document.querySelectorAll('.scrim').forEach(s=>s.addEventListener('click',e=>{ if(e.target===s) closeModals(); }));
+document.addEventListener('keydown',e=>{ if(e.key==='Escape') closeModals(); });
+
+let toastTimer=null;
+function showToast(main,sub,warn){
+  const t=document.getElementById('toast');
+  document.getElementById('toastMain').textContent=main;
+  document.getElementById('toastSub').textContent=sub;
+  t.querySelector('.toast__ico').style.background=warn?'var(--danger-dot)':'var(--ok-dot)';
+  t.querySelector('.toast__ico').textContent=warn?'⏹':'✓';
+  t.classList.add('show');
+  clearTimeout(toastTimer); toastTimer=setTimeout(()=>t.classList.remove('show'),3600);
+}
+
+/* ── Toolbar wiring ──────────────────────────────────────────────── */
+document.getElementById('doneToggle').addEventListener('click',function(){
+  showDone=!showDone; this.classList.toggle('on',showDone); renderQueue();
+});
+document.getElementById('qSearch').addEventListener('input',function(){
+  searchTerm=this.value.trim().toLowerCase(); renderQueue();
+});
+document.getElementById('switchBtn').addEventListener('click',e=>{
+  e.stopPropagation(); document.getElementById('switchMenu').classList.toggle('open');
+});
+document.addEventListener('click',()=>document.getElementById('switchMenu').classList.remove('open'));
+document.getElementById('switchMenu').addEventListener('click',e=>e.stopPropagation());
+
+/* ── Init ────────────────────────────────────────────────────────── */
+renderQueue(); renderDetail(); renderStats();
+</script>
+</body>
+</html>

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/operator-work-queue.html
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/operator-work-queue.html
@@ -4,7 +4,6 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
 <title>LAURESTA · ShopfloorPilot — AUDINIO PJOVIMAS</title>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&family=JetBrains+Mono:wght@400;500;600;700;800&display=swap" rel="stylesheet">
 <style>
 /* ── LKvitai.MES tokens (inlined for standalone drop-in) ─────────── */
 :root{
@@ -480,7 +479,7 @@ button,input,select{font:inherit;color:inherit}
           <b>Work queue</b>
           <span>Auto-ordered by prioritization engine</span>
         </div>
-        <label class="field field--search"><span class="field__ico"></span><input type="search" placeholder="Filter order / fabric / product…" id="qSearch"></label>
+        <label class="field field--search"><span class="field__ico"></span><input type="search" placeholder="Filter order / fabric / product…" id="qSearch" aria-label="Filter order, fabric or product"></label>
         <div class="toggle" id="doneToggle"><span class="toggle__sw"></span>Include done today</div>
         <div class="engine-note"><span class="dot"></span>Ranked: due · changeover · kit impact · fairness</div>
       </div>
@@ -688,7 +687,7 @@ let searchTerm = '';
 let doneToday = 6, cphBase = 11.4;
 
 /* ── Helpers ─────────────────────────────────────────────────────── */
-function fmt(n){ return n.toLocaleString('lt-LT').replace(/,/g,' '); }
+function fmt(n){ return n.toLocaleString('lt-LT').replaceAll(',',' '); }
 function dueClass(d){
   if(d<=TODAY) return 'due--today';
   const dt=new Date(d), t=new Date(TODAY);
@@ -727,19 +726,24 @@ function renderQueue(){
       const same=vis.filter(x=>x.cluster===it.cluster);
       const color=CLUSTER_COLORS[it.cluster]||CLUSTER_COLORS._solo;
       const isBatch=same.length>1;
+      const batchMeta = isBatch
+        ? '<span class="grp__save">⇄ same batch · ' + same.length + ' cuts · saves 1 changeover</span>'
+        : '<span style="color:var(--n-400)">single cut</span>';
       html+=`<tr class="grp-row"><td colspan="9"><div class="grp">
         <span class="grp__band" style="background:${color}"></span>
         <span class="grp__sku">${it.cluster}</span>
         <span class="grp__name">${it.fabricName}</span>
         <span class="grp__meta">
-          ${isBatch?`<span class="grp__save">⇄ same batch · ${same.length} cuts · saves 1 changeover</span>`:`<span style="color:var(--n-400)">single cut</span>`}
+          ${batchMeta}
         </span>
       </div></td></tr>`;
     }
     const color=CLUSTER_COLORS[it.cluster]||CLUSTER_COLORS._solo;
     const rm=REASON_META[it.reason], sm=STATUS_META[it.status];
     const sel=it._uid===selectedUid?'sel':'';
-    const extraCls=it.status==='done'?'done':(it.status==='stopped'?'stopped':'');
+    let extraCls='';
+    if(it.status==='done') extraCls='done';
+    else if(it.status==='stopped') extraCls='stopped';
     html+=`<tr class="qrow ${sel} ${extraCls}" data-uid="${it._uid}">
       <td class="clband"><i style="background:${color}"></i></td>
       <td>
@@ -902,14 +906,17 @@ function detailActions(it){
     <button class="btn btn--danger" data-dact="stop">⏹ Stop</button>`;
   if(it.status==='blocked') return `
     <button class="btn btn--block" disabled>Blocked — waiting on predecessor</button>`;
-  if(it.status==='done') return `
-    <button class="btn btn--block" disabled>✓ Completed${it.actual?` · logged ${it.actual} mm × ${it.qty}`:''}</button>`;
+  if(it.status==='done'){
+    const actualText = it.actual ? ' · logged ' + it.actual + ' mm × ' + it.qty : '';
+    return `
+    <button class="btn btn--block" disabled>✓ Completed${actualText}</button>`;
+  }
   if(it.status==='stopped') return `
     <button class="btn btn--primary btn--block" data-dact="start">▶ Resume job</button>`;
   return '';
 }
 function barcode(seed){
-  let s=0; for(const c of seed) s=(s*31+c.charCodeAt(0))&0xffff;
+  let s=0; for(const c of seed) s=(s*31+c.codePointAt(0))&0xffff;
   let out='';
   for(let i=0;i<40;i++){ s=(s*1103515245+12345)&0x7fffffff; const h=8+((s>>i)&1?14:6); out+=`<i style="height:${h}px;opacity:${(s>>3&1)?1:.78}"></i>`; }
   return out;
@@ -960,7 +967,7 @@ function openComplete(it){
 }
 function updateDelta(){
   const it=completeTarget; if(!it) return;
-  const a=parseFloat(document.getElementById('cmActual').value)||0;
+  const a=Number.parseFloat(document.getElementById('cmActual').value)||0;
   const d=a-it.cut;
   const el=document.getElementById('cmDelta');
   if(d===0){ el.className='delta delta--match'; el.innerHTML='● matches plan'; }
@@ -974,7 +981,7 @@ document.querySelectorAll('#cmReasons button').forEach(b=>{
 });
 document.getElementById('cmConfirm').addEventListener('click',()=>{
   const it=completeTarget; if(!it) return;
-  const actual=parseFloat(document.getElementById('cmActual').value)||it.cut;
+  const actual=Number.parseFloat(document.getElementById('cmActual').value)||it.cut;
   it.actual=actual; it.status='done';
   doneToday++; cphBase=Math.min(14,cphBase+0.2);
   closeModals();
@@ -991,7 +998,8 @@ document.getElementById('cmConfirm').addEventListener('click',()=>{
     if(showDone){ const r=document.querySelector(`.qrow[data-uid="${it._uid}"]`); if(r) r.classList.add('done-flash'); }
     if(unblocked){ const r=document.querySelector(`.qrow[data-uid="${unblocked._uid}"]`); if(r) r.classList.add('unblocking'); }
   });
-  showToast('Cut completed', `${it.id} · logged ${fmt(actual*it.qty)} mm of ${it.fabric}${unblocked?` · unblocked ${unblocked.id}`:''}`);
+  const unblockText = unblocked ? ' · unblocked ' + unblocked.id : '';
+  showToast('Cut completed', `${it.id} · logged ${fmt(actual*it.qty)} mm of ${it.fabric}${unblockText}`);
 });
 
 /* STOP */


### PR DESCRIPTION
## Summary
- add Shopfloor architecture foundation document
- add full-bleed Operator Work Queue demo page under Shopfloor WebUI
- embed the provided Operator Work Queue prototype as a static asset with its original JS/functionality preserved
- add Shopfloor menu entry: Execution -> Operator Queue

## Verification
- dotnet build src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/LKvitai.MES.Modules.Shopfloor.WebUI.csproj -c Release
- git diff --check
- local HTTP smoke: /operator-work-queue and /prototypes/operator-work-queue.html returned 200
- copied operator queue prototype is byte-identical to /Users/bykovas/Downloads/Operator Work Queue.html