### PR TITLE
Shopfloor: smart workflow validation

### DIFF
--- a/docs/shopfloor/shopfloor-12-smart-validation.md
+++ b/docs/shopfloor/shopfloor-12-smart-validation.md
@@ -90,6 +90,15 @@ everything available in the authoring MVP. No order/material/runtime data needed
 | **H5** | Isolated cluster | a connected group attached to neither start nor finish |
 | **H6** | Family anomaly | task count far from sibling families (e.g. "similar flows have ~6 tasks, this has 1") |
 
+### 3.3.1 Implementation status (v0.2)
+
+The engine `SmartWorkflowValidator` (Domain) implements: **E1–E7**, **W1, W3–W9, W11**,
+**H1–H4**. W2 is surfaced as a metric (`metrics.criticalPath`), not a finding. Not yet
+implemented: **W10** (runtime), **H5** (overlaps E3/E4), **H6** (needs cross-template
+sibling data). Engine entry point: `SmartWorkflowValidator.Validate(graph, stations)`;
+result mapped to `ValidationReportDto`. Runs on `POST …/validate`, `POST …/{id}/validate`,
+and as the `POST …/{id}/publish` gate (422 + report when not publishable).
+
 ### 3.4 Backlog — not in the authoring validator
 
 - **W10 · Changeover clustering** — real setup waste depends on **order** material/colour/size
@@ -160,12 +169,81 @@ ValidationReport {
 
 ## 7. Presentation (visual guide)
 
-How findings are shown — node/line highlighting, the report panel, badges, critical-path
-overlay, bottleneck badge, score/throughput display, click-to-locate, empty/all-good
-state — is defined by the **paired design guide** produced via the Claude Designer pass.
-That guide pastes in here as §7 once approved. Design constraints: reuse the existing
-editor prototype tokens (Cikada.MES teal; danger=red, warn=sand, ok=green, info=teal);
-no new color families; WOW but enterprise-clean.
+This is the approved Designer pass. The buildable reference mockup is
+`wwwroot/prototypes/shopfloor-validation-report-prototype.html` (standalone, inline
+CSS/JS, no build) — it extends the editor prototype with the Validate button + badge,
+the report drawer, node/edge/line highlighting, the branch-imbalance callout, and the
+all-good state. **Reuse the editor tokens verbatim; add no new color families.**
+
+### 7.1 Severity → visual mapping (locked)
+
+| Severity | Token family | Ring / fill | Icon | Where |
+|----------|--------------|-------------|------|-------|
+| **Error** ⛔ | `--danger-*` (red) | `--danger-strong` ring | ⛔ | node ring, finding row, badge `err` |
+| **Warning** ⚠ | `--warn-* / --sand-*` (amber) | `--warn-strong` ring | ⚠ | node ring, finding row, badge `warn` |
+| **Hint** 💡 | `--info-* / --accent-*` (teal) | `--info-strong` ring | 💡 | node ring, finding row, badge `hint` |
+| **OK** ✓ | `--ok-* / green` | `--ok-dot` | ✓ | score state, all-good, clean badge |
+| **Critical path** | `--accent-*` (teal) | `--accent-500` rail + thick teal edge | — | informational overlay (not a severity) |
+| **Bottleneck** | `--n-800` (neutral-dark) | dark chip + dark load bar | ▣ | the one constraint marker — neutral so it never reads as "error" |
+
+Critical-path and bottleneck are **informational**, not problems — that's why they map to
+the teal accent and neutral-dark, never to red/amber. They show in the all-good state too.
+
+### 7.2 Surfaces & where they live
+
+1. **Validate button** — editor toolbar, next to Save / Publish. Carries a live
+   **count badge** `2 ⛔ · 5 ⚠ · 1 💡` (mono, severity-tinted pills). Clean graph →
+   the button goes green with `✓ healthy`. The badge updates on edit; clicking opens the
+   report drawer (non-destructive).
+2. **Report drawer** — right side, fixed `392px`, four stacked zones:
+   - **Header** — score ring (0–100, color by band: ≥80 green, 50–79 amber, <50 red),
+     publish-state chip (`Publish blocked` / `Ready to publish`), summary pills.
+   - **Metrics** — `Lead time`, `Bottleneck` line, and a full-width **Throughput** tile
+     (the one number that matters — accent-washed, big mono `~12 units/hr`).
+   - **Per-line load strip** — one bar per station (load = width, mono value inside).
+     Bottleneck bar is dark + `▣ BOTTLENECK`; over-WIP bar is sand-striped + `WIP 5/3`.
+     Rows are clickable → locate that line's nodes.
+   - **Findings** — grouped `Errors → Warnings → Hints`; each row = severity icon, rule
+     id chip (`E4`), title, one-line message (ids/numbers in mono), and a locate button.
+3. **Node highlights** (canvas) — ring color by precedence (below), corner severity chip
+   top-right, `▣ BOTTLENECK` chip, and bottom-left flags `CRITICAL PATH` / `WIP n/limit`.
+4. **Edge highlights** — critical path = thick teal solid + sparse flow; cycle = red
+   dashed; redundant/over-constraining = thin amber dotted.
+5. **Branch-imbalance callout** — a small card anchored left of the merge node: two
+   mini-bars (Branch A teal vs Branch B sand) + `Branch B idles 2h 58m at this merge`.
+6. **All-good state** — replaces the findings list: green check, "Flow is healthy", and
+   the throughput number. Score ring 100, Publish enabled.
+
+### 7.3 Node highlight precedence (overlaps coexist)
+
+A node can be several things at once. Resolve as:
+
+- **Ring color** = single highest severity present: `error > warning > hint > (critical-only)`.
+  A critical-path node with a warning shows an **amber** ring (warning wins the ring).
+- **Critical-path rail** (teal left stripe + `CRITICAL PATH` flag) renders **regardless**
+  of ring color, so a critical+warning node shows amber ring **and** teal rail together.
+- **Bottleneck chip** (`▣`, neutral-dark) renders **regardless** of everything else.
+- **WIP flag** renders independently at bottom-left.
+- Worked example (Assembly merge node): amber ring (W1+W3) + teal critical rail +
+  `▣ BOTTLENECK` chip — all visible, instantly legible.
+
+### 7.4 Click-to-locate interaction
+
+Clicking a finding (row or its locate button) — or a line-load row:
+
+1. Marks the finding **active** (teal left-border + `--accent-50` wash).
+2. Resolves targets → node ids (expanding any `stationIds` to that line's nodes).
+3. **Pans + zooms** the canvas to fit the targets (animated `~520ms`, capped ≤115%).
+4. **Pulses** the target nodes (scale 1→1.045 ×2) and target edges (stroke 3→6 ×2).
+
+Edges are re-rendered after the pan settles so socket-anchored beziers stay accurate.
+
+### 7.5 Tiered enforcement reflected in the UI
+
+- Save (`PUT …/graph`) never blocks — badge still shows counts; drawer stays advisory.
+- Publish is **disabled while any Error exists**; the header reads `Publish blocked · N
+  errors must be fixed`. With zero errors it flips to `Ready to publish` and enables.
+- Warnings + Hints never gate Publish — they are insight, not a wall.
 
 ---
 
@@ -174,4 +252,5 @@ no new color families; WOW but enterprise-clean.
 - Rules origin & MVP scope: [`shopfloor-10`](./shopfloor-10-mvp-authoring-scope.md),
   [`shopfloor-11`](./shopfloor-11-mvp-authoring-implementation-blueprint.md) §7
 - Editor bridge (where Validate lives): `shopfloor-11` §9
-- Prototype to extend: `wwwroot/prototypes/shopfloor-workflow-editor-prototype.html`
+- Editor prototype to extend: `wwwroot/prototypes/shopfloor-workflow-editor-prototype.html`
+- **Validation report mockup (this §7):** `wwwroot/prototypes/shopfloor-validation-report-prototype.html`

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Api/Endpoints/WorkflowsEndpoints.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Api/Endpoints/WorkflowsEndpoints.cs
@@ -38,6 +38,14 @@ public static class WorkflowsEndpoints
         workflows.MapPost("/{id:guid}/publish", async (Guid id, IWorkflowService service, CancellationToken ct) =>
             Results.Ok(await service.PublishAsync(id, ct).ConfigureAwait(false)));
 
+        // Smart validation — non-destructive. Editor Validate / Preview posts the
+        // current canvas graph; the stored-graph variant backs the publish gate.
+        workflows.MapPost("/{id:guid}/validate", async (Guid id, IWorkflowService service, CancellationToken ct) =>
+            Results.Ok(await service.ValidateAsync(id, ct).ConfigureAwait(false)));
+
+        workflows.MapPost("/validate", async (SaveWorkflowGraphRequest request, IWorkflowService service, CancellationToken ct) =>
+            Results.Ok(await service.ValidateGraphAsync(request.Graph, ct).ConfigureAwait(false)));
+
         workflows.MapPost("/{id:guid}/clone", async (Guid id, CloneWorkflowTemplateRequest request, IWorkflowService service, CancellationToken ct) =>
         {
             var created = await service.CloneAsync(id, request, ct).ConfigureAwait(false);

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Api/Middleware/ShopfloorExceptionMiddleware.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Api/Middleware/ShopfloorExceptionMiddleware.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using LKvitai.MES.Modules.Shopfloor.Application.Exceptions;
+using LKvitai.MES.Modules.Shopfloor.Contracts.Workflows;
 
 namespace LKvitai.MES.Modules.Shopfloor.Api.Middleware;
 
@@ -10,6 +11,8 @@ namespace LKvitai.MES.Modules.Shopfloor.Api.Middleware;
 /// </summary>
 public sealed class ShopfloorExceptionMiddleware
 {
+    private static readonly JsonSerializerOptions JsonOptions = new(JsonSerializerDefaults.Web);
+
     private readonly RequestDelegate _next;
     private readonly ILogger<ShopfloorExceptionMiddleware> _logger;
 
@@ -24,6 +27,10 @@ public sealed class ShopfloorExceptionMiddleware
         try
         {
             await _next(context).ConfigureAwait(false);
+        }
+        catch (ShopfloorWorkflowNotPublishableException ex)
+        {
+            await WriteReportAsync(context, ex.Message, ex.Report).ConfigureAwait(false);
         }
         catch (ShopfloorValidationException ex)
         {
@@ -57,6 +64,28 @@ public sealed class ShopfloorExceptionMiddleware
             message,
             errors = errors ?? Array.Empty<string>(),
         });
+
+        await context.Response.WriteAsync(payload).ConfigureAwait(false);
+    }
+
+    private async Task WriteReportAsync(HttpContext context, string message, ValidationReportDto report)
+    {
+        if (context.Response.HasStarted)
+        {
+            _logger.LogWarning("[Shopfloor] cannot write 422 report, response already started for {Path}", context.Request.Path);
+            return;
+        }
+
+        context.Response.Clear();
+        context.Response.StatusCode = StatusCodes.Status422UnprocessableEntity;
+        context.Response.ContentType = "application/json";
+
+        var payload = JsonSerializer.Serialize(new
+        {
+            status = StatusCodes.Status422UnprocessableEntity,
+            message,
+            report,
+        }, JsonOptions);
 
         await context.Response.WriteAsync(payload).ConfigureAwait(false);
     }

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Exceptions/ShopfloorExceptions.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Exceptions/ShopfloorExceptions.cs
@@ -1,3 +1,5 @@
+using LKvitai.MES.Modules.Shopfloor.Contracts.Workflows;
+
 namespace LKvitai.MES.Modules.Shopfloor.Application.Exceptions;
 
 /// <summary>Raised when a referenced resource does not exist (maps to 404).</summary>
@@ -32,4 +34,20 @@ public sealed class ShopfloorValidationException : Exception
     {
         Errors = errors;
     }
+}
+
+/// <summary>
+/// Raised when a workflow cannot be published because the smart validator found
+/// blocking errors. Carries the full <see cref="ValidationReportDto"/> so the API
+/// can return it (maps to 422).
+/// </summary>
+public sealed class ShopfloorWorkflowNotPublishableException : Exception
+{
+    public ShopfloorWorkflowNotPublishableException(ValidationReportDto report)
+        : base($"Workflow cannot be published: {report.Summary.Errors} blocking error(s).")
+    {
+        Report = report;
+    }
+
+    public ValidationReportDto Report { get; }
 }

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Services/IWorkflowService.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Services/IWorkflowService.cs
@@ -16,6 +16,12 @@ public interface IWorkflowService
 
     Task<WorkflowTemplateDto> PublishAsync(Guid id, CancellationToken cancellationToken);
 
+    /// <summary>Runs the full smart validator over the stored graph (non-destructive).</summary>
+    Task<ValidationReportDto> ValidateAsync(Guid id, CancellationToken cancellationToken);
+
+    /// <summary>Runs the full smart validator over a posted graph (editor Validate / Preview).</summary>
+    Task<ValidationReportDto> ValidateGraphAsync(WorkflowGraphDto graph, CancellationToken cancellationToken);
+
     Task<WorkflowTemplateDto> CloneAsync(Guid id, CloneWorkflowTemplateRequest request, CancellationToken cancellationToken);
 
     Task DeleteAsync(Guid id, CancellationToken cancellationToken);

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Services/WorkflowService.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Services/WorkflowService.cs
@@ -14,6 +14,7 @@ public sealed class WorkflowService : IWorkflowService
 {
     private readonly IWorkflowTemplateRepository _repository;
     private readonly IProductTypeMappingRepository _mappings;
+    private readonly IWorkStationRepository _workStations;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IValidator<CreateWorkflowTemplateRequest> _createValidator;
     private readonly IValidator<UpdateWorkflowTemplateRequest> _updateValidator;
@@ -22,6 +23,7 @@ public sealed class WorkflowService : IWorkflowService
     public WorkflowService(
         IWorkflowTemplateRepository repository,
         IProductTypeMappingRepository mappings,
+        IWorkStationRepository workStations,
         IUnitOfWork unitOfWork,
         IValidator<CreateWorkflowTemplateRequest> createValidator,
         IValidator<UpdateWorkflowTemplateRequest> updateValidator,
@@ -29,6 +31,7 @@ public sealed class WorkflowService : IWorkflowService
     {
         _repository = repository;
         _mappings = mappings;
+        _workStations = workStations;
         _unitOfWork = unitOfWork;
         _createValidator = createValidator;
         _updateValidator = updateValidator;
@@ -106,17 +109,42 @@ public sealed class WorkflowService : IWorkflowService
             ?? throw NotFound(id);
 
         var graph = WorkflowGraphMapper.Deserialize(template.GraphJson);
-        var domain = WorkflowGraphMapper.ToDomain(graph);
-        var result = WorkflowGraphValidator.ValidateForPublish(domain);
-        if (!result.IsValid)
+        var report = await RunValidatorAsync(graph, cancellationToken).ConfigureAwait(false);
+        if (!report.Publishable)
         {
-            throw new ShopfloorValidationException(
-                "Workflow cannot be published: " + string.Join("; ", result.Errors), result.Errors);
+            throw new ShopfloorWorkflowNotPublishableException(WorkflowValidationMapper.ToDto(report));
         }
 
         template.Publish(DateTimeOffset.UtcNow);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         return MapFull(template);
+    }
+
+    public async Task<ValidationReportDto> ValidateAsync(Guid id, CancellationToken cancellationToken)
+    {
+        var template = await _repository.GetAsync(id, cancellationToken).ConfigureAwait(false)
+            ?? throw NotFound(id);
+
+        var graph = WorkflowGraphMapper.Deserialize(template.GraphJson);
+        var report = await RunValidatorAsync(graph, cancellationToken).ConfigureAwait(false);
+        return WorkflowValidationMapper.ToDto(report);
+    }
+
+    public async Task<ValidationReportDto> ValidateGraphAsync(WorkflowGraphDto graph, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        var report = await RunValidatorAsync(graph, cancellationToken).ConfigureAwait(false);
+        return WorkflowValidationMapper.ToDto(report);
+    }
+
+    private async Task<ValidationReport> RunValidatorAsync(WorkflowGraphDto graph, CancellationToken cancellationToken)
+    {
+        var domain = WorkflowGraphMapper.ToDomain(graph);
+        var stations = await _workStations.ListAsync(cancellationToken).ConfigureAwait(false);
+        var stationInfos = stations
+            .Select(s => new WorkflowStationInfo(s.Station.Id, s.Station.Code, s.Station.Name, s.Station.WipLimit, s.Station.IsActive))
+            .ToList();
+        return SmartWorkflowValidator.Validate(domain, stationInfos);
     }
 
     public async Task<WorkflowTemplateDto> CloneAsync(Guid id, CloneWorkflowTemplateRequest request, CancellationToken cancellationToken)

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Workflows/WorkflowValidationMapper.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Application/Workflows/WorkflowValidationMapper.cs
@@ -1,0 +1,44 @@
+using LKvitai.MES.Modules.Shopfloor.Contracts.Workflows;
+using LKvitai.MES.Modules.Shopfloor.Domain.Workflows;
+
+namespace LKvitai.MES.Modules.Shopfloor.Application.Workflows;
+
+/// <summary>Maps the domain <see cref="ValidationReport"/> to its serializable DTO.</summary>
+public static class WorkflowValidationMapper
+{
+    public static ValidationReportDto ToDto(ValidationReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        return new ValidationReportDto(
+            report.Score,
+            report.Publishable,
+            new ValidationSummaryDto(report.Summary.Errors, report.Summary.Warnings, report.Summary.Hints),
+            ToDto(report.Metrics),
+            report.Findings.Select(ToDto).ToList());
+    }
+
+    private static ValidationMetricsDto ToDto(ValidationMetrics m) => new(
+        m.LeadTimeSec,
+        m.CriticalPath is null ? null : new CriticalPathDto(m.CriticalPath.NodeIds, m.CriticalPath.DurationSec),
+        m.Bottleneck is null ? null : new BottleneckDto(m.Bottleneck.StationId, m.Bottleneck.StationName, m.Bottleneck.LoadSec),
+        m.ThroughputPerHour,
+        m.LineLoads.Select(l => new LineLoadDto(l.StationId, l.StationName, l.LoadSec, l.TaskCount)).ToList(),
+        m.Merges.Select(g => new MergeDto(g.NodeId, g.MaxInSec, g.MinInSec, g.WaitSec)).ToList());
+
+    private static ValidationFindingDto ToDto(ValidationFinding f) => new(
+        f.RuleId,
+        SeverityName(f.Severity),
+        f.Title,
+        f.Message,
+        new ValidationTargetsDto(f.Targets.NodeIds, f.Targets.EdgeIds, f.Targets.StationIds),
+        f.Detail);
+
+    private static string SeverityName(ValidationSeverity severity) => severity switch
+    {
+        ValidationSeverity.Error => "error",
+        ValidationSeverity.Warning => "warning",
+        ValidationSeverity.Hint => "hint",
+        _ => "hint",
+    };
+}

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Contracts/Workflows/ValidationReportDto.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Contracts/Workflows/ValidationReportDto.cs
@@ -1,0 +1,44 @@
+namespace LKvitai.MES.Modules.Shopfloor.Contracts.Workflows;
+
+/// <summary>
+/// Serializable smart-validation report (shopfloor-12 §5). One shape consumed by
+/// the editor report panel and (on publish) the API. <c>Severity</c> is the
+/// lowercase string <c>"error" | "warning" | "hint"</c> to match the editor.
+/// </summary>
+public sealed record ValidationReportDto(
+    int Score,
+    bool Publishable,
+    ValidationSummaryDto Summary,
+    ValidationMetricsDto Metrics,
+    IReadOnlyList<ValidationFindingDto> Findings);
+
+public sealed record ValidationSummaryDto(int Errors, int Warnings, int Hints);
+
+public sealed record ValidationFindingDto(
+    string RuleId,
+    string Severity,
+    string Title,
+    string Message,
+    ValidationTargetsDto Targets,
+    IReadOnlyDictionary<string, double>? Detail);
+
+public sealed record ValidationTargetsDto(
+    IReadOnlyList<string> NodeIds,
+    IReadOnlyList<string> EdgeIds,
+    IReadOnlyList<string> StationIds);
+
+public sealed record ValidationMetricsDto(
+    int LeadTimeSec,
+    CriticalPathDto? CriticalPath,
+    BottleneckDto? Bottleneck,
+    int ThroughputPerHour,
+    IReadOnlyList<LineLoadDto> LineLoads,
+    IReadOnlyList<MergeDto> Merges);
+
+public sealed record CriticalPathDto(IReadOnlyList<string> NodeIds, int DurationSec);
+
+public sealed record BottleneckDto(string StationId, string StationName, int LoadSec);
+
+public sealed record LineLoadDto(string StationId, string StationName, int LoadSec, int TaskCount);
+
+public sealed record MergeDto(string NodeId, int MaxInSec, int MinInSec, int WaitSec);

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Domain/Workflows/SmartWorkflowValidator.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Domain/Workflows/SmartWorkflowValidator.cs
@@ -1,0 +1,771 @@
+namespace LKvitai.MES.Modules.Shopfloor.Domain.Workflows;
+
+/// <summary>
+/// The smart workflow validator (shopfloor-12). Runs the full rule catalog —
+/// errors (E1–E7), warnings (W1, W3–W9, W11) and hints (H1–H4) — and computes
+/// the production metrics (critical path, bottleneck, throughput, per-line load,
+/// branch imbalance) into a single <see cref="ValidationReport"/>.
+///
+/// <para>Framework-free and deterministic: the same engine runs in the editor
+/// (Validate / Preview) and on the server (Publish gate).</para>
+/// </summary>
+public static class SmartWorkflowValidator
+{
+    // Tunable thresholds (configuration candidates — S-7). Kept as constants for now.
+    private const int BranchImbalanceWaitSec = 30 * 60;   // W1: flag a merge wait above 30 min
+    private const double DominantTaskShare = 0.60;        // W7: one task > 60% of lead time
+    private const double LineImbalanceShare = 0.60;       // W8: one line > 60% of total work
+    private const int LongChainLength = 4;                // W11: >= 4 consecutive same-line tasks
+    private const double DurationOutlierFactor = 8.0;     // H2: > 8x the median sibling duration
+    private const int AbsurdDurationSec = 24 * 60 * 60;   // H2: > 24h is almost certainly wrong
+
+    private const int ErrorWeight = 18;
+    private const int WarningWeight = 6;
+    private const int HintWeight = 2;
+
+    public static ValidationReport Validate(
+        WorkflowGraph graph,
+        IReadOnlyCollection<WorkflowStationInfo>? stations = null)
+    {
+        ArgumentNullException.ThrowIfNull(graph);
+        var ctx = new Context(graph, stations ?? Array.Empty<WorkflowStationInfo>());
+        var findings = new List<ValidationFinding>();
+
+        CheckErrors(ctx, findings);
+        var metrics = ComputeMetrics(ctx);
+        CheckWarnings(ctx, metrics, findings);
+        CheckHints(ctx, findings);
+
+        var summary = new ValidationSummary(
+            findings.Count(f => f.Severity == ValidationSeverity.Error),
+            findings.Count(f => f.Severity == ValidationSeverity.Warning),
+            findings.Count(f => f.Severity == ValidationSeverity.Hint));
+
+        var score = Math.Clamp(
+            100 - (summary.Errors * ErrorWeight) - (summary.Warnings * WarningWeight) - (summary.Hints * HintWeight),
+            0, 100);
+
+        return new ValidationReport(score, summary.Errors == 0, summary, metrics, findings);
+    }
+
+    // ── Errors ─────────────────────────────────────────────────────────────
+    private static void CheckErrors(Context ctx, List<ValidationFinding> findings)
+    {
+        // E6 — broken edges: missing endpoint, self-loop, duplicate.
+        var seen = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var e in ctx.Graph.Edges)
+        {
+            if (!ctx.NodeIds.Contains(e.From) || !ctx.NodeIds.Contains(e.To))
+            {
+                findings.Add(Error("E6", "Broken edge",
+                    $"Edge {e.From} → {e.To} references a missing node.",
+                    new ValidationTargets(Array.Empty<string>(), new[] { ValidationTargets.EdgeId(e.From, e.To) }, Array.Empty<string>())));
+                continue;
+            }
+
+            if (string.Equals(e.From, e.To, StringComparison.Ordinal))
+            {
+                findings.Add(Error("E6", "Broken edge", $"Self-loop on node {e.From}.",
+                    EdgeTarget(e.From, e.To)));
+            }
+
+            if (!seen.Add($"{e.From}\u0001{e.To}"))
+            {
+                findings.Add(Error("E6", "Broken edge", $"Duplicate edge {e.From} → {e.To}.",
+                    EdgeTarget(e.From, e.To)));
+            }
+        }
+
+        // E1 / E2 — single start / single finish.
+        if (ctx.Starts.Count != 1)
+        {
+            findings.Add(Error("E1", "Single start",
+                $"Graph must have exactly one start node (found {ctx.Starts.Count}).",
+                new ValidationTargets(ctx.Starts.Select(n => n.Id).ToList(), Array.Empty<string>(), Array.Empty<string>())));
+        }
+
+        if (ctx.Finishes.Count != 1)
+        {
+            findings.Add(Error("E2", "Single finish",
+                $"Graph must have exactly one finish node (found {ctx.Finishes.Count}). Parallel branches must converge to one finish.",
+                new ValidationTargets(ctx.Finishes.Select(n => n.Id).ToList(), Array.Empty<string>(), Array.Empty<string>())));
+        }
+
+        // E7 — incomplete task: missing line or non-positive duration.
+        foreach (var t in ctx.Tasks)
+        {
+            if (t.WorkStationId is null || t.WorkStationId == Guid.Empty)
+            {
+                findings.Add(Error("E7", "Incomplete task",
+                    $"Task '{NameOf(t)}' has no work station.", ValidationTargets.Nodes(t.Id)));
+            }
+
+            if (t.DurationSec is null || t.DurationSec <= 0)
+            {
+                findings.Add(Error("E7", "Incomplete task",
+                    $"Task '{NameOf(t)}' has no positive duration.", ValidationTargets.Nodes(t.Id)));
+            }
+        }
+
+        // E5 — cycle (nodes that fall outside any topological order).
+        if (ctx.CyclicNodes.Count > 0)
+        {
+            var cyclicEdges = ctx.Graph.Edges
+                .Where(e => ctx.CyclicNodes.Contains(e.From) && ctx.CyclicNodes.Contains(e.To))
+                .Select(e => ValidationTargets.EdgeId(e.From, e.To))
+                .ToList();
+            findings.Add(Error("E5", "Cycle",
+                "The flow contains a cycle, so it can never complete.",
+                new ValidationTargets(ctx.CyclicNodes.ToList(), cyclicEdges, Array.Empty<string>())));
+        }
+
+        // E3 / E4 — reachability (only meaningful with a single start + finish, acyclic).
+        if (ctx.Starts.Count == 1 && ctx.Finishes.Count == 1 && ctx.CyclicNodes.Count == 0)
+        {
+            if (!ctx.ReachableFromStart.Contains(ctx.Finishes[0].Id))
+            {
+                findings.Add(Error("E4", "Dead-end flow",
+                    "Finish is not reachable from start.", ValidationTargets.Nodes(ctx.Finishes[0].Id)));
+            }
+
+            foreach (var t in ctx.Tasks)
+            {
+                if (!ctx.ReachableFromStart.Contains(t.Id))
+                {
+                    findings.Add(Error("E3", "Unreachable task",
+                        $"Task '{NameOf(t)}' has no path from start — it never begins.",
+                        ValidationTargets.Nodes(t.Id)));
+                }
+                else if (!ctx.CanReachFinish.Contains(t.Id))
+                {
+                    findings.Add(Error("E4", "Dead-end task",
+                        $"Task '{NameOf(t)}' hangs — no path to finish.", ValidationTargets.Nodes(t.Id)));
+                }
+            }
+        }
+    }
+
+    // ── Metrics ────────────────────────────────────────────────────────────
+    private static ValidationMetrics ComputeMetrics(Context ctx)
+    {
+        // Per-line load works regardless of DAG validity.
+        var lineLoads = ctx.Tasks
+            .Where(t => t.WorkStationId is { } s && s != Guid.Empty)
+            .GroupBy(t => t.WorkStationId!.Value)
+            .Select(g => new LineLoadInfo(
+                g.Key.ToString(),
+                ctx.StationName(g.Key),
+                g.Sum(t => t.DurationSec ?? 0),
+                g.Count()))
+            .OrderByDescending(l => l.LoadSec)
+            .ToList();
+
+        BottleneckInfo? bottleneck = null;
+        var throughput = 0;
+        if (lineLoads.Count > 0 && lineLoads[0].LoadSec > 0)
+        {
+            var top = lineLoads[0];
+            bottleneck = new BottleneckInfo(top.StationId, top.StationName, top.LoadSec);
+            throughput = (int)Math.Round(3600.0 / top.LoadSec, MidpointRounding.AwayFromZero);
+        }
+
+        // Critical path + merges require a single start/finish and an acyclic graph.
+        CriticalPathInfo? criticalPath = null;
+        var merges = new List<MergeInfo>();
+        var leadTime = 0;
+        if (ctx.Starts.Count == 1 && ctx.Finishes.Count == 1 && ctx.CyclicNodes.Count == 0)
+        {
+            var (path, total) = ctx.LongestPathToFinish();
+            if (path.Count > 0)
+            {
+                criticalPath = new CriticalPathInfo(path, total);
+                leadTime = total;
+            }
+
+            foreach (var node in ctx.Graph.Nodes)
+            {
+                var arrivals = ctx.Predecessors(node.Id)
+                    .Where(p => ctx.ReachableFromStart.Contains(p))
+                    .Select(ctx.DistanceTo)
+                    .Where(d => d >= 0)
+                    .ToList();
+                if (arrivals.Count < 2)
+                {
+                    continue;
+                }
+
+                var max = arrivals.Max();
+                var min = arrivals.Min();
+                merges.Add(new MergeInfo(node.Id, max, min, max - min));
+            }
+        }
+
+        return new ValidationMetrics(leadTime, criticalPath, bottleneck, throughput, lineLoads, merges);
+    }
+
+    // ── Warnings ───────────────────────────────────────────────────────────
+    private static void CheckWarnings(Context ctx, ValidationMetrics metrics, List<ValidationFinding> findings)
+    {
+        // W1 — branch imbalance / starvation at a merge.
+        foreach (var m in metrics.Merges.Where(m => m.WaitSec >= BranchImbalanceWaitSec))
+        {
+            findings.Add(new ValidationFinding("W1", ValidationSeverity.Warning, "Branch imbalance",
+                $"Branches into '{ctx.NodeName(m.NodeId)}' differ by {Hms(m.WaitSec)} — the fast branch idles ({Hms(m.MaxInSec)} vs {Hms(m.MinInSec)}).",
+                ValidationTargets.Nodes(m.NodeId),
+                new Dictionary<string, double> { ["waitSec"] = m.WaitSec, ["maxInSec"] = m.MaxInSec, ["minInSec"] = m.MinInSec }));
+        }
+
+        // W3 — bottleneck line (only meaningful when a real constraint exists).
+        if (metrics.Bottleneck is { } b && metrics.LineLoads.Count >= 2)
+        {
+            var nodes = ctx.TaskNodesOnStation(b.StationId);
+            findings.Add(new ValidationFinding("W3", ValidationSeverity.Warning, "Bottleneck line",
+                $"'{b.StationName}' is the bottleneck — caps throughput at ~{metrics.ThroughputPerHour}/hr.",
+                new ValidationTargets(nodes, Array.Empty<string>(), new[] { b.StationId }),
+                new Dictionary<string, double> { ["loadSec"] = b.LoadSec, ["throughputPerHour"] = metrics.ThroughputPerHour }));
+        }
+
+        // W4 — false parallelism: concurrent tasks pinned to the same line.
+        if (ctx.CyclicNodes.Count == 0)
+        {
+            foreach (var group in ctx.TasksByStation())
+            {
+                var concurrent = ctx.ConcurrentTaskSet(group.Value);
+                if (concurrent.Count >= 2)
+                {
+                    findings.Add(new ValidationFinding("W4", ValidationSeverity.Warning, "False parallelism",
+                        $"{concurrent.Count} tasks look parallel but share line '{ctx.StationName(group.Key)}' — they queue (real time = sum, not max).",
+                        new ValidationTargets(concurrent, Array.Empty<string>(), new[] { group.Key.ToString() })));
+                }
+            }
+        }
+
+        // W5 — WIP / CONWIP risk.
+        foreach (var group in ctx.TasksByStation())
+        {
+            var station = ctx.Station(group.Key);
+            if (station?.WipLimit is { } limit && limit > 0 && group.Value.Count > limit)
+            {
+                findings.Add(new ValidationFinding("W5", ValidationSeverity.Warning, "WIP risk",
+                    $"{group.Value.Count} tasks routed through '{station.Name}' (WIP limit {limit}) — a guaranteed queue.",
+                    new ValidationTargets(group.Value.Select(t => t.Id).ToList(), Array.Empty<string>(), new[] { group.Key.ToString() }),
+                    new Dictionary<string, double> { ["routed"] = group.Value.Count, ["wipLimit"] = limit }));
+            }
+        }
+
+        // W6 — line ping-pong: A → B → A (same line bracketing a different one).
+        var pingPong = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var t in ctx.Tasks)
+        {
+            if (t.WorkStationId is not { } a || a == Guid.Empty)
+            {
+                continue;
+            }
+
+            foreach (var midId in ctx.Successors(t.Id))
+            {
+                if (ctx.StationOf(midId) is not { } mid || mid == a)
+                {
+                    continue;
+                }
+
+                foreach (var endId in ctx.Successors(midId))
+                {
+                    if (ctx.StationOf(endId) == a)
+                    {
+                        var key = string.CompareOrdinal(a.ToString(), mid.ToString()) <= 0
+                            ? $"{a}|{mid}" : $"{mid}|{a}";
+                        if (pingPong.Add(key))
+                        {
+                            findings.Add(new ValidationFinding("W6", ValidationSeverity.Warning, "Line ping-pong",
+                                $"Flow bounces '{ctx.StationName(a)}' → '{ctx.StationName(mid)}' → '{ctx.StationName(a)}' — extra transport/changeovers. Group consecutive same-line tasks.",
+                                ValidationTargets.Nodes(t.Id, midId, endId)));
+                        }
+                    }
+                }
+            }
+        }
+
+        // W7 — dominant task: one operation owns most of the lead time
+        // (only meaningful when there is more than one task to compare against).
+        if (metrics.CriticalPath is { } cp && cp.DurationSec > 0 && ctx.Tasks.Count >= 2)
+        {
+            foreach (var t in ctx.Tasks)
+            {
+                var dur = t.DurationSec ?? 0;
+                var share = (double)dur / cp.DurationSec;
+                if (share >= DominantTaskShare)
+                {
+                    findings.Add(new ValidationFinding("W7", ValidationSeverity.Warning, "Dominant task",
+                        $"'{NameOf(t)}' is {Pct(share)} of the lead time — the whole flow hinges on one operation.",
+                        ValidationTargets.Nodes(t.Id),
+                        new Dictionary<string, double> { ["percent"] = Math.Round(share * 100, 1) }));
+                }
+            }
+        }
+
+        // W8 — line load imbalance: one line carries most of the work.
+        var totalLoad = metrics.LineLoads.Sum(l => (long)l.LoadSec);
+        if (totalLoad > 0 && metrics.LineLoads.Count >= 2)
+        {
+            var top = metrics.LineLoads[0];
+            var share = (double)top.LoadSec / totalLoad;
+            if (share >= LineImbalanceShare)
+            {
+                findings.Add(new ValidationFinding("W8", ValidationSeverity.Warning, "Line load imbalance",
+                    $"'{top.StationName}' carries {Pct(share)} of the total work while other lines idle — rebalance opportunity.",
+                    new ValidationTargets(ctx.TaskNodesOnStation(top.StationId), Array.Empty<string>(), new[] { top.StationId }),
+                    new Dictionary<string, double> { ["percent"] = Math.Round(share * 100, 1) }));
+            }
+        }
+
+        // W9 — redundant dependency: A → C while A ⇒ … ⇒ C already exists.
+        foreach (var e in ctx.Graph.Edges)
+        {
+            if (!ctx.NodeIds.Contains(e.From) || !ctx.NodeIds.Contains(e.To) || string.Equals(e.From, e.To, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            if (ctx.HasAlternatePath(e.From, e.To))
+            {
+                findings.Add(new ValidationFinding("W9", ValidationSeverity.Warning, "Redundant dependency",
+                    $"Edge '{ctx.NodeName(e.From)}' → '{ctx.NodeName(e.To)}' is redundant — already reached another way. Over-constrains scheduling.",
+                    EdgeTarget(e.From, e.To)));
+            }
+        }
+
+        // W11 — long single-line chain.
+        var chain = ctx.LongestSameLineChain();
+        if (chain.Count >= LongChainLength)
+        {
+            findings.Add(new ValidationFinding("W11", ValidationSeverity.Warning, "Long single-line chain",
+                $"{chain.Count} sequential tasks on '{ctx.StationName(ctx.StationOf(chain[0])!.Value)}' — a serial bottleneck; candidate to parallelize.",
+                new ValidationTargets(chain, Array.Empty<string>(), Array.Empty<string>())));
+        }
+    }
+
+    // ── Hints ──────────────────────────────────────────────────────────────
+    private static void CheckHints(Context ctx, List<ValidationFinding> findings)
+    {
+        // H1 — name hygiene: empty / placeholder / duplicate task names.
+        var placeholders = new HashSet<string>(
+            new[] { "task", "new task", "new_task", "newtask", "untitled" }, StringComparer.OrdinalIgnoreCase);
+        foreach (var t in ctx.Tasks)
+        {
+            var name = t.Name?.Trim() ?? string.Empty;
+            if (name.Length == 0 || placeholders.Contains(name))
+            {
+                findings.Add(new ValidationFinding("H1", ValidationSeverity.Hint, "Name hygiene",
+                    name.Length == 0 ? "A task has no name — give it a real name." : $"Task named '{name}' — give it a real name.",
+                    ValidationTargets.Nodes(t.Id)));
+            }
+        }
+
+        foreach (var dup in ctx.Tasks
+                     .Where(t => !string.IsNullOrWhiteSpace(t.Name))
+                     .GroupBy(t => t.Name!.Trim(), StringComparer.OrdinalIgnoreCase)
+                     .Where(g => g.Count() > 1))
+        {
+            findings.Add(new ValidationFinding("H1", ValidationSeverity.Hint, "Duplicate name",
+                $"{dup.Count()} tasks share the name '{dup.Key}' — make them distinct.",
+                new ValidationTargets(dup.Select(t => t.Id).ToList(), Array.Empty<string>(), Array.Empty<string>())));
+        }
+
+        // H2 — duration outlier vs sibling tasks.
+        var durations = ctx.Tasks.Where(t => t.DurationSec is > 0).Select(t => t.DurationSec!.Value).ToList();
+        if (durations.Count >= 3)
+        {
+            var median = Median(durations);
+            foreach (var t in ctx.Tasks.Where(t => t.DurationSec is > 0))
+            {
+                var dur = t.DurationSec!.Value;
+                if ((median > 0 && dur > median * DurationOutlierFactor) || dur > AbsurdDurationSec)
+                {
+                    findings.Add(new ValidationFinding("H2", ValidationSeverity.Hint, "Duration outlier",
+                        $"'{NameOf(t)}' is {Hms(dur)} — far from the typical {Hms(median)}. Double-check the duration.",
+                        ValidationTargets.Nodes(t.Id),
+                        new Dictionary<string, double> { ["durationSec"] = dur, ["medianSec"] = median }));
+                }
+            }
+        }
+
+        // H3 — bad station reference (unknown or inactive station).
+        if (ctx.HasStationCatalog)
+        {
+            foreach (var t in ctx.Tasks)
+            {
+                if (t.WorkStationId is not { } sid || sid == Guid.Empty)
+                {
+                    continue; // covered by E7
+                }
+
+                var station = ctx.Station(sid);
+                if (station is null)
+                {
+                    findings.Add(new ValidationFinding("H3", ValidationSeverity.Hint, "Bad station ref",
+                        $"'{NameOf(t)}' points at a work station that no longer exists.",
+                        new ValidationTargets(new[] { t.Id }, Array.Empty<string>(), new[] { sid.ToString() })));
+                }
+                else if (!station.IsActive)
+                {
+                    findings.Add(new ValidationFinding("H3", ValidationSeverity.Hint, "Inactive station",
+                        $"'{NameOf(t)}' runs on '{station.Name}', which is inactive.",
+                        new ValidationTargets(new[] { t.Id }, Array.Empty<string>(), new[] { sid.ToString() })));
+                }
+            }
+        }
+
+        // H4 — no convergence: parallel branches each go straight to finish.
+        if (ctx.Starts.Count == 1 && ctx.Finishes.Count == 1 && ctx.CyclicNodes.Count == 0)
+        {
+            var finish = ctx.Finishes[0];
+            var taskPreds = ctx.Predecessors(finish.Id).Where(p => ctx.IsTask(p)).ToList();
+            if (taskPreds.Count >= 2)
+            {
+                findings.Add(new ValidationFinding("H4", ValidationSeverity.Hint, "No convergence",
+                    $"{taskPreds.Count} branches reach finish with no shared assembly step — confirm that's intended.",
+                    new ValidationTargets(taskPreds.Append(finish.Id).ToList(), Array.Empty<string>(), Array.Empty<string>())));
+            }
+        }
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────
+    private static ValidationFinding Error(string id, string title, string message, ValidationTargets targets) =>
+        new(id, ValidationSeverity.Error, title, message, targets);
+
+    private static ValidationTargets EdgeTarget(string from, string to) =>
+        new(Array.Empty<string>(), new[] { ValidationTargets.EdgeId(from, to) }, Array.Empty<string>());
+
+    private static string NameOf(WorkflowGraphNode n) =>
+        string.IsNullOrWhiteSpace(n.Name) ? n.Id : n.Name.Trim();
+
+    private static string Pct(double share) => $"{Math.Round(share * 100)}%";
+
+    private static int Median(List<int> values)
+    {
+        var sorted = values.OrderBy(v => v).ToList();
+        var mid = sorted.Count / 2;
+        return sorted.Count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+    }
+
+    private static string Hms(int sec)
+    {
+        if (sec < 60)
+        {
+            return $"{sec}s";
+        }
+
+        var h = sec / 3600;
+        var m = (sec % 3600 + 30) / 60;
+        if (h > 0 && m > 0)
+        {
+            return $"{h}h {m}m";
+        }
+
+        return h > 0 ? $"{h}h" : $"{m}m";
+    }
+
+    /// <summary>Pre-computed graph helpers shared across rule passes.</summary>
+    private sealed class Context
+    {
+        private const int NegativeInfinity = int.MinValue / 4;
+
+        private readonly Dictionary<string, WorkflowGraphNode> _byId;
+        private readonly Dictionary<string, List<string>> _adj;
+        private readonly Dictionary<string, List<string>> _rev;
+        private readonly Dictionary<Guid, WorkflowStationInfo> _stations;
+        private readonly Dictionary<string, int> _distance = new(StringComparer.Ordinal);
+        private List<string>? _topoOrder;
+
+        public Context(WorkflowGraph graph, IReadOnlyCollection<WorkflowStationInfo> stations)
+        {
+            Graph = graph;
+            _byId = graph.Nodes
+                .Where(n => !string.IsNullOrWhiteSpace(n.Id))
+                .GroupBy(n => n.Id, StringComparer.Ordinal)
+                .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
+            NodeIds = new HashSet<string>(_byId.Keys, StringComparer.Ordinal);
+
+            _adj = NodeIds.ToDictionary(id => id, _ => new List<string>(), StringComparer.Ordinal);
+            _rev = NodeIds.ToDictionary(id => id, _ => new List<string>(), StringComparer.Ordinal);
+            foreach (var e in graph.Edges)
+            {
+                if (NodeIds.Contains(e.From) && NodeIds.Contains(e.To) && !string.Equals(e.From, e.To, StringComparison.Ordinal))
+                {
+                    _adj[e.From].Add(e.To);
+                    _rev[e.To].Add(e.From);
+                }
+            }
+
+            _stations = stations
+                .GroupBy(s => s.Id)
+                .ToDictionary(g => g.Key, g => g.First());
+            HasStationCatalog = stations.Count > 0;
+
+            Starts = graph.Nodes.Where(n => n.Kind == WorkflowNodeKind.Start).ToList();
+            Finishes = graph.Nodes.Where(n => n.Kind == WorkflowNodeKind.Finish).ToList();
+            Tasks = graph.Nodes.Where(n => n.Kind == WorkflowNodeKind.Task).ToList();
+
+            TopoSort();
+            ReachableFromStart = Starts.Count == 1 ? Traverse(Starts[0].Id, _adj) : new HashSet<string>(StringComparer.Ordinal);
+            CanReachFinish = Finishes.Count == 1 ? Traverse(Finishes[0].Id, _rev) : new HashSet<string>(StringComparer.Ordinal);
+        }
+
+        public WorkflowGraph Graph { get; }
+
+        public HashSet<string> NodeIds { get; }
+
+        public IReadOnlyList<WorkflowGraphNode> Starts { get; }
+
+        public IReadOnlyList<WorkflowGraphNode> Finishes { get; }
+
+        public IReadOnlyList<WorkflowGraphNode> Tasks { get; }
+
+        public HashSet<string> CyclicNodes { get; private set; } = new(StringComparer.Ordinal);
+
+        public HashSet<string> ReachableFromStart { get; }
+
+        public HashSet<string> CanReachFinish { get; }
+
+        public bool HasStationCatalog { get; }
+
+        public IReadOnlyList<string> Successors(string id) =>
+            _adj.TryGetValue(id, out var s) ? s : Array.Empty<string>();
+
+        public IReadOnlyList<string> Predecessors(string id) =>
+            _rev.TryGetValue(id, out var p) ? p : Array.Empty<string>();
+
+        public bool IsTask(string id) => _byId.TryGetValue(id, out var n) && n.Kind == WorkflowNodeKind.Task;
+
+        public Guid? StationOf(string id) =>
+            _byId.TryGetValue(id, out var n) && n.WorkStationId is { } s && s != Guid.Empty ? s : null;
+
+        public WorkflowStationInfo? Station(Guid id) => _stations.TryGetValue(id, out var s) ? s : null;
+
+        public string StationName(Guid id) => _stations.TryGetValue(id, out var s) ? s.Name : id.ToString();
+
+        public string NodeName(string id) =>
+            _byId.TryGetValue(id, out var n) && !string.IsNullOrWhiteSpace(n.Name) ? n.Name.Trim() : id;
+
+        public IReadOnlyDictionary<Guid, List<WorkflowGraphNode>> TasksByStation() =>
+            Tasks.Where(t => t.WorkStationId is { } s && s != Guid.Empty)
+                .GroupBy(t => t.WorkStationId!.Value)
+                .ToDictionary(g => g.Key, g => g.ToList());
+
+        public IReadOnlyList<string> TaskNodesOnStation(string stationId) =>
+            Guid.TryParse(stationId, out var guid)
+                ? Tasks.Where(t => t.WorkStationId == guid).Select(t => t.Id).ToList()
+                : Array.Empty<string>();
+
+        public int DistanceTo(string id) => _distance.TryGetValue(id, out var d) ? d : 0;
+
+        /// <summary>Tasks within <paramref name="group"/> that are mutually unreachable (truly concurrent).</summary>
+        public List<string> ConcurrentTaskSet(List<WorkflowGraphNode> group)
+        {
+            var concurrent = new HashSet<string>(StringComparer.Ordinal);
+            for (var i = 0; i < group.Count; i++)
+            {
+                for (var j = i + 1; j < group.Count; j++)
+                {
+                    var a = group[i].Id;
+                    var b = group[j].Id;
+                    if (!Reaches(a, b) && !Reaches(b, a))
+                    {
+                        concurrent.Add(a);
+                        concurrent.Add(b);
+                    }
+                }
+            }
+
+            return concurrent.ToList();
+        }
+
+        /// <summary>True if <paramref name="to"/> is reachable from <paramref name="from"/> ignoring the direct edge.</summary>
+        public bool HasAlternatePath(string from, string to)
+        {
+            var stack = new Stack<string>();
+            foreach (var next in Successors(from))
+            {
+                if (!string.Equals(next, to, StringComparison.Ordinal))
+                {
+                    stack.Push(next);
+                }
+            }
+
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            while (stack.Count > 0)
+            {
+                var cur = stack.Pop();
+                if (string.Equals(cur, to, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+
+                if (!seen.Add(cur))
+                {
+                    continue;
+                }
+
+                foreach (var next in Successors(cur))
+                {
+                    stack.Push(next);
+                }
+            }
+
+            return false;
+        }
+
+        public (IReadOnlyList<string> Path, int Total) LongestPathToFinish()
+        {
+            if (_topoOrder is null || Starts.Count != 1 || Finishes.Count != 1)
+            {
+                return (Array.Empty<string>(), 0);
+            }
+
+            var pred = new Dictionary<string, string?>(StringComparer.Ordinal);
+            foreach (var id in _topoOrder)
+            {
+                pred[id] = null;
+            }
+
+            foreach (var id in _topoOrder)
+            {
+                foreach (var next in Successors(id))
+                {
+                    var candidate = _distance[id] + Weight(next);
+                    if (candidate > _distance[next])
+                    {
+                        _distance[next] = candidate;
+                        pred[next] = id;
+                    }
+                }
+            }
+
+            var finishId = Finishes[0].Id;
+            if (!_distance.TryGetValue(finishId, out var finishDist) || finishDist < 0)
+            {
+                return (Array.Empty<string>(), 0);
+            }
+
+            var path = new List<string>();
+            string? cursor = finishId;
+            while (cursor is not null)
+            {
+                path.Add(cursor);
+                cursor = pred[cursor];
+            }
+
+            path.Reverse();
+            return (path, _distance[finishId]);
+        }
+
+        public List<string> LongestSameLineChain()
+        {
+            if (_topoOrder is null)
+            {
+                return new List<string>();
+            }
+
+            var best = new Dictionary<string, List<string>>(StringComparer.Ordinal);
+            List<string> longest = new();
+            foreach (var id in _topoOrder)
+            {
+                if (!IsTask(id) || StationOf(id) is not { } station)
+                {
+                    continue;
+                }
+
+                var chain = new List<string> { id };
+                foreach (var p in Predecessors(id))
+                {
+                    if (StationOf(p) == station && best.TryGetValue(p, out var prev) && prev.Count + 1 > chain.Count)
+                    {
+                        chain = new List<string>(prev) { id };
+                    }
+                }
+
+                best[id] = chain;
+                if (chain.Count > longest.Count)
+                {
+                    longest = chain;
+                }
+            }
+
+            return longest;
+        }
+
+        private int Weight(string id) =>
+            _byId.TryGetValue(id, out var n) && n.Kind == WorkflowNodeKind.Task ? Math.Max(0, n.DurationSec ?? 0) : 0;
+
+        private bool Reaches(string from, string to) => Traverse(from, _adj).Contains(to);
+
+        private void TopoSort()
+        {
+            var indeg = NodeIds.ToDictionary(id => id, _ => 0, StringComparer.Ordinal);
+            foreach (var kv in _adj)
+            {
+                foreach (var to in kv.Value)
+                {
+                    indeg[to]++;
+                }
+            }
+
+            var queue = new Queue<string>(indeg.Where(kv => kv.Value == 0).Select(kv => kv.Key));
+            var order = new List<string>();
+            while (queue.Count > 0)
+            {
+                var id = queue.Dequeue();
+                order.Add(id);
+                foreach (var next in _adj[id])
+                {
+                    if (--indeg[next] == 0)
+                    {
+                        queue.Enqueue(next);
+                    }
+                }
+            }
+
+            if (order.Count == NodeIds.Count)
+            {
+                _topoOrder = order;
+                // Base distances: a source node starts at its own weight; every other
+                // node starts at a sentinel so the first predecessor relaxation wins
+                // (and records a predecessor for critical-path backtracking).
+                foreach (var id in order)
+                {
+                    _distance[id] = _rev[id].Count == 0 ? Weight(id) : NegativeInfinity;
+                }
+            }
+            else
+            {
+                CyclicNodes = new HashSet<string>(NodeIds.Except(order), StringComparer.Ordinal);
+            }
+        }
+
+        private static HashSet<string> Traverse(string from, IReadOnlyDictionary<string, List<string>> adjacency)
+        {
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var stack = new Stack<string>();
+            stack.Push(from);
+            while (stack.Count > 0)
+            {
+                var cur = stack.Pop();
+                if (!seen.Add(cur))
+                {
+                    continue;
+                }
+
+                if (adjacency.TryGetValue(cur, out var next))
+                {
+                    foreach (var n in next)
+                    {
+                        stack.Push(n);
+                    }
+                }
+            }
+
+            return seen;
+        }
+    }
+}

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Domain/Workflows/ValidationReport.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.Domain/Workflows/ValidationReport.cs
@@ -1,0 +1,80 @@
+namespace LKvitai.MES.Modules.Shopfloor.Domain.Workflows;
+
+/// <summary>Smart-validation severity tiers (see shopfloor-12 §2).</summary>
+public enum ValidationSeverity
+{
+    /// <summary>Flow is structurally invalid / unrunnable — blocks publish.</summary>
+    Error,
+
+    /// <summary>Flow runs, but has a production problem (queue, bottleneck, imbalance).</summary>
+    Warning,
+
+    /// <summary>Hygiene / optimization suggestion.</summary>
+    Hint,
+}
+
+/// <summary>
+/// Read-only metadata about a work station, supplied to the validator so
+/// station-aware rules (W3/W5, H3) and labels can be computed without the
+/// Domain layer depending on persistence.
+/// </summary>
+public sealed record WorkflowStationInfo(Guid Id, string Code, string Name, int? WipLimit, bool IsActive);
+
+/// <summary>What a finding points at on the canvas (highlight targets).</summary>
+public sealed record ValidationTargets(
+    IReadOnlyList<string> NodeIds,
+    IReadOnlyList<string> EdgeIds,
+    IReadOnlyList<string> StationIds)
+{
+    public static readonly ValidationTargets None =
+        new(Array.Empty<string>(), Array.Empty<string>(), Array.Empty<string>());
+
+    public static ValidationTargets Nodes(params string[] nodeIds) =>
+        new(nodeIds, Array.Empty<string>(), Array.Empty<string>());
+
+    /// <summary>Canonical edge identifier used in <see cref="EdgeIds"/>.</summary>
+    public static string EdgeId(string from, string to) => $"{from}->{to}";
+}
+
+/// <summary>A single validation finding (one rule firing on one target set).</summary>
+public sealed record ValidationFinding(
+    string RuleId,
+    ValidationSeverity Severity,
+    string Title,
+    string Message,
+    ValidationTargets Targets,
+    IReadOnlyDictionary<string, double>? Detail = null);
+
+public sealed record CriticalPathInfo(IReadOnlyList<string> NodeIds, int DurationSec);
+
+public sealed record BottleneckInfo(string StationId, string StationName, int LoadSec);
+
+public sealed record LineLoadInfo(string StationId, string StationName, int LoadSec, int TaskCount);
+
+public sealed record MergeInfo(string NodeId, int MaxInSec, int MinInSec, int WaitSec);
+
+/// <summary>Numbers the report surfaces beyond pass/fail (shopfloor-12 §4).</summary>
+public sealed record ValidationMetrics(
+    int LeadTimeSec,
+    CriticalPathInfo? CriticalPath,
+    BottleneckInfo? Bottleneck,
+    int ThroughputPerHour,
+    IReadOnlyList<LineLoadInfo> LineLoads,
+    IReadOnlyList<MergeInfo> Merges)
+{
+    public static readonly ValidationMetrics Empty =
+        new(0, null, null, 0, Array.Empty<LineLoadInfo>(), Array.Empty<MergeInfo>());
+}
+
+public sealed record ValidationSummary(int Errors, int Warnings, int Hints);
+
+/// <summary>
+/// One shape produced by the engine and consumed by both the editor report
+/// panel and (on publish) the API (shopfloor-12 §5).
+/// </summary>
+public sealed record ValidationReport(
+    int Score,
+    bool Publishable,
+    ValidationSummary Summary,
+    ValidationMetrics Metrics,
+    IReadOnlyList<ValidationFinding> Findings);

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-validation-report-prototype.html
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-validation-report-prototype.html
@@ -1,0 +1,875 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>ShopfloorPilot — Smart Validation Report · ROLLER_STD</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+/* ───────────────────────────────────────────────
+   Cikada.MES tokens — IDENTICAL to the workflow editor
+   prototype. Validation presentation adds NO new color
+   families: error=danger/red, warning=warn/sand-amber,
+   hint=info/teal, ok=green, critical-path=accent/teal.
+   ─────────────────────────────────────────────── */
+:root{
+  --n-0:#fff; --n-25:#fbfcfd; --n-50:#f5f6f8; --n-100:#eef1f4;
+  --n-150:#e2e7ec; --n-200:#d5dce4; --n-300:#b9c3ce; --n-400:#8996a4;
+  --n-500:#66717f; --n-600:#4e5966; --n-700:#323b45; --n-800:#1f2632; --n-900:#151922;
+
+  --accent-50:#eaf8f7; --accent-100:#d1eeec; --accent-400:#56aaa7;
+  --accent-500:#2f8f8b; --accent-600:#257773; --accent-700:#1d5d5a;
+
+  --sand-25:#faf6ee; --sand-50:#f7f1e5; --sand-100:#ede2c8;
+  --sand-500:#c79f63; --sand-600:#b08a4a; --sand-700:#7c5f2a;
+
+  --brand-50:var(--accent-50); --brand-100:var(--accent-100); --brand-300:var(--accent-400);
+  --brand-500:var(--accent-500); --brand-600:var(--accent-600); --brand-700:var(--accent-700);
+
+  /* node families (from editor): start=info teal, task=warn sand, finish=ok green */
+  --start-bg:#e3f2f1; --start-bg2:#d4ebe9; --start-bd:#b4dad7; --start-fg:#1d5d5a; --start-dot:#2f8f8b;
+  --task-bg:#f7eed5;  --task-bg2:#f0e3bf; --task-bd:#e2cf9a; --task-fg:#7c5f2a; --task-dot:#b08a4a;
+  --finish-bg:#e6f4ec; --finish-bg2:#d8ecdf; --finish-bd:#bfe0cd; --finish-fg:#19744a; --finish-dot:#1f9d61;
+
+  --ok-dot:#1f9d61; --ok-fg:#19744a; --ok-bg:#e6f4ec; --ok-bd:#bfe0cd;
+  --warn-bg:#f7eed5; --warn-bd:#e2cf9a; --warn-fg:#7c5f2a; --warn-strong:#b08a4a;
+  --danger-fg:#8a1f12; --danger-bg:#fbe7e3; --danger-bd:#f0c2b8; --danger-strong:#c0392b;
+  --info-fg:#1d5d5a; --info-bg:#eaf8f7; --info-bd:#bfe6e3; --info-strong:#2f8f8b;
+
+  --dark:#20242c; --dark-2:#171b22; --dark-line:#3a404c; --dark-fg:#fff; --dark-fg-muted:#a5adb8;
+  --page-wash:#f0eee9;
+
+  --font-ui:Inter,"Segoe UI",system-ui,-apple-system,sans-serif;
+  --font-mono:"JetBrains Mono","SF Mono",Consolas,monospace;
+
+  --r-xs:3px; --r-sm:5px; --r-md:7px; --r-lg:10px; --r-pill:999px;
+  --shadow-xs:0 1px 0 rgba(15,23,35,.04);
+  --shadow-sm:0 1px 2px rgba(15,23,35,.06),0 0 0 1px rgba(15,23,35,.03);
+  --shadow-md:0 6px 18px rgba(15,23,42,.08);
+  --shadow-lg:0 14px 30px rgba(15,23,42,.12);
+  --ls-eyebrow:1.4px;
+}
+
+*{box-sizing:border-box;}
+html,body{height:100%;}
+body{
+  margin:0; font-family:var(--font-ui); font-size:12.5px; color:var(--n-900);
+  background:var(--n-50); -webkit-font-smoothing:antialiased; overflow:hidden;
+}
+.mono{font-family:var(--font-mono); font-variant-numeric:tabular-nums; font-feature-settings:"zero";}
+
+.app{display:flex; flex-direction:column; height:100vh; width:100vw;}
+
+/* ── Topbar ──────────────────────────────────── */
+.topbar{
+  display:flex; align-items:center; gap:12px; height:56px; flex:0 0 56px;
+  padding:0 16px; background:var(--n-0); border-bottom:1px solid var(--n-200);
+  box-shadow:var(--shadow-xs); z-index:30; position:relative;
+}
+.brand-pill{display:flex; align-items:center; gap:9px; padding:7px 13px 7px 8px; background:var(--dark); border-radius:var(--r-pill); color:var(--dark-fg);}
+.brand-mark{width:24px; height:24px; border-radius:6px; background:var(--brand-500); display:grid; place-items:center; font-weight:800; font-size:11px; color:#fff; letter-spacing:.5px; box-shadow:inset 0 0 0 1px rgba(255,255,255,.12);}
+.brand-pill .b-name{font-weight:700; font-size:12px;}
+.brand-pill .b-dim{color:var(--dark-fg-muted); font-weight:500;}
+.ctx-pill{display:flex; align-items:center; gap:7px; padding:7px 12px; background:var(--n-50); border:1px solid var(--n-200); border-radius:var(--r-pill); font-size:11.5px;}
+.ctx-pill .lbl{color:var(--n-500); font-weight:500;}
+.ctx-pill .val{font-family:var(--font-mono); font-weight:700; color:var(--n-900); letter-spacing:.3px;}
+.ctx-pill .dot{width:7px; height:7px; border-radius:50%; background:var(--ok-dot);}
+.spacer{flex:1 1 auto;}
+
+.btn{
+  display:inline-flex; align-items:center; gap:7px; height:34px; padding:0 13px;
+  border-radius:var(--r-sm); font-family:var(--font-ui); font-size:13px; font-weight:600;
+  border:1px solid var(--n-200); background:var(--n-0); color:var(--n-800); cursor:pointer;
+  transition:background .14s, border-color .14s, box-shadow .14s, color .14s, transform .05s; white-space:nowrap;
+}
+.btn:hover{background:var(--n-50); border-color:var(--n-300);}
+.btn:active{transform:translateY(.5px);}
+.btn .ic{width:15px; height:15px; flex:0 0 auto;}
+.btn-primary{background:var(--brand-500); border-color:var(--brand-600); color:#fff; box-shadow:0 1px 0 rgba(29,93,90,.30), inset 0 1px 0 rgba(255,255,255,.18);}
+.btn-primary:hover{background:var(--brand-600); border-color:var(--brand-700);}
+.btn-primary:disabled{background:var(--n-100); border-color:var(--n-200); color:var(--n-400); cursor:not-allowed; box-shadow:none;}
+.btn-sep{width:1px; height:24px; background:var(--n-200); margin:0 2px;}
+
+/* ── Validate button + live count badge ─────────── */
+.btn-validate{position:relative; padding-right:12px;}
+.btn-validate.is-clean{color:var(--ok-fg); border-color:var(--ok-bd); background:var(--ok-bg);}
+.count-badge{display:inline-flex; align-items:center; gap:7px; margin-left:3px; padding:2px 4px; border-radius:var(--r-pill); background:var(--n-50); border:1px solid var(--n-150);}
+.count-badge .cb{display:inline-flex; align-items:center; gap:3px; font-family:var(--font-mono); font-size:11px; font-weight:700; padding:1px 6px; border-radius:var(--r-pill);}
+.cb.err{color:var(--danger-fg); background:var(--danger-bg);}
+.cb.warn{color:var(--warn-fg); background:var(--warn-bg);}
+.cb.hint{color:var(--info-fg); background:var(--info-bg);}
+.cb.ok{color:var(--ok-fg); background:var(--ok-bg);}
+
+.seg{display:inline-flex; border:1px solid var(--n-200); border-radius:var(--r-sm); overflow:hidden; background:var(--n-0);}
+.seg button{height:32px; padding:0 12px; border:none; background:transparent; font-family:var(--font-ui); font-size:12px; font-weight:600; color:var(--n-600); cursor:pointer;}
+.seg button+button{border-left:1px solid var(--n-200);}
+.seg button.active{background:var(--brand-500); color:#fff;}
+
+/* ── Body: canvas + report drawer ─────────────── */
+.body-row{display:flex; flex:1 1 auto; min-height:0;}
+.canvas-wrap{position:relative; flex:1 1 auto; min-width:0; overflow:hidden; background:var(--n-50);}
+.canvas{
+  position:absolute; inset:0; overflow:hidden; cursor:grab; background-color:#f6f7f9;
+  background-image:radial-gradient(circle at 1px 1px, rgba(60,72,88,.16) 1px, transparent 0);
+  background-size:22px 22px;
+}
+.canvas.panning{cursor:grabbing;}
+.canvas::after{content:""; position:absolute; inset:0; pointer-events:none; background:radial-gradient(120% 80% at 50% 0%, rgba(255,255,255,.55), transparent 60%), linear-gradient(180deg, rgba(245,246,248,0), rgba(228,231,236,.45));}
+.world{position:absolute; top:0; left:0; width:6000px; height:4000px; transform-origin:0 0;}
+.world.animating{transition:transform .5s cubic-bezier(.4,0,.2,1);}
+.edges{position:absolute; top:0; left:0; width:6000px; height:4000px; overflow:visible; pointer-events:none;}
+
+/* ── Edges ────────────────────────────────────── */
+.edge-path{fill:none; stroke:var(--n-400); stroke-width:2.25; stroke-linecap:round;}
+.edge-flow{fill:none; stroke:var(--n-500); stroke-width:2.25; stroke-linecap:round; stroke-dasharray:7 9; animation:dashflow 1s linear infinite;}
+@keyframes dashflow{to{stroke-dashoffset:-32;}}
+/* critical path overlay */
+.edge.is-critical .edge-path{stroke:var(--accent-500); stroke-width:3.5;}
+.edge.is-critical .edge-flow{stroke:var(--accent-600); stroke-width:3.5; stroke-dasharray:2 10; animation:dashflow 1.5s linear infinite;}
+/* cycle (error) */
+.edge.is-cycle .edge-path{stroke:var(--danger-strong); stroke-width:3; stroke-dasharray:9 6;}
+.edge.is-cycle .edge-flow{stroke:transparent; animation:none;}
+/* redundant / over-constraining */
+.edge.is-redundant .edge-path{stroke:var(--warn-strong); stroke-width:2; stroke-dasharray:2 6; opacity:.85;}
+.edge.is-redundant .edge-flow{stroke:transparent; animation:none;}
+.edge.pulse .edge-path{animation:edgepulse 1.1s ease-in-out 2;}
+@keyframes edgepulse{0%,100%{stroke-width:3;}50%{stroke-width:6;}}
+
+/* ── Node cards ───────────────────────────────── */
+.node{position:absolute; user-select:none; transition:box-shadow .16s, transform .12s;}
+.card{position:relative; border-radius:var(--r-lg); border:1px solid var(--n-200); background:var(--n-0); box-shadow:var(--shadow-sm);}
+.card-head{display:flex; align-items:center; justify-content:space-between; gap:10px; padding:9px 12px 7px;}
+.card-title{font-weight:700; font-size:12.5px; line-height:1.15;}
+.card-kind{font-family:var(--font-mono); font-size:9px; font-weight:700; letter-spacing:var(--ls-eyebrow); text-transform:uppercase; padding:2px 6px; border-radius:var(--r-xs);}
+.node-start .card{width:172px; background:linear-gradient(180deg,var(--start-bg),var(--start-bg2)); border-color:var(--start-bd);}
+.node-start .card-title{color:var(--start-fg);} .node-start .card-kind{color:var(--start-fg); background:rgba(47,143,139,.14);}
+.node-finish .card{width:188px; background:linear-gradient(180deg,var(--finish-bg),var(--finish-bg2)); border-color:var(--finish-bd);}
+.node-finish .card-title{color:var(--finish-fg);} .node-finish .card-kind{color:var(--finish-fg); background:rgba(31,157,97,.14);}
+.node-task .card{width:232px; background:linear-gradient(180deg,var(--task-bg),var(--task-bg2)); border-color:var(--task-bd);}
+.node-task .card-title{color:var(--task-fg);} .node-task .card-kind{color:var(--task-fg); background:rgba(176,138,74,.18);}
+
+.meta{padding:2px 12px 11px; display:grid; gap:3px;}
+.meta-row{display:flex; gap:5px; font-size:10.5px; line-height:1.35; color:var(--n-600);}
+.meta-row .k{font-weight:700; color:var(--task-fg); white-space:nowrap;}
+.start-body,.finish-body{padding:2px 0 10px;}
+
+.sock-row{display:flex; align-items:center; gap:8px; padding:4px 12px; position:relative;}
+.sock-row.out{justify-content:flex-end;}
+.sock-label{font-family:var(--font-mono); font-size:10px; font-weight:600; color:var(--n-500);}
+.socket{width:12px; height:12px; border-radius:50%; background:var(--n-0); border:2.5px solid var(--task-dot); position:absolute; top:50%; transform:translateY(-50%); box-shadow:0 0 0 3px rgba(255,255,255,.6);}
+.socket.in{left:-6px;} .socket.out{right:-6px;}
+.node-start .socket{border-color:var(--start-dot);} .node-finish .socket{border-color:var(--finish-dot);}
+
+/* ── Validation highlight states (precedence via ring color) ── */
+/* ring = highest severity present; rule: error > warning > hint > critical-only */
+.node.mk-critical .card{box-shadow:0 0 0 2px var(--accent-400), var(--shadow-sm);}
+.node.mk-hint .card{box-shadow:0 0 0 2px var(--info-strong), var(--shadow-sm); border-color:var(--info-bd);}
+.node.mk-warning .card{box-shadow:0 0 0 2.5px var(--warn-strong), var(--shadow-md); border-color:var(--warn-bd);}
+.node.mk-error .card{box-shadow:0 0 0 2.5px var(--danger-strong), var(--shadow-md); border-color:var(--danger-bd);}
+/* critical-path rail — ALWAYS visible even when an error/warning ring wins */
+.node.mk-critical .card::before{
+  content:""; position:absolute; left:-1px; top:10px; bottom:10px; width:4px;
+  border-radius:var(--r-pill); background:linear-gradient(180deg,var(--accent-500),var(--accent-600));
+}
+.node.pulse{animation:nodepulse 1.1s ease-in-out 2;}
+@keyframes nodepulse{0%,100%{transform:scale(1);}50%{transform:scale(1.045);}}
+
+/* corner severity chip (top-right, stacks downward) */
+.mk-chips{position:absolute; top:-11px; right:8px; display:flex; gap:5px; z-index:4;}
+.mk-chip{display:inline-flex; align-items:center; gap:4px; height:20px; padding:0 7px; border-radius:var(--r-pill); font-family:var(--font-mono); font-size:9.5px; font-weight:800; letter-spacing:.4px; box-shadow:var(--shadow-sm); border:1px solid;}
+.mk-chip.err{color:#fff; background:var(--danger-strong); border-color:var(--danger-strong);}
+.mk-chip.warn{color:#3c2f10; background:var(--sand-500); border-color:var(--warn-strong);}
+.mk-chip.hint{color:#fff; background:var(--info-strong); border-color:var(--info-strong);}
+.mk-chip.bott{color:#fff; background:var(--n-800); border-color:var(--n-900);}
+/* bottom-left small flags (wip / critical label) */
+.mk-flags{position:absolute; left:8px; bottom:-10px; display:flex; gap:5px; z-index:4;}
+.mk-flag{display:inline-flex; align-items:center; gap:4px; height:18px; padding:0 7px; border-radius:var(--r-pill); font-family:var(--font-mono); font-size:9px; font-weight:700; letter-spacing:.3px; box-shadow:var(--shadow-xs); border:1px solid;}
+.mk-flag.wip{color:var(--danger-fg); background:var(--danger-bg); border-color:var(--danger-bd);}
+.mk-flag.crit{color:var(--accent-700); background:var(--accent-50); border-color:var(--accent-100);}
+
+/* ── Branch-imbalance merge callout ───────────── */
+.merge-callout{
+  position:absolute; z-index:6; width:188px; padding:9px 11px 10px;
+  background:var(--n-0); border:1px solid var(--warn-bd); border-radius:var(--r-md); box-shadow:var(--shadow-md);
+}
+.merge-callout::after{content:""; position:absolute; right:-7px; top:24px; width:12px; height:12px; background:var(--n-0); border-right:1px solid var(--warn-bd); border-bottom:1px solid var(--warn-bd); transform:rotate(-45deg);}
+.mc-head{display:flex; align-items:center; gap:6px; font-size:10px; font-weight:800; color:var(--warn-fg); text-transform:uppercase; letter-spacing:.6px; margin-bottom:7px;}
+.mc-head .ic{width:13px; height:13px;}
+.mc-bars{display:grid; gap:6px;}
+.mc-bar{display:grid; grid-template-columns:42px 1fr auto; align-items:center; gap:7px; font-size:10px;}
+.mc-bar .lbl{font-family:var(--font-mono); font-weight:700; color:var(--n-600);}
+.mc-bar .track{height:8px; background:var(--n-100); border-radius:var(--r-pill); overflow:hidden;}
+.mc-bar .fill{height:100%; border-radius:var(--r-pill);}
+.mc-bar .fill.a{background:var(--accent-500);} .mc-bar .fill.b{background:var(--sand-500);}
+.mc-bar .val{font-family:var(--font-mono); font-weight:700; color:var(--n-700);}
+.mc-wait{margin-top:8px; padding-top:7px; border-top:1px dashed var(--warn-bd); font-size:10.5px; color:var(--warn-fg);}
+.mc-wait b{font-family:var(--font-mono);}
+
+/* ── Canvas chrome ────────────────────────────── */
+.legend{position:absolute; left:14px; top:14px; z-index:11; display:flex; flex-wrap:wrap; gap:6px; max-width:560px;}
+.legend .lg{display:flex; align-items:center; gap:6px; padding:5px 10px; background:rgba(255,255,255,.9); border:1px solid var(--n-200); border-radius:var(--r-pill); font-size:10.5px; font-weight:600; color:var(--n-600); backdrop-filter:saturate(1.2);}
+.legend .sw{width:12px; height:12px; border-radius:4px; flex:0 0 auto;}
+.sw.err{background:var(--danger-strong);} .sw.warn{background:var(--sand-500);} .sw.hint{background:var(--info-strong);}
+.sw.crit{background:var(--accent-500);} .sw.bott{background:var(--n-800);}
+.mini-tb{position:absolute; left:14px; bottom:14px; z-index:12; display:flex; align-items:center; gap:2px; padding:4px; background:var(--n-0); border:1px solid var(--n-200); border-radius:var(--r-md); box-shadow:var(--shadow-md);}
+.mini-btn{width:30px; height:30px; display:grid; place-items:center; border:none; background:transparent; border-radius:var(--r-sm); cursor:pointer; color:var(--n-600);}
+.mini-btn:hover{background:var(--n-100); color:var(--n-900);} .mini-btn svg{width:16px; height:16px;}
+.zoom-val{min-width:46px; text-align:center; font-family:var(--font-mono); font-size:11px; font-weight:600; color:var(--n-600); padding:0 4px;}
+.mini-sep{width:1px; height:20px; background:var(--n-200); margin:0 2px;}
+.canvas-hint{position:absolute; right:14px; bottom:14px; z-index:11; display:flex; align-items:center; gap:8px; padding:6px 11px; background:rgba(255,255,255,.82); border:1px solid var(--n-200); border-radius:var(--r-pill); font-size:10.5px; color:var(--n-500);}
+.canvas-hint .dot{width:6px; height:6px; border-radius:50%; background:var(--n-400);}
+
+/* ── Report drawer ────────────────────────────── */
+.report{flex:0 0 392px; width:392px; background:var(--n-0); border-left:1px solid var(--n-200); display:flex; flex-direction:column; min-height:0; z-index:20;}
+.rep-head{padding:15px 16px 14px; border-bottom:1px solid var(--n-150);}
+.rep-eyebrow{display:flex; align-items:center; justify-content:space-between;}
+.rep-eyebrow .ttl{font-family:var(--font-mono); font-size:10px; font-weight:700; letter-spacing:var(--ls-eyebrow); text-transform:uppercase; color:var(--brand-700);}
+.rep-x{width:26px; height:26px; border:none; background:transparent; border-radius:var(--r-sm); cursor:pointer; color:var(--n-500); display:grid; place-items:center;}
+.rep-x:hover{background:var(--n-100); color:var(--n-900);}
+
+.score-row{display:flex; align-items:center; gap:14px; margin-top:12px;}
+.score-ring{position:relative; width:74px; height:74px; flex:0 0 auto;}
+.score-ring svg{transform:rotate(-90deg);}
+.score-ring .val{position:absolute; inset:0; display:grid; place-content:center; text-align:center;}
+.score-ring .num{font-family:var(--font-mono); font-size:22px; font-weight:800; line-height:1; color:var(--n-900);}
+.score-ring .max{font-family:var(--font-mono); font-size:9px; color:var(--n-400); font-weight:700;}
+.score-meta{flex:1 1 auto; min-width:0;}
+.score-state{display:inline-flex; align-items:center; gap:7px; padding:4px 10px; border-radius:var(--r-pill); font-size:11px; font-weight:700;}
+.score-state.blocked{color:var(--danger-fg); background:var(--danger-bg); border:1px solid var(--danger-bd);}
+.score-state.ok{color:var(--ok-fg); background:var(--ok-bg); border:1px solid var(--ok-bd);}
+.score-state .d{width:7px; height:7px; border-radius:50%;}
+.score-state.blocked .d{background:var(--danger-strong);} .score-state.ok .d{background:var(--ok-dot);}
+.score-sub{font-size:11px; color:var(--n-500); margin-top:7px; line-height:1.45;}
+.summary-pills{display:flex; gap:6px; margin-top:10px;}
+.sp{display:inline-flex; align-items:center; gap:5px; padding:3px 9px; border-radius:var(--r-pill); font-family:var(--font-mono); font-size:11px; font-weight:700; border:1px solid;}
+.sp.err{color:var(--danger-fg); background:var(--danger-bg); border-color:var(--danger-bd);}
+.sp.warn{color:var(--warn-fg); background:var(--warn-bg); border-color:var(--warn-bd);}
+.sp.hint{color:var(--info-fg); background:var(--info-bg); border-color:var(--info-bd);}
+
+/* metrics tiles */
+.metrics{display:grid; grid-template-columns:1fr 1fr; gap:1px; background:var(--n-150); border-top:1px solid var(--n-150); border-bottom:1px solid var(--n-150);}
+.metric{background:var(--n-0); padding:11px 14px;}
+.metric.span{grid-column:1 / -1; display:flex; align-items:center; justify-content:space-between; background:linear-gradient(180deg,var(--accent-50),#fff);}
+.metric .ml{font-size:10px; font-weight:700; color:var(--n-500); text-transform:uppercase; letter-spacing:.6px;}
+.metric .mv{font-family:var(--font-mono); font-size:17px; font-weight:800; color:var(--n-900); margin-top:3px;}
+.metric .mv small{font-size:11px; font-weight:700; color:var(--n-500);}
+.metric.span .mv{font-size:24px; color:var(--accent-700);}
+.metric .mhint{font-size:10px; color:var(--n-500); margin-top:1px;}
+.metric.bott .mv{color:var(--n-900);}
+.tp-ic{width:30px; height:30px; border-radius:8px; background:var(--accent-100); color:var(--accent-700); display:grid; place-items:center;}
+
+/* per-line load strip */
+.lineload{padding:13px 16px 4px; border-bottom:1px solid var(--n-150);}
+.lineload .ll-h{display:flex; align-items:center; justify-content:space-between; margin-bottom:10px;}
+.lineload .ll-h .t{font-size:12px; font-weight:700; color:var(--n-800);}
+.lineload .ll-h .s{font-size:10.5px; color:var(--n-500);}
+.ll-row{display:grid; grid-template-columns:96px 1fr; align-items:center; gap:10px; margin-bottom:11px; cursor:pointer; border-radius:var(--r-sm); padding:2px;}
+.ll-row:hover{background:var(--n-50);}
+.ll-name{font-size:11px; font-weight:600; color:var(--n-700); display:flex; flex-direction:column; gap:1px;}
+.ll-name .sub{font-family:var(--font-mono); font-size:9.5px; color:var(--n-400); font-weight:600;}
+.ll-bar{position:relative;}
+.ll-track{height:14px; background:var(--n-100); border-radius:var(--r-sm); overflow:hidden;}
+.ll-fill{height:100%; background:linear-gradient(90deg,var(--accent-400),var(--accent-500)); border-radius:var(--r-sm);}
+.ll-row.is-bott .ll-fill{background:linear-gradient(90deg,var(--n-600),var(--n-800));}
+.ll-row.is-wip .ll-fill{background:repeating-linear-gradient(45deg,var(--sand-500),var(--sand-500) 7px,var(--sand-600) 7px,var(--sand-600) 14px);}
+.ll-val{position:absolute; right:7px; top:50%; transform:translateY(-50%); font-family:var(--font-mono); font-size:9.5px; font-weight:700; color:var(--n-0); text-shadow:0 0 3px rgba(0,0,0,.45);}
+.ll-tag{display:inline-flex; align-items:center; gap:3px; margin-left:7px; font-family:var(--font-mono); font-size:9px; font-weight:800; padding:1px 6px; border-radius:var(--r-pill); vertical-align:middle;}
+.ll-tag.bott{color:#fff; background:var(--n-800);} .ll-tag.wip{color:var(--danger-fg); background:var(--danger-bg); border:1px solid var(--danger-bd);}
+
+/* findings */
+.findings{flex:1 1 auto; overflow-y:auto; padding:6px 0 16px;}
+.fgroup-h{display:flex; align-items:center; gap:8px; padding:13px 16px 7px; font-size:10px; font-weight:800; letter-spacing:.7px; text-transform:uppercase; color:var(--n-500);}
+.fgroup-h .c{font-family:var(--font-mono); color:var(--n-400);}
+.finding{display:flex; gap:11px; padding:10px 16px; cursor:pointer; border-left:3px solid transparent; transition:background .12s;}
+.finding:hover{background:var(--n-50);}
+.finding.active{background:var(--accent-50); border-left-color:var(--accent-500);}
+.finding .ic{width:24px; height:24px; flex:0 0 auto; border-radius:7px; display:grid; place-items:center; font-size:13px; margin-top:1px;}
+.finding.err .ic{color:#fff; background:var(--danger-strong);}
+.finding.warn .ic{color:#3c2f10; background:var(--sand-500);}
+.finding.hint .ic{color:#fff; background:var(--info-strong);}
+.finding .body{flex:1 1 auto; min-width:0;}
+.finding .ftop{display:flex; align-items:center; gap:7px;}
+.finding .rid{font-family:var(--font-mono); font-size:9px; font-weight:800; padding:1px 5px; border-radius:var(--r-xs); letter-spacing:.4px;}
+.finding.err .rid{color:var(--danger-fg); background:var(--danger-bg);}
+.finding.warn .rid{color:var(--warn-fg); background:var(--warn-bg);}
+.finding.hint .rid{color:var(--info-fg); background:var(--info-bg);}
+.finding .ttl{font-size:12px; font-weight:700; color:var(--n-900);}
+.finding .msg{font-size:11px; color:var(--n-600); line-height:1.45; margin-top:3px;}
+.finding .msg .mono{color:var(--n-800); font-weight:600;}
+.finding .locate{flex:0 0 auto; align-self:center; width:28px; height:28px; border:1px solid var(--n-200); background:var(--n-0); border-radius:var(--r-sm); display:grid; place-items:center; color:var(--n-500); cursor:pointer;}
+.finding:hover .locate{border-color:var(--accent-400); color:var(--accent-600);}
+
+/* all-good state */
+.allgood{display:none; flex-direction:column; align-items:center; text-align:center; padding:40px 28px;}
+.allgood.show{display:flex;}
+.allgood .ag-ic{width:64px; height:64px; border-radius:18px; background:var(--ok-bg); color:var(--ok-fg); display:grid; place-items:center; margin-bottom:16px; box-shadow:inset 0 0 0 1px var(--ok-bd);}
+.allgood .ag-t{font-size:16px; font-weight:800; color:var(--n-900);}
+.allgood .ag-d{font-size:12px; color:var(--n-500); line-height:1.6; margin-top:8px; max-width:260px;}
+.allgood .ag-tp{margin-top:18px; display:flex; align-items:center; gap:9px; padding:10px 16px; border:1px solid var(--accent-100); background:var(--accent-50); border-radius:var(--r-md);}
+.allgood .ag-tp .n{font-family:var(--font-mono); font-size:20px; font-weight:800; color:var(--accent-700);}
+.allgood .ag-tp .l{font-size:11px; color:var(--n-600); text-align:left; line-height:1.3;}
+
+::-webkit-scrollbar{width:11px; height:11px;}
+::-webkit-scrollbar-thumb{background:var(--n-200); border-radius:99px; border:3px solid transparent; background-clip:content-box;}
+::-webkit-scrollbar-thumb:hover{background:var(--n-300); background-clip:content-box;}
+</style>
+</head>
+<body>
+<div class="app">
+
+  <!-- ── TOPBAR ───────────────────────────────── -->
+  <header class="topbar">
+    <div class="brand-pill">
+      <div class="brand-mark">LK</div>
+      <div><span class="b-dim">LAURESTA</span> <span class="b-name">• ShopfloorPilot</span></div>
+    </div>
+    <div class="ctx-pill">
+      <span class="dot"></span><span class="lbl">Family</span><span class="val">ROLLER_STD</span>
+    </div>
+    <div class="spacer"></div>
+
+    <!-- scenario switch (mockup only — toggles the two states) -->
+    <div class="seg" id="scenarioSeg">
+      <button data-sc="issues" class="active">Issues</button>
+      <button data-sc="healthy">Healthy</button>
+    </div>
+    <button class="btn">
+      <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8M7 3v5h8"/></svg>
+      Save
+    </button>
+    <button class="btn btn-validate" id="btnValidate">
+      <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
+      Validate
+      <span class="count-badge" id="validateBadge"></span>
+    </button>
+    <div class="btn-sep"></div>
+    <button class="btn btn-primary" id="btnPublish" disabled>
+      <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3v12M8 7l4-4 4 4M5 21h14"/></svg>
+      Publish
+    </button>
+  </header>
+
+  <!-- ── BODY ──────────────────────────────────── -->
+  <div class="body-row">
+
+    <!-- CANVAS -->
+    <div class="canvas-wrap">
+      <div class="canvas" id="canvas">
+        <div class="world" id="world">
+          <svg class="edges" id="edges">
+            <defs>
+              <marker id="arrow" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="var(--n-500)"/></marker>
+              <marker id="arrow-crit" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="var(--accent-600)"/></marker>
+              <marker id="arrow-cyc" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="var(--danger-strong)"/></marker>
+              <marker id="arrow-red" viewBox="0 0 10 10" refX="8.5" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse"><path d="M1 1 L9 5 L1 9 z" fill="var(--warn-strong)"/></marker>
+            </defs>
+          </svg>
+        </div>
+      </div>
+
+      <div class="legend" id="legend">
+        <div class="lg"><span class="sw err"></span>Error</div>
+        <div class="lg"><span class="sw warn"></span>Warning</div>
+        <div class="lg"><span class="sw hint"></span>Hint</div>
+        <div class="lg"><span class="sw crit"></span>Critical path</div>
+        <div class="lg"><span class="sw bott"></span>Bottleneck</div>
+      </div>
+
+      <div class="mini-tb">
+        <button class="mini-btn" id="zoomOut" title="Zoom out"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round"><path d="M5 12h14"/></svg></button>
+        <span class="zoom-val" id="zoomVal">100%</span>
+        <button class="mini-btn" id="zoomIn" title="Zoom in"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round"><path d="M12 5v14M5 12h14"/></svg></button>
+        <div class="mini-sep"></div>
+        <button class="mini-btn" id="zoomFit" title="Fit to view"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3H5a2 2 0 0 0-2 2v3M16 3h3a2 2 0 0 1 2 2v3M21 16v3a2 2 0 0 1-2 2h-3M3 16v3a2 2 0 0 0 2 2h3"/></svg></button>
+      </div>
+      <div class="canvas-hint"><span class="dot"></span>Click a finding to locate it on the canvas</div>
+    </div>
+
+    <!-- REPORT DRAWER -->
+    <aside class="report" id="report">
+      <div class="rep-head">
+        <div class="rep-eyebrow">
+          <span class="ttl">Smart Validation · Report</span>
+          <button class="rep-x" title="Close report"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg></button>
+        </div>
+        <div class="score-row">
+          <div class="score-ring" id="scoreRing"></div>
+          <div class="score-meta" id="scoreMeta"></div>
+        </div>
+        <div class="summary-pills" id="summaryPills"></div>
+      </div>
+
+      <div class="metrics" id="metrics"></div>
+      <div class="lineload" id="lineload"></div>
+
+      <div class="findings" id="findings"></div>
+      <div class="allgood" id="allgood">
+        <div class="ag-ic"><svg viewBox="0 0 24 24" width="30" height="30" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></div>
+        <div class="ag-t">Flow is healthy</div>
+        <div class="ag-d">No errors, warnings or hints. The graph is balanced and ready to publish.</div>
+        <div class="ag-tp"><span class="n" id="agThroughput">~12</span><span class="l">units / hour<br>est. throughput</span></div>
+      </div>
+    </aside>
+  </div>
+</div>
+
+<script>
+/* ════════════════════════════════════════════════
+   ShopfloorPilot — Smart Validation REPORT mockup.
+   Presentation only: a hand-authored sample graph,
+   a hand-authored ValidationReport per scenario, and
+   the rendering / click-to-locate behavior.
+   ════════════════════════════════════════════════ */
+
+const $ = s=>document.querySelector(s);
+const world = $("#world"), canvas = $("#canvas"), edgesSvg = $("#edges");
+const SVGNS = "http://www.w3.org/2000/svg";
+const esc = s=>String(s==null?"":s).replace(/&/g,"&amp;").replace(/</g,"&lt;").replace(/>/g,"&gt;");
+
+/* ── Sample graph (ROLLER_STD-ish, with intentional flaws) ── */
+const NODES = [
+  {id:"start",     kind:"start",  name:"Job Received", x:60,  y:560},
+  {id:"atsvaro",   kind:"task", name:"ATSVARO PJOVIMAS",   line:"FAB-CUT", station:"Fabric Cutting", dur:10800, x:420, y:140},
+  {id:"veleno",    kind:"task", name:"VELENO PJOVIMAS",    line:"FAB-CUT", station:"Fabric Cutting", dur:120,   x:420, y:360},
+  {id:"audinio",   kind:"task", name:"AUDINIO PJOVIMAS",   line:"FAB-CUT", station:"Fabric Cutting", dur:900,   x:420, y:600},
+  {id:"profilio",  kind:"task", name:"PROFILIO PJOVIMAS",  line:"FAB-CUT", station:"Fabric Cutting", dur:600,   x:420, y:820},
+  {id:"newtask",   kind:"task", name:"NEW_TASK",           line:"FAB-CUT", station:"Fabric Cutting", dur:0,     x:420, y:1030},
+  {id:"tikrinimas",kind:"task", name:"VELENO TIKRINIMAS",  line:"QA",      station:"Quality",        dur:300,   x:830, y:360},
+  {id:"klijavimas",kind:"task", name:"AUDINIO KLIJAVIMAS", line:"GLUE",    station:"Gluing",         dur:1800,  x:830, y:600},
+  {id:"assembly",  kind:"task", name:"SURINKIMAS",         line:"ASSY",    station:"Assembly",       dur:3600,  x:1230,y:380},
+  {id:"kokybe",    kind:"task", name:"KOKYBĖ",             line:"QA",      station:"Quality",        dur:600,   x:1610,y:380},
+  {id:"finish",    kind:"finish", name:"Print Label", x:1980, y:400},
+];
+const EDGES = [
+  {id:"e1",  from:"start",      to:"atsvaro"},
+  {id:"e2",  from:"start",      to:"veleno"},
+  {id:"e3",  from:"start",      to:"audinio"},
+  {id:"e4",  from:"start",      to:"profilio"},
+  {id:"e5",  from:"start",      to:"newtask"},
+  {id:"e6",  from:"atsvaro",    to:"assembly"},
+  {id:"e7",  from:"veleno",     to:"tikrinimas"},
+  {id:"e8",  from:"tikrinimas", to:"veleno"},
+  {id:"e9",  from:"veleno",     to:"assembly"},
+  {id:"e10", from:"profilio",   to:"assembly"},
+  {id:"e11", from:"audinio",    to:"klijavimas"},
+  {id:"e12", from:"newtask",    to:"assembly"},
+  {id:"e13", from:"assembly",   to:"kokybe"},
+  {id:"e14", from:"kokybe",     to:"finish"},
+  {id:"e15", from:"profilio",   to:"kokybe"},
+];
+const nodeById = Object.fromEntries(NODES.map(n=>[n.id,n]));
+
+/* ── ValidationReport per scenario (hand-authored) ── */
+const REPORTS = {
+  issues:{
+    score:64, publishable:false,
+    summary:{errors:2, warnings:5, hints:1},
+    metrics:{
+      leadTimeSec:15000,
+      criticalPath:{nodeIds:["start","atsvaro","assembly","kokybe","finish"], durationSec:15000},
+      bottleneck:{stationId:"ASSY", stationName:"Assembly", loadSec:3600},
+      throughputPerHour:12,
+      lineLoads:[
+        {stationId:"FAB-CUT", stationName:"Fabric Cutting", loadSec:12420, taskCount:5, wipLimit:3},
+        {stationId:"ASSY",    stationName:"Assembly",       loadSec:3600,  taskCount:1},
+        {stationId:"GLUE",    stationName:"Gluing",         loadSec:1800,  taskCount:1},
+        {stationId:"QA",      stationName:"Quality",        loadSec:900,   taskCount:2},
+      ],
+      merges:[{nodeId:"assembly", maxInSec:10800, minInSec:120, waitSec:10680}],
+    },
+    findings:[
+      {ruleId:"E4", severity:"error", title:"Dead-end task",
+       message:"<span class='mono'>AUDINIO KLIJAVIMAS</span> hangs — no path to finish.",
+       targets:{nodeIds:["klijavimas"]}},
+      {ruleId:"E5", severity:"error", title:"Cycle",
+       message:"Cycle: <span class='mono'>VELENO PJOVIMAS → VELENO TIKRINIMAS → VELENO PJOVIMAS</span>.",
+       targets:{nodeIds:["veleno","tikrinimas"], edgeIds:["e7","e8"]}},
+      {ruleId:"W1", severity:"warning", title:"Branch imbalance",
+       message:"Branch&nbsp;B idles <span class='mono'>2h&nbsp;58m</span> waiting for Branch&nbsp;A (<span class='mono'>3h</span> vs <span class='mono'>2min</span>).",
+       targets:{nodeIds:["assembly"]}, detail:{waitSec:10680}},
+      {ruleId:"W3", severity:"warning", title:"Bottleneck line",
+       message:"<span class='mono'>Assembly</span> is the bottleneck — caps throughput at <span class='mono'>~12/hr</span>.",
+       targets:{nodeIds:["assembly"], stationIds:["ASSY"]}, detail:{throughputPerHour:12}},
+      {ruleId:"W4", severity:"warning", title:"False parallelism",
+       message:"<span class='mono'>ATSVARO</span> &amp; <span class='mono'>VELENO</span> look parallel but share line <span class='mono'>FAB-CUT</span> — they queue.",
+       targets:{nodeIds:["atsvaro","veleno"], stationIds:["FAB-CUT"]}},
+      {ruleId:"W5", severity:"warning", title:"WIP risk",
+       message:"<span class='mono'>5</span> tasks routed through <span class='mono'>Fabric Cutting</span> (WIP limit <span class='mono'>3</span>).",
+       targets:{nodeIds:["atsvaro","veleno","audinio","profilio","newtask"], stationIds:["FAB-CUT"]}, detail:{routed:5, wipLimit:3}},
+      {ruleId:"W9", severity:"warning", title:"Redundant dependency",
+       message:"Edge <span class='mono'>PROFILIO → KOKYBĖ</span> is redundant — already reached via Assembly.",
+       targets:{edgeIds:["e15"]}},
+      {ruleId:"H1", severity:"hint", title:"Name hygiene",
+       message:"Task named <span class='mono'>'NEW_TASK'</span> — give it a real name.",
+       targets:{nodeIds:["newtask"]}},
+    ],
+  },
+  healthy:{
+    score:100, publishable:true,
+    summary:{errors:0, warnings:0, hints:0},
+    metrics:{
+      leadTimeSec:9000,
+      criticalPath:{nodeIds:["start","atsvaro","assembly","kokybe","finish"], durationSec:9000},
+      bottleneck:{stationId:"ASSY", stationName:"Assembly", loadSec:3600},
+      throughputPerHour:12,
+      lineLoads:[
+        {stationId:"ASSY",    stationName:"Assembly",       loadSec:3600, taskCount:1},
+        {stationId:"FAB-CUT", stationName:"Fabric Cutting", loadSec:2400, taskCount:3, wipLimit:3},
+        {stationId:"QA",      stationName:"Quality",        loadSec:900,  taskCount:1},
+      ],
+      merges:[],
+    },
+    findings:[],
+  },
+};
+
+/* ── Build per-node / per-edge marks from a report ── */
+function computeMarks(report){
+  const nodeMarks = {}; // id -> {error,warning,hint,critical,bottleneck,wip}
+  const edgeMarks = {}; // id -> 'critical'|'cycle'|'redundant'
+  NODES.forEach(n=>nodeMarks[n.id]={});
+
+  // critical path (informational overlay)
+  const cp = report.metrics.criticalPath?.nodeIds || [];
+  cp.forEach(id=>{ if(nodeMarks[id]) nodeMarks[id].critical=true; });
+  for(let i=0;i<cp.length-1;i++){
+    const e = EDGES.find(e=>e.from===cp[i] && e.to===cp[i+1]);
+    if(e) edgeMarks[e.id]="critical";
+  }
+  // bottleneck marker
+  const bId = report.metrics.bottleneck?.stationId;
+  if(bId) NODES.filter(n=>n.line===bId).forEach(n=>nodeMarks[n.id].bottleneck=true);
+
+  // findings → severity marks (errors win, then warnings, then hints)
+  report.findings.forEach(f=>{
+    (f.targets.nodeIds||[]).forEach(id=>{ if(nodeMarks[id]) nodeMarks[id][f.severity]=true; });
+    (f.targets.edgeIds||[]).forEach(eid=>{
+      if(f.ruleId==="E5") edgeMarks[eid]="cycle";
+      else if(f.ruleId==="W9") edgeMarks[eid]="redundant";
+    });
+    if(f.ruleId==="W5"){ (f.targets.nodeIds||[]).forEach(id=>{ if(nodeMarks[id]) nodeMarks[id].wip=true; }); }
+  });
+  return {nodeMarks, edgeMarks};
+}
+
+/* ── Node rendering ────────────────────────────── */
+function nodeHtml(n){
+  if(n.kind==="start"){
+    return `<div class="card"><div class="card-head"><span class="card-title">${esc(n.name)}</span><span class="card-kind">START</span></div>
+      <div class="start-body"><div class="sock-row out"><span class="sock-label">flow</span><span class="socket out"></span></div></div></div>`;
+  }
+  if(n.kind==="finish"){
+    return `<div class="card"><div class="card-head"><span class="card-title">${esc(n.name)}</span><span class="card-kind">FINISH</span></div>
+      <div class="finish-body"><div class="sock-row in"><span class="socket in"></span><span class="sock-label">flow</span></div></div></div>`;
+  }
+  return `<div class="card">
+    <div class="card-head"><span class="card-title">${esc(n.name)}</span><span class="card-kind">${esc(n.line)}</span></div>
+    <div class="sock-row out"><span class="sock-label">next</span><span class="socket out"></span></div>
+    <div class="meta">
+      <div class="meta-row"><span class="k">Station:</span><span class="v">${esc(n.station)}</span></div>
+      <div class="meta-row"><span class="k">Duration:</span><span class="v">${n.dur?fmtDur(n.dur):"—"}</span></div>
+    </div>
+    <div class="sock-row in"><span class="socket in"></span><span class="sock-label">prev</span></div>
+  </div>`;
+}
+
+function renderNodes(marks){
+  [...world.querySelectorAll(".node")].forEach(el=>el.remove());
+  NODES.forEach(n=>{
+    const m = marks.nodeMarks[n.id]||{};
+    const el = document.createElement("div");
+    let cls = "node node-"+n.kind;
+    if(m.error) cls+=" mk-error"; else if(m.warning) cls+=" mk-warning"; else if(m.hint) cls+=" mk-hint";
+    if(m.critical) cls+=" mk-critical";
+    el.className = cls;
+    el.dataset.id = n.id;
+    el.style.left=n.x+"px"; el.style.top=n.y+"px";
+    el.innerHTML = nodeHtml(n) + chipsHtml(m) + flagsHtml(m);
+    world.appendChild(el);
+  });
+}
+function chipsHtml(m){
+  const c=[];
+  if(m.bottleneck) c.push(`<span class="mk-chip bott">▣ BOTTLENECK</span>`);
+  if(m.error) c.push(`<span class="mk-chip err">⛔ ERROR</span>`);
+  else if(m.warning) c.push(`<span class="mk-chip warn">⚠ WARN</span>`);
+  else if(m.hint) c.push(`<span class="mk-chip hint">💡 HINT</span>`);
+  return c.length?`<div class="mk-chips">${c.join("")}</div>`:"";
+}
+function flagsHtml(m){
+  const f=[];
+  if(m.critical) f.push(`<span class="mk-flag crit">CRITICAL PATH</span>`);
+  if(m.wip) f.push(`<span class="mk-flag wip">WIP 5/3</span>`);
+  return f.length?`<div class="mk-flags">${f.join("")}</div>`:"";
+}
+
+/* ── Edge rendering (socket-accurate beziers) ──── */
+function socketCenter(nodeId, which){
+  const sock = world.querySelector(`.node[data-id="${CSS.escape(nodeId)}"] .socket.${which}`);
+  if(!sock) return null;
+  const r = sock.getBoundingClientRect(), wr = world.getBoundingClientRect();
+  return {x:(r.left+r.width/2-wr.left)/view.scale, y:(r.top+r.height/2-wr.top)/view.scale};
+}
+function renderEdges(marks){
+  [...edgesSvg.querySelectorAll(".edge")].forEach(el=>el.remove());
+  EDGES.forEach(e=>{
+    const a=socketCenter(e.from,"out"), b=socketCenter(e.to,"in");
+    if(!a||!b) return;
+    const back = b.x < a.x; // backward edge (cycle) — loop it out further
+    const dx = back ? Math.max(120, Math.abs(b.x-a.x)*0.6+90) : Math.max(60, Math.abs(b.x-a.x)*0.5);
+    const d = `M ${a.x} ${a.y} C ${a.x+dx} ${a.y-(back?70:0)}, ${b.x-dx} ${b.y-(back?70:0)}, ${b.x} ${b.y}`;
+    const mk = marks.edgeMarks[e.id];
+    let cls="edge", marker="arrow";
+    if(mk==="critical"){cls+=" is-critical"; marker="arrow-crit";}
+    else if(mk==="cycle"){cls+=" is-cycle"; marker="arrow-cyc";}
+    else if(mk==="redundant"){cls+=" is-redundant"; marker="arrow-red";}
+    const g = document.createElementNS(SVGNS,"g");
+    g.setAttribute("class",cls);
+    g.dataset.id=e.id;
+    g.innerHTML = `<path class="edge-path" d="${d}" marker-end="url(#${marker})"></path><path class="edge-flow" d="${d}"></path>`;
+    edgesSvg.appendChild(g);
+  });
+}
+
+/* ── Branch-imbalance merge callout ────────────── */
+function renderMergeCallouts(report){
+  [...world.querySelectorAll(".merge-callout")].forEach(el=>el.remove());
+  (report.metrics.merges||[]).forEach(m=>{
+    const n = nodeById[m.nodeId]; if(!n) return;
+    const maxP = Math.max(m.maxInSec,1);
+    const aPct = 100, bPct = Math.max(3, Math.round(m.minInSec/maxP*100));
+    const el = document.createElement("div");
+    el.className="merge-callout";
+    // place to the LEFT of the merge node
+    el.style.left = (n.x - 210) + "px";
+    el.style.top  = (n.y - 24) + "px";
+    el.innerHTML = `
+      <div class="mc-head"><svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 9v4M12 17h.01M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z"/></svg>Branch imbalance</div>
+      <div class="mc-bars">
+        <div class="mc-bar"><span class="lbl">Branch A</span><span class="track"><span class="fill a" style="width:${aPct}%"></span></span><span class="val">${fmtDur(m.maxInSec)}</span></div>
+        <div class="mc-bar"><span class="lbl">Branch B</span><span class="track"><span class="fill b" style="width:${bPct}%"></span></span><span class="val">${fmtDur(m.minInSec)}</span></div>
+      </div>
+      <div class="mc-wait">Branch B idles <b>${fmtDur(m.waitSec)}</b> at this merge.</div>`;
+    world.appendChild(el);
+  });
+}
+
+/* ── Report drawer rendering ───────────────────── */
+function scoreColor(s){ return s>=80 ? "var(--ok-dot)" : s>=50 ? "var(--sand-500)" : "var(--danger-strong)"; }
+function renderReport(report){
+  // score ring
+  const R=30, C=2*Math.PI*R, off=C*(1-report.score/100);
+  $("#scoreRing").innerHTML = `
+    <svg width="74" height="74" viewBox="0 0 74 74">
+      <circle cx="37" cy="37" r="${R}" fill="none" stroke="var(--n-100)" stroke-width="8"/>
+      <circle cx="37" cy="37" r="${R}" fill="none" stroke="${scoreColor(report.score)}" stroke-width="8" stroke-linecap="round" stroke-dasharray="${C}" stroke-dashoffset="${off}"/>
+    </svg>
+    <div class="val"><div class="num">${report.score}</div><div class="max">/ 100</div></div>`;
+
+  const pub = report.publishable;
+  $("#scoreMeta").innerHTML = `
+    <span class="score-state ${pub?'ok':'blocked'}"><span class="d"></span>${pub?'Ready to publish':'Publish blocked'}</span>
+    <div class="score-sub">${pub
+      ? 'No blocking errors. Warnings &amp; hints are advisory.'
+      : `<b>${report.summary.errors}</b> error${report.summary.errors===1?'':'s'} must be fixed before publish. Warnings &amp; hints don't block.`}</div>`;
+
+  $("#summaryPills").innerHTML =
+    `<span class="sp err">⛔ ${report.summary.errors}</span>
+     <span class="sp warn">⚠ ${report.summary.warnings}</span>
+     <span class="sp hint">💡 ${report.summary.hints}</span>`;
+
+  // metrics tiles
+  const mt=report.metrics;
+  $("#metrics").innerHTML = `
+    <div class="metric"><div class="ml">Lead time</div><div class="mv">${fmtDur(mt.leadTimeSec)}</div><div class="mhint">critical path · ${mt.criticalPath.nodeIds.length} nodes</div></div>
+    <div class="metric bott"><div class="ml">Bottleneck</div><div class="mv">${esc(mt.bottleneck.stationName)}</div><div class="mhint">load ${fmtDur(mt.bottleneck.loadSec)}</div></div>
+    <div class="metric span"><div><div class="ml">Throughput</div><div class="mv">~${mt.throughputPerHour} <small>units / hr</small></div></div>
+      <div class="tp-ic"><svg viewBox="0 0 24 24" width="17" height="17" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h7l-1 8 10-12h-7l1-8z"/></svg></div></div>`;
+
+  // line load strip
+  const maxLoad = Math.max(...mt.lineLoads.map(l=>l.loadSec),1);
+  $("#lineload").innerHTML =
+    `<div class="ll-h"><span class="t">Per-line load</span><span class="s">${mt.lineLoads.length} lines</span></div>` +
+    mt.lineLoads.map(l=>{
+      const isB = l.stationId===mt.bottleneck.stationId;
+      const isW = l.wipLimit && l.taskCount>l.wipLimit;
+      const tag = isB?`<span class="ll-tag bott">▣ BOTTLENECK</span>`:(isW?`<span class="ll-tag wip">WIP ${l.taskCount}/${l.wipLimit}</span>`:"");
+      return `<div class="ll-row ${isB?'is-bott':''} ${isW?'is-wip':''}" data-station="${esc(l.stationId)}">
+        <div class="ll-name"><span>${esc(l.stationName)}${tag}</span><span class="sub">${l.taskCount} task${l.taskCount===1?'':'s'}</span></div>
+        <div class="ll-bar"><div class="ll-track"><div class="ll-fill" style="width:${Math.max(8,Math.round(l.loadSec/maxLoad*100))}%"></div></div><span class="ll-val">${fmtDur(l.loadSec)}</span></div>
+      </div>`;
+    }).join("");
+  $("#lineload").querySelectorAll(".ll-row").forEach(row=>{
+    row.addEventListener("click",()=>locateStation(row.dataset.station));
+  });
+
+  // findings vs all-good
+  const fwrap = $("#findings"), good = $("#allgood");
+  if(report.findings.length===0){
+    fwrap.innerHTML=""; good.classList.add("show");
+    $("#agThroughput").textContent = "~"+mt.throughputPerHour;
+  } else {
+    good.classList.remove("show");
+    fwrap.innerHTML = renderFindings(report.findings);
+    fwrap.querySelectorAll(".finding").forEach(el=>{
+      el.addEventListener("click",()=>locateFinding(el.dataset.rule));
+    });
+  }
+}
+
+const SEV = {error:{lbl:"Errors",ic:"⛔",cls:"err"}, warning:{lbl:"Warnings",ic:"⚠",cls:"warn"}, hint:{lbl:"Hints",ic:"💡",cls:"hint"}};
+function renderFindings(findings){
+  let html="";
+  ["error","warning","hint"].forEach(sev=>{
+    const grp = findings.filter(f=>f.severity===sev);
+    if(!grp.length) return;
+    const s=SEV[sev];
+    html += `<div class="fgroup-h">${s.ic} ${s.lbl} <span class="c">· ${grp.length}</span></div>`;
+    grp.forEach(f=>{
+      html += `<div class="finding ${s.cls}" data-rule="${esc(f.ruleId)}">
+        <div class="ic">${s.ic}</div>
+        <div class="body">
+          <div class="ftop"><span class="rid">${esc(f.ruleId)}</span><span class="ttl">${esc(f.title)}</span></div>
+          <div class="msg">${f.message}</div>
+        </div>
+        <button class="locate" title="Locate on canvas"><svg viewBox="0 0 24 24" width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v3M12 19v3M2 12h3M19 12h3"/><circle cx="12" cy="12" r="6"/></svg></button>
+      </div>`;
+    });
+  });
+  return html;
+}
+
+/* ── Click-to-locate ───────────────────────────── */
+function locateFinding(ruleId){
+  const f = current.findings.find(x=>x.ruleId===ruleId);
+  if(!f) return;
+  $("#findings").querySelectorAll(".finding").forEach(el=>el.classList.toggle("active", el.dataset.rule===ruleId));
+  const ids = (f.targets.nodeIds||[]).slice();
+  (f.targets.stationIds||[]).forEach(st=>NODES.filter(n=>n.line===st).forEach(n=>ids.push(n.id)));
+  panTo(ids);
+  pulseNodes(ids);
+  pulseEdges(f.targets.edgeIds||[]);
+}
+function locateStation(stationId){
+  const ids = NODES.filter(n=>n.line===stationId).map(n=>n.id);
+  panTo(ids); pulseNodes(ids);
+}
+function pulseNodes(ids){
+  ids.forEach(id=>{
+    const el = world.querySelector(`.node[data-id="${CSS.escape(id)}"]`);
+    if(!el) return; el.classList.remove("pulse"); void el.offsetWidth; el.classList.add("pulse");
+    setTimeout(()=>el.classList.remove("pulse"),2400);
+  });
+}
+function pulseEdges(ids){
+  ids.forEach(id=>{
+    const el = edgesSvg.querySelector(`.edge[data-id="${id}"]`);
+    if(!el) return; el.classList.remove("pulse"); void el.getBBox; el.classList.add("pulse");
+    setTimeout(()=>el.classList.remove("pulse"),2400);
+  });
+}
+function panTo(ids){
+  if(!ids.length) return;
+  let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
+  ids.forEach(id=>{
+    const el=world.querySelector(`.node[data-id="${CSS.escape(id)}"]`);
+    const n=nodeById[id]; if(!n) return;
+    const w=el?el.offsetWidth:230, h=el?el.offsetHeight:150;
+    minX=Math.min(minX,n.x); minY=Math.min(minY,n.y); maxX=Math.max(maxX,n.x+w); maxY=Math.max(maxY,n.y+h);
+  });
+  const rect=canvas.getBoundingClientRect(), pad=130;
+  const bw=maxX-minX+pad*2, bh=maxY-minY+pad*2;
+  const s=Math.min(rect.width/bw, rect.height/bh, 1.15);
+  view.scale=s;
+  view.x=(rect.width-(maxX+minX)*s)/2;
+  view.y=(rect.height-(maxY+minY)*s)/2;
+  world.classList.add("animating");
+  applyView();
+  setTimeout(()=>{world.classList.remove("animating"); renderEdgesCurrent();}, 520);
+}
+
+/* ── View transform + zoom ─────────────────────── */
+const view = {scale:0.62, x:40, y:30};
+function applyView(){ world.style.transform=`translate(${view.x}px,${view.y}px) scale(${view.scale})`; $("#zoomVal").textContent=Math.round(view.scale*100)+"%"; }
+function zoomBy(f){
+  const rect=canvas.getBoundingClientRect(), mx=rect.width/2, my=rect.height/2;
+  const old=view.scale, ns=Math.min(2,Math.max(0.3,old*f));
+  view.x=mx-(mx-view.x)*(ns/old); view.y=my-(my-view.y)*(ns/old); view.scale=ns; applyView(); renderEdgesCurrent();
+}
+$("#zoomIn").onclick=()=>zoomBy(1.15);
+$("#zoomOut").onclick=()=>zoomBy(1/1.15);
+$("#zoomFit").onclick=()=>{fitView(); renderEdgesCurrent();};
+function fitView(){
+  let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
+  NODES.forEach(n=>{
+    const el=world.querySelector(`.node[data-id="${CSS.escape(n.id)}"]`);
+    const w=el?el.offsetWidth:230, h=el?el.offsetHeight:150;
+    minX=Math.min(minX,n.x); minY=Math.min(minY,n.y); maxX=Math.max(maxX,n.x+w); maxY=Math.max(maxY,n.y+h);
+  });
+  const pad=90, rect=canvas.getBoundingClientRect();
+  const bw=maxX-minX+pad*2, bh=maxY-minY+pad*2;
+  const s=Math.min(rect.width/bw, rect.height/bh, 1.2);
+  view.scale=s; view.x=(rect.width-(maxX+minX)*s)/2; view.y=(rect.height-(maxY+minY)*s)/2; applyView();
+}
+
+/* canvas pan + wheel zoom */
+let pan=null;
+canvas.addEventListener("pointerdown",ev=>{ if(ev.button!==0)return; pan={sx:ev.clientX,sy:ev.clientY,ox:view.x,oy:view.y}; canvas.classList.add("panning"); canvas.setPointerCapture(ev.pointerId); });
+canvas.addEventListener("pointermove",ev=>{ if(!pan)return; view.x=pan.ox+(ev.clientX-pan.sx); view.y=pan.oy+(ev.clientY-pan.sy); applyView(); });
+canvas.addEventListener("pointerup",ev=>{ if(!pan)return; pan=null; canvas.classList.remove("panning"); try{canvas.releasePointerCapture(ev.pointerId);}catch(e){} renderEdgesCurrent(); });
+canvas.addEventListener("wheel",ev=>{
+  ev.preventDefault();
+  const rect=canvas.getBoundingClientRect(), mx=ev.clientX-rect.left, my=ev.clientY-rect.top;
+  const old=view.scale, factor=ev.deltaY<0?1.1:1/1.1, ns=Math.min(2,Math.max(0.3,old*factor));
+  view.x=mx-(mx-view.x)*(ns/old); view.y=my-(my-view.y)*(ns/old); view.scale=ns; applyView(); renderEdgesCurrent();
+},{passive:false});
+
+/* ── Helpers ───────────────────────────────────── */
+function fmtDur(sec){
+  if(sec==null) return "—";
+  if(sec<60) return sec+"s";
+  const h=Math.floor(sec/3600), m=Math.round((sec%3600)/60);
+  if(h && m) return h+"h "+m+"m";
+  if(h) return h+"h";
+  return m+"m";
+}
+
+/* ── Scenario state + boot ─────────────────────── */
+let current = null, currentMarks = null;
+function renderEdgesCurrent(){ if(currentMarks) renderEdges(currentMarks); }
+
+function setScenario(sc){
+  current = REPORTS[sc];
+  currentMarks = computeMarks(current);
+  renderNodes(currentMarks);
+
+  // toolbar validate badge
+  const s=current.summary;
+  const badge=$("#validateBadge"), vbtn=$("#btnValidate");
+  if(s.errors+s.warnings+s.hints===0){
+    badge.innerHTML=`<span class="cb ok">✓ healthy</span>`; vbtn.classList.add("is-clean");
+  } else {
+    let h=""; if(s.errors) h+=`<span class="cb err">${s.errors} ⛔</span>`; if(s.warnings) h+=`<span class="cb warn">${s.warnings} ⚠</span>`; if(s.hints) h+=`<span class="cb hint">${s.hints} 💡</span>`;
+    badge.innerHTML=h; vbtn.classList.remove("is-clean");
+  }
+  $("#btnPublish").disabled = !current.publishable;
+
+  renderReport(current);
+  requestAnimationFrame(()=>{ renderEdgesCurrent(); renderMergeCallouts(current); fitView(); requestAnimationFrame(renderEdgesCurrent); });
+}
+
+$("#scenarioSeg").addEventListener("click",ev=>{
+  const b=ev.target.closest("button"); if(!b) return;
+  $("#scenarioSeg").querySelectorAll("button").forEach(x=>x.classList.toggle("active",x===b));
+  setScenario(b.dataset.sc);
+});
+$("#btnValidate").onclick=()=>{ renderReport(current); fitView(); renderEdgesCurrent(); };
+
+applyView();
+setScenario("issues");
+window.addEventListener("resize",()=>{ renderEdgesCurrent(); renderMergeCallouts(current); });
+</script>
+</body>
+</html>

--- a/tests/Modules/Shopfloor/LKvitai.MES.Tests.Shopfloor.Unit/SmartWorkflowValidatorTests.cs
+++ b/tests/Modules/Shopfloor/LKvitai.MES.Tests.Shopfloor.Unit/SmartWorkflowValidatorTests.cs
@@ -1,0 +1,226 @@
+using FluentAssertions;
+using LKvitai.MES.Modules.Shopfloor.Domain.Workflows;
+using Xunit;
+
+namespace LKvitai.MES.Tests.Shopfloor.Unit;
+
+public class SmartWorkflowValidatorTests
+{
+    private static WorkflowGraphNode Start(string id = "start") =>
+        new(id, WorkflowNodeKind.Start, "Start", null, null, null);
+
+    private static WorkflowGraphNode Finish(string id = "finish") =>
+        new(id, WorkflowNodeKind.Finish, "Finish", null, null, null);
+
+    private static WorkflowGraphNode Task(string id, Guid station, int dur = 60, string? name = null) =>
+        new(id, WorkflowNodeKind.Task, name ?? id, station, dur, null);
+
+    private static WorkflowGraph Graph(WorkflowGraphNode[] nodes, (string From, string To)[] edges) =>
+        new(nodes, edges.Select(e => new WorkflowGraphEdge(e.From, e.To)).ToList());
+
+    private static bool Has(ValidationReport r, string ruleId) =>
+        r.Findings.Any(f => f.RuleId == ruleId);
+
+    [Fact]
+    public void HealthyLinearGraph_IsPublishable_WithFullScore()
+    {
+        var station = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("cut", station, 60), Finish() },
+            new[] { ("start", "cut"), ("cut", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Publishable.Should().BeTrue();
+        report.Summary.Errors.Should().Be(0);
+        report.Score.Should().Be(100);
+        report.Findings.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void Cycle_RaisesE5_AndBlocksPublish()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s), Task("b", s), Finish() },
+            new[] { ("start", "a"), ("a", "b"), ("b", "a"), ("b", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        Has(report, "E5").Should().BeTrue();
+        report.Publishable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void DeadEndTask_RaisesE4()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s), Task("hang", s), Finish() },
+            new[] { ("start", "a"), ("a", "finish"), ("a", "hang") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Findings.Should().Contain(f => f.RuleId == "E4" && f.Targets.NodeIds.Contains("hang"));
+        report.Publishable.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UnreachableTask_RaisesE3()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s), Task("island", s), Finish() },
+            new[] { ("start", "a"), ("a", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Findings.Should().Contain(f => f.RuleId == "E3" && f.Targets.NodeIds.Contains("island"));
+    }
+
+    [Fact]
+    public void IncompleteTask_RaisesE7()
+    {
+        var graph = Graph(
+            new[]
+            {
+                Start(),
+                new WorkflowGraphNode("cut", WorkflowNodeKind.Task, "cut", null, null, null),
+                Finish(),
+            },
+            new[] { ("start", "cut"), ("cut", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Findings.Count(f => f.RuleId == "E7").Should().Be(2); // no station + no duration
+    }
+
+    [Fact]
+    public void MultipleStarts_RaisesE1()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start("s1"), Start("s2"), Task("cut", s), Finish() },
+            new[] { ("s1", "cut"), ("cut", "finish") });
+
+        SmartWorkflowValidator.Validate(graph).Findings.Should().Contain(f => f.RuleId == "E1");
+    }
+
+    [Fact]
+    public void DuplicateEdge_RaisesE6()
+    {
+        var graph = Graph(
+            new[] { Start(), Finish() },
+            new[] { ("start", "finish"), ("start", "finish") });
+
+        SmartWorkflowValidator.Validate(graph).Findings.Should().Contain(f => f.RuleId == "E6");
+    }
+
+    [Fact]
+    public void BranchImbalance_RaisesW1_AndReportsMergeWait()
+    {
+        var l1 = Guid.NewGuid();
+        var l2 = Guid.NewGuid();
+        var l3 = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("slow", l1, 10800), Task("fast", l2, 120), Task("merge", l3, 60), Finish() },
+            new[] { ("start", "slow"), ("start", "fast"), ("slow", "merge"), ("fast", "merge"), ("merge", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        Has(report, "W1").Should().BeTrue();
+        report.Metrics.Merges.Should().Contain(m => m.NodeId == "merge" && m.WaitSec == 10680);
+    }
+
+    [Fact]
+    public void CriticalPathAndBottleneck_AreComputed()
+    {
+        var l1 = Guid.NewGuid();
+        var l2 = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("slow", l1, 10800), Task("fast", l2, 120), Task("merge", l2, 60), Finish() },
+            new[] { ("start", "slow"), ("start", "fast"), ("slow", "merge"), ("fast", "merge"), ("merge", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Metrics.CriticalPath!.NodeIds.Should().ContainInOrder("start", "slow", "merge", "finish");
+        report.Metrics.LeadTimeSec.Should().Be(10860);
+        report.Metrics.Bottleneck!.StationId.Should().Be(l1.ToString());
+        report.Metrics.LineLoads.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void WipRisk_RaisesW5()
+    {
+        var station = Guid.NewGuid();
+        var stations = new[] { new WorkflowStationInfo(station, "FAB-CUT", "Fabric Cutting", 1, true) };
+        var graph = Graph(
+            new[] { Start(), Task("a", station), Task("b", station), Finish() },
+            new[] { ("start", "a"), ("a", "b"), ("b", "finish") });
+
+        var report = SmartWorkflowValidator.Validate(graph, stations);
+
+        report.Findings.Should().Contain(f => f.RuleId == "W5" && f.Targets.StationIds.Contains(station.ToString()));
+    }
+
+    [Fact]
+    public void FalseParallelism_RaisesW4()
+    {
+        var shared = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", shared), Task("b", shared), Task("join", Guid.NewGuid()), Finish() },
+            new[] { ("start", "a"), ("start", "b"), ("a", "join"), ("b", "join"), ("join", "finish") });
+
+        SmartWorkflowValidator.Validate(graph).Findings.Should().Contain(f => f.RuleId == "W4");
+    }
+
+    [Fact]
+    public void RedundantDependency_RaisesW9()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s), Task("b", s), Finish() },
+            new[] { ("start", "a"), ("a", "b"), ("b", "finish"), ("start", "b") });
+
+        SmartWorkflowValidator.Validate(graph).Findings
+            .Should().Contain(f => f.RuleId == "W9" && f.Targets.EdgeIds.Contains("start->b"));
+    }
+
+    [Fact]
+    public void PlaceholderName_RaisesH1()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s, 60, "NEW_TASK"), Finish() },
+            new[] { ("start", "a"), ("a", "finish") });
+
+        SmartWorkflowValidator.Validate(graph).Findings.Should().Contain(f => f.RuleId == "H1");
+    }
+
+    [Fact]
+    public void InactiveStation_RaisesH3()
+    {
+        var station = Guid.NewGuid();
+        var stations = new[] { new WorkflowStationInfo(station, "OLD", "Retired line", null, false) };
+        var graph = Graph(
+            new[] { Start(), Task("a", station), Finish() },
+            new[] { ("start", "a"), ("a", "finish") });
+
+        SmartWorkflowValidator.Validate(graph, stations).Findings
+            .Should().Contain(f => f.RuleId == "H3" && f.Targets.NodeIds.Contains("a"));
+    }
+
+    [Fact]
+    public void Score_DropsWithSeverity()
+    {
+        var s = Guid.NewGuid();
+        var graph = Graph(
+            new[] { Start(), Task("a", s), Task("hang", s), Finish() },
+            new[] { ("start", "a"), ("a", "finish"), ("a", "hang") });
+
+        var report = SmartWorkflowValidator.Validate(graph);
+
+        report.Score.Should().BeLessThan(100);
+        report.Publishable.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Summary
- Add the **smart workflow validator** (`SmartWorkflowValidator`, Domain) producing a single `ValidationReport`: errors **E1–E7**, warnings **W1, W3–W9, W11**, hints **H1–H4**, plus production metrics (critical path, bottleneck, throughput/hr, per-line load, branch-imbalance merges) and a 0–100 health score.
- Wire it into the workflow service: new `ValidateAsync` / `ValidateGraphAsync`, and the **publish gate** now returns **422 + the report** when not publishable (`POST /workflows/{id}/validate`, `POST /workflows/validate`, `POST /workflows/{id}/publish`).
- Add `ValidationReportDto` contracts (severity as `"error|warning|hint"`, edge targets as `from->to`, station targets as guid) so the editor presentation binds directly.
- Add the **validation-report presentation prototype** (`wwwroot/prototypes/shopfloor-validation-report-prototype.html`) and the **§7 Presentation** guide in `shopfloor-12-smart-validation.md`.

## Notes
- Domain stays dependency-free; station metadata is passed in via `WorkflowStationInfo` (built from `IWorkStationRepository` in the app layer).
- W2 is surfaced as a metric (critical path), not a finding. Not implemented: W10 (runtime), H5 (overlaps E3/E4), H6 (needs cross-template data) — noted in the spec.

## Test plan
- [x] Shopfloor unit tests (38/38, incl. 14 new `SmartWorkflowValidatorTests`)
- [x] Architecture dependency tests (29/29)
- [x] Full solution build in Release (0 errors)
- [ ] Reviewer: open the prototype mockup and confirm presentation matches §7

Made with [Cursor](https://cursor.com)