### PR TITLE
Shopfloor: wire smart validation into live workflow editor

### DIFF
--- a/docs/shopfloor/shopfloor-12-smart-validation.md
+++ b/docs/shopfloor/shopfloor-12-smart-validation.md
@@ -175,6 +175,16 @@ CSS/JS, no build) — it extends the editor prototype with the Validate button +
 the report drawer, node/edge/line highlighting, the branch-imbalance callout, and the
 all-good state. **Reuse the editor tokens verbatim; add no new color families.**
 
+> **Wired into the live editor (v0.3).** The Validate button, count badge, report
+> drawer, node/edge highlights, and click-to-locate are now integrated directly in
+> `wwwroot/prototypes/shopfloor-workflow-editor-prototype.html` (the iframe the Blazor
+> `WorkflowEditor.razor` hosts). Validate posts the current graph over the existing
+> `postMessage` bridge → `WorkflowEditor.OnValidateRequested` → `POST
+> /api/shopfloor/workflows/validate` → the report is posted back and rendered. Any graph
+> edit marks the report **stale** (highlights drop, badge greys) until re-validated.
+> The branch-imbalance callout and over-WIP striping remain in the standalone mockup
+> only (not yet ported to the live editor).
+
 ### 7.1 Severity → visual mapping (locked)
 
 | Severity | Token family | Ring / fill | Icon | Where |

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
@@ -174,6 +174,47 @@
         await JS.InvokeVoidAsync("shopfloorWorkflowBridge.postSaveResult", json);
     }
 
+    [JSInvokable]
+    public async Task OnValidateRequested(string messageJson)
+    {
+        try
+        {
+            using var doc = System.Text.Json.JsonDocument.Parse(messageJson);
+            var graph = doc.RootElement.GetProperty("graph").Deserialize<WorkflowGraphDto>(JsonOptions);
+            if (graph is null)
+            {
+                await PostValidateResultAsync(false, "Invalid graph payload.", null);
+                return;
+            }
+
+            var result = await Api.ValidateWorkflowGraphAsync(new SaveWorkflowGraphRequest(graph), CancellationToken.None);
+            if (result.Success && result.Value is not null)
+            {
+                await PostValidateResultAsync(true, null, result.Value);
+            }
+            else
+            {
+                await PostValidateResultAsync(false, result.Error ?? "Validation failed.", null);
+            }
+        }
+        catch (Exception ex)
+        {
+            await PostValidateResultAsync(false, "Validation failed: " + ex.Message, null);
+        }
+    }
+
+    private async Task PostValidateResultAsync(bool ok, string? message, ValidationReportDto? report)
+    {
+        var json = System.Text.Json.JsonSerializer.Serialize(new
+        {
+            type = "shopfloor.workflow.validate-result",
+            ok,
+            message,
+            report,
+        }, JsonOptions);
+        await JS.InvokeVoidAsync("shopfloorWorkflowBridge.postValidateResult", json);
+    }
+
     private static string StatusChip(WorkflowStatus status) => status switch
     {
         WorkflowStatus.Published => "chip--ok",

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Services/ShopfloorApiClient.cs
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Services/ShopfloorApiClient.cs
@@ -97,6 +97,9 @@ public sealed class ShopfloorApiClient
     public Task<ApiResult<WorkflowTemplateDto>> PublishWorkflowAsync(Guid id, CancellationToken ct)
         => SendAsync<WorkflowTemplateDto>(HttpMethod.Post, $"/api/shopfloor/workflows/{id}/publish", null, ct);
 
+    public Task<ApiResult<ValidationReportDto>> ValidateWorkflowGraphAsync(SaveWorkflowGraphRequest request, CancellationToken ct)
+        => SendAsync<ValidationReportDto>(HttpMethod.Post, "/api/shopfloor/workflows/validate", request, ct);
+
     public Task<ApiResult<WorkflowTemplateDto>> CloneWorkflowAsync(Guid id, CloneWorkflowTemplateRequest request, CancellationToken ct)
         => SendAsync<WorkflowTemplateDto>(HttpMethod.Post, $"/api/shopfloor/workflows/{id}/clone", request, ct);
 

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/js/workflow-editor-bridge.js
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/js/workflow-editor-bridge.js
@@ -44,6 +44,11 @@ window.shopfloorWorkflowBridge = (function () {
 
         if (data.type === 'shopfloor.workflow.save' && dotNetRef) {
             dotNetRef.invokeMethodAsync('OnSaveRequested', JSON.stringify(data));
+            return;
+        }
+
+        if (data.type === 'shopfloor.workflow.validate' && dotNetRef) {
+            dotNetRef.invokeMethodAsync('OnValidateRequested', JSON.stringify(data));
         }
     }
 
@@ -58,6 +63,9 @@ window.shopfloorWorkflowBridge = (function () {
             post(JSON.parse(loadJson));
         },
         postSaveResult: function (resultJson) {
+            post(JSON.parse(resultJson));
+        },
+        postValidateResult: function (resultJson) {
             post(JSON.parse(resultJson));
         },
         dispose: function () {

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-workflow-editor-prototype.html
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-workflow-editor-prototype.html
@@ -410,6 +410,136 @@ pre.json{
 ::-webkit-scrollbar{width:11px;height:11px;}
 ::-webkit-scrollbar-thumb{background:var(--n-200); border-radius:99px; border:3px solid transparent; background-clip:content-box;}
 ::-webkit-scrollbar-thumb:hover{background:var(--n-300); background-clip:content-box;}
+
+/* ════════════════════════════════════════════════
+   Smart validation — Validate button, report drawer,
+   node/edge highlights. Tokens reused verbatim.
+   ════════════════════════════════════════════════ */
+.btn-validate{border-color:var(--accent-400); color:var(--accent-700); background:var(--accent-50);}
+.btn-validate:hover{background:var(--accent-100); border-color:var(--accent-500);}
+.v-badge{
+  display:none; min-width:19px; height:19px; padding:0 6px; border-radius:var(--r-pill);
+  font-family:var(--font-mono); font-size:10.5px; font-weight:700; line-height:1;
+  align-items:center; justify-content:center; color:#fff; background:var(--n-400);
+}
+.v-badge.show{display:inline-flex;}
+.v-badge.band-ok{background:var(--ok-dot);}
+.v-badge.band-warn{background:var(--sand-600);}
+.v-badge.band-bad{background:var(--danger-fg);}
+.v-badge.band-busy{background:var(--n-400);}
+
+/* node decorations */
+.node.v-error .card{box-shadow:0 0 0 2.5px var(--danger-fg), var(--shadow-md);}
+.node.v-warning .card{box-shadow:0 0 0 2.5px var(--sand-600), var(--shadow-md);}
+.node.v-hint .card{box-shadow:0 0 0 2.5px var(--accent-500), var(--shadow-md);}
+.v-deco{position:absolute; inset:0; pointer-events:none; z-index:4;}
+.v-rail{position:absolute; left:-6px; top:7px; bottom:7px; width:4px; border-radius:3px;
+  background:var(--accent-500); box-shadow:0 0 0 1px rgba(255,255,255,.65);}
+.v-chip{
+  position:absolute; min-width:19px; height:19px; padding:0 6px; border-radius:var(--r-pill);
+  font-family:var(--font-mono); font-size:10px; font-weight:700; display:flex; align-items:center;
+  gap:3px; box-shadow:var(--shadow-sm); white-space:nowrap;
+}
+.v-chip-sev{top:-10px; right:12px;}
+.v-chip-sev.sev-error{background:var(--danger-bg); color:var(--danger-fg); border:1px solid var(--danger-bd);}
+.v-chip-sev.sev-warning{background:var(--warn-bg); color:var(--warn-fg); border:1px solid var(--warn-bd);}
+.v-chip-sev.sev-hint{background:var(--accent-50); color:var(--accent-700); border:1px solid var(--accent-100);}
+.v-chip-bot{top:-10px; left:12px; background:var(--n-800); color:#fff; border:1px solid var(--n-900);}
+
+@keyframes vPulse{0%{box-shadow:0 0 0 0 rgba(47,143,139,.55);}70%{box-shadow:0 0 0 16px rgba(47,143,139,0);}100%{box-shadow:0 0 0 0 rgba(47,143,139,0);}}
+.node.v-pulse .card{animation:vPulse 1s ease-out 2;}
+.world.v-pan{transition:transform .5s cubic-bezier(.4,0,.2,1);}
+
+/* edge decorations (rules come after sel-edge so they win when both present) */
+.edge.v-edge-critical .edge-path{stroke:var(--accent-600); stroke-width:3.5;}
+.edge.v-edge-critical .edge-flow{stroke:var(--accent-400); stroke-width:3.5; stroke-dasharray:11 12;}
+.edge.v-edge-cycle .edge-path{stroke:var(--danger-fg); stroke-width:3;}
+.edge.v-edge-cycle .edge-flow{stroke:#c0392b;}
+.edge.v-edge-warn .edge-path{stroke:var(--sand-600); stroke-width:3;}
+.edge.v-edge-warn .edge-flow{stroke:var(--sand-500);}
+.edge.v-edge-hint .edge-path{stroke:var(--accent-500);}
+
+/* ── Report drawer ───────────────────────────── */
+.vreport{
+  position:absolute; top:0; right:0; bottom:0; width:362px; z-index:25;
+  background:var(--n-0); border-left:1px solid var(--n-200); box-shadow:-10px 0 30px rgba(15,23,42,.10);
+  display:flex; flex-direction:column; transform:translateX(100%);
+  transition:transform .26s cubic-bezier(.3,.7,.3,1); overflow:hidden;
+}
+.vreport.show{transform:translateX(0);}
+.vr-head{padding:15px 16px 13px; border-bottom:1px solid var(--n-150); position:relative;}
+.vr-close{position:absolute; top:11px; right:11px; width:28px; height:28px; border:none; background:transparent;
+  border-radius:var(--r-sm); cursor:pointer; color:var(--n-500); display:grid; place-items:center;}
+.vr-close:hover{background:var(--n-100); color:var(--n-900);}
+.vr-eyebrow{font-family:var(--font-mono); font-size:10px; font-weight:700; letter-spacing:var(--ls-eyebrow);
+  text-transform:uppercase; color:var(--accent-700); margin-bottom:11px;}
+.vr-scorebar{display:flex; align-items:center; gap:14px;}
+.vr-ring{
+  --p:0; width:62px; height:62px; border-radius:50%; flex:0 0 auto; display:grid; place-items:center;
+  background:conic-gradient(var(--ring-c) calc(var(--p)*1%), var(--n-150) 0);
+}
+.vr-ring::before{content:""; position:absolute; width:48px; height:48px; border-radius:50%; background:var(--n-0);}
+.vr-ring{position:relative;}
+.vr-ring span{position:relative; font-family:var(--font-mono); font-size:18px; font-weight:700; color:var(--n-900);}
+.vr-ring.band-ok{--ring-c:var(--ok-dot);}
+.vr-ring.band-warn{--ring-c:var(--sand-600);}
+.vr-ring.band-bad{--ring-c:var(--danger-fg);}
+.vr-score-meta{min-width:0;}
+.vr-score-title{font-size:14px; font-weight:700; color:var(--n-900);}
+.vr-pub{margin-top:5px; display:inline-flex; align-items:center; gap:6px; font-size:11px; font-weight:600;
+  padding:3px 9px; border-radius:var(--r-pill);}
+.vr-pub.ok{background:var(--finish-bg); color:var(--finish-fg); border:1px solid var(--finish-bd);}
+.vr-pub.bad{background:var(--danger-bg); color:var(--danger-fg); border:1px solid var(--danger-bd);}
+.vr-summary{display:flex; gap:7px; margin-top:13px;}
+.vr-pill{display:inline-flex; align-items:center; gap:5px; font-size:11px; font-weight:700;
+  padding:4px 9px; border-radius:var(--r-pill); border:1px solid transparent; font-family:var(--font-mono);}
+.vr-pill .d{width:7px; height:7px; border-radius:50%;}
+.vr-pill.err{background:var(--danger-bg); color:var(--danger-fg);} .vr-pill.err .d{background:var(--danger-fg);}
+.vr-pill.warn{background:var(--warn-bg); color:var(--warn-fg);} .vr-pill.warn .d{background:var(--sand-600);}
+.vr-pill.hint{background:var(--accent-50); color:var(--accent-700);} .vr-pill.hint .d{background:var(--accent-500);}
+.vr-stale-banner{display:none; align-items:center; gap:7px; padding:8px 16px; background:var(--sand-25);
+  border-bottom:1px solid var(--sand-100); color:var(--sand-700); font-size:11px; font-weight:600;}
+.vreport.stale .vr-stale-banner{display:flex;}
+.vr-body{flex:1 1 auto; overflow-y:auto; padding:14px 16px 24px;}
+.vr-metrics{display:grid; grid-template-columns:1fr 1fr; gap:9px; margin-bottom:16px;}
+.vr-tile{border:1px solid var(--n-150); border-radius:var(--r-md); padding:9px 11px; background:var(--n-25);}
+.vr-tile-wide{grid-column:1 / -1;}
+.vt-k{font-size:10px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; color:var(--n-500); margin-bottom:4px;}
+.vt-v{font-size:15px; font-weight:700; color:var(--n-900);}
+.vt-v.bot{display:flex; align-items:center; gap:7px;}
+.vt-v .bot-tag{font-family:var(--font-mono); font-size:9px; font-weight:700; letter-spacing:.6px;
+  background:var(--n-800); color:#fff; padding:2px 6px; border-radius:var(--r-xs);}
+.vr-section{margin-bottom:18px;}
+.vr-sec-title{font-size:11px; font-weight:700; letter-spacing:.4px; text-transform:uppercase; color:var(--n-600);
+  margin-bottom:9px; display:flex; align-items:center; justify-content:space-between;}
+.vr-load{display:grid; gap:7px;}
+.vr-load-row{display:grid; grid-template-columns:78px 1fr auto; align-items:center; gap:8px;}
+.vr-load-name{font-family:var(--font-mono); font-size:10.5px; font-weight:600; color:var(--n-700); white-space:nowrap; overflow:hidden; text-overflow:ellipsis;}
+.vr-load-track{height:9px; border-radius:99px; background:var(--n-100); overflow:hidden;}
+.vr-load-fill{height:100%; border-radius:99px; background:var(--accent-400);}
+.vr-load-row.bot .vr-load-fill{background:var(--n-800);}
+.vr-load-val{font-family:var(--font-mono); font-size:10px; font-weight:700; color:var(--n-600);}
+.vr-find{
+  width:100%; text-align:left; display:flex; gap:10px; align-items:flex-start; padding:10px 11px;
+  border:1px solid var(--n-150); border-radius:var(--r-md); background:var(--n-0); cursor:pointer;
+  margin-bottom:8px; transition:border-color .12s, box-shadow .12s, background .12s;
+}
+.vr-find:hover{box-shadow:var(--shadow-sm); background:var(--n-25);}
+.vr-find .vf-ic{flex:0 0 auto; width:22px; height:22px; border-radius:6px; display:grid; place-items:center;
+  font-family:var(--font-mono); font-weight:700; font-size:12px;}
+.vr-find.sev-error{border-left:3px solid var(--danger-fg);} .vr-find.sev-error .vf-ic{background:var(--danger-bg); color:var(--danger-fg);}
+.vr-find.sev-warning{border-left:3px solid var(--sand-600);} .vr-find.sev-warning .vf-ic{background:var(--warn-bg); color:var(--warn-fg);}
+.vr-find.sev-hint{border-left:3px solid var(--accent-500);} .vr-find.sev-hint .vf-ic{background:var(--accent-50); color:var(--accent-700);}
+.vf-body{min-width:0; flex:1;}
+.vf-title{font-size:12.5px; font-weight:700; color:var(--n-900); margin-bottom:2px;}
+.vf-msg{font-size:11px; line-height:1.45; color:var(--n-600);}
+.vf-rule{flex:0 0 auto; font-size:9px; font-weight:700; color:var(--n-400); margin-top:2px;}
+.vr-clean{text-align:center; padding:26px 14px; color:var(--finish-fg);}
+.vr-clean .vc-ic{width:42px; height:42px; margin:0 auto 11px; border-radius:50%; background:var(--finish-bg);
+  display:grid; place-items:center; color:var(--finish-fg);}
+.vr-clean .vc-t{font-size:14px; font-weight:700; color:var(--n-800); margin-bottom:4px;}
+.vr-clean .vc-d{font-size:11.5px; color:var(--n-500);}
+.vr-loading{padding:30px 14px; text-align:center; color:var(--n-500); font-size:12px;}
 </style>
 </head>
 <body>
@@ -452,6 +582,11 @@ pre.json{
       Export JSON
     </button>
     <div class="btn-sep"></div>
+    <button class="btn btn-validate" id="btnValidate" title="Run smart validation">
+      <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="M9 12l2 2 4-4"/></svg>
+      Validate
+      <span class="v-badge" id="vBadge"></span>
+    </button>
     <button class="btn btn-primary" id="btnSave">
       <svg class="ic" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.1" stroke-linecap="round" stroke-linejoin="round"><path d="M19 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11l5 5v11a2 2 0 0 1-2 2z"/><path d="M17 21v-8H7v8M7 3v5h8"/></svg>
       Save
@@ -506,6 +641,22 @@ pre.json{
         <span class="dot"></span>
         Drag nodes · drag a socket to link · click a link to delete · scroll to zoom
       </div>
+
+      <!-- ── SMART VALIDATION REPORT DRAWER ──────── -->
+      <aside class="vreport" id="vreport" aria-hidden="true">
+        <div class="vr-head">
+          <button class="vr-close" id="vrClose" title="Close report">
+            <svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round"><path d="M18 6 6 18M6 6l12 12"/></svg>
+          </button>
+          <div class="vr-eyebrow">Smart validation</div>
+          <div id="vrHeadBody"></div>
+        </div>
+        <div class="vr-stale-banner">
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12a9 9 0 1 0 3-6.7M3 4v4h4"/></svg>
+          Graph changed — re-validate for fresh results.
+        </div>
+        <div class="vr-body" id="vrBody"></div>
+      </aside>
     </div>
 
     <!-- SIDEBAR -->
@@ -733,8 +884,10 @@ function renderEdges(){
     const nodeSel = state.selected && (e.from===state.selected || e.to===state.selected);
     const edgeSel = state.selectedEdge===i;
     const hi = nodeSel || edgeSel;
+    const vEdge = (validation && validation.edgeMarks[e.from+"->"+e.to]) || null;
+    const vCls = vEdge ? " v-edge-"+vEdge : "";
     const g = document.createElementNS(SVGNS,"g");
-    g.setAttribute("class","edge"+(hi?" sel-edge":"")+(edgeSel?" edge-active":""));
+    g.setAttribute("class","edge"+(hi?" sel-edge":"")+(edgeSel?" edge-active":"")+vCls);
     g.innerHTML =
       `<path class="edge-hit" d="${d}"></path>
        <path class="edge-path" d="${d}" marker-end="url(#${hi?'arrow-sel':'arrow'})"></path>
@@ -784,6 +937,7 @@ function deleteEdge(i){
   if(!e) return;
   state.edges.splice(i,1);
   state.selectedEdge = null;
+  markValidationStale();
   renderEdges(); syncSidebar();
   toast("Link removed · "+e.from+" → "+e.to);
 }
@@ -796,6 +950,7 @@ function addEdge(fromId, toId){
   if(state.edges.some(e=>e.from===fromId && e.to===toId)){ toast("Link already exists"); return false; }
   if(reaches(toId, fromId)){ toast("Link would create a cycle"); return false; }
   state.edges.push({from:fromId, to:toId});
+  markValidationStale();
   toast("Linked · "+fromId+" → "+toId);
   return true;
 }
@@ -916,6 +1071,7 @@ function syncSidebar(){
 function updateCardFromForm(){
   const n = state.nodes.find(x=>x.id===state.selected);
   if(!n||n.kind!=="task") return;
+  markValidationStale();
   n.name = $("#fName").value.trim() || "Task";
   n.description = $("#fDescription").value.trim() || null;
   n.workStationId = $("#fStation").value || null;
@@ -1072,6 +1228,7 @@ $("#btnAdd").onclick=()=>{
     x:Math.round(cx), y:Math.round(cy)};
   state.nodes.push(n);
   renderNodes(); renderEdges();
+  markValidationStale();
   select(id);
   flashNode(id);
   toast("Task "+id+" added");
@@ -1092,6 +1249,7 @@ $("#btnDelete").onclick=()=>{
     state.nodes = state.nodes.filter(x=>x.id!==n.id);
     state.edges = state.edges.filter(e=>e.from!==n.id && e.to!==n.id);
     renderNodes();
+    markValidationStale();
     select(null);
     toast("Task "+n.id+" removed");
   };
@@ -1225,6 +1383,7 @@ function postToParent(msg){
 
 function loadFromPayload(workflow, stations){
   if(!workflow) return;
+  resetValidation();
   state.workflowId = workflow.id || null;
   state.familyCode = workflow.code || "—";
   state.familyName = workflow.name || "";
@@ -1269,6 +1428,10 @@ window.addEventListener("message", ev=>{
   if(!d || typeof d!=="object") return;
   if(d.type==="shopfloor.workflow.load"){ loadFromPayload(d.workflow, d.stations); }
   else if(d.type==="shopfloor.workflow.save-result"){ toast(d.ok ? (d.message||"Saved") : (d.message||"Save failed")); }
+  else if(d.type==="shopfloor.workflow.validate-result"){
+    if(d.ok && d.report) onValidationReport(d.report);
+    else onValidationFailed(d.message);
+  }
 });
 
 $("#btnSave").onclick=()=>{
@@ -1284,6 +1447,286 @@ function toast(msg){
   $("#toast").classList.add("show");
   clearTimeout(toastT); toastT=setTimeout(()=>$("#toast").classList.remove("show"),1900);
 }
+
+/* ════════════════════════════════════════════════
+   Smart validation — request, render report drawer,
+   highlight targets, click-to-locate.
+   ════════════════════════════════════════════════ */
+let validation = null;     // { report, nodeMarks, edgeMarks }
+let lastReport = null;     // last received report (kept while editing → stale)
+let vBusy = false;
+
+const SEV_RANK = { hint:1, warning:2, error:3 };
+const SEV_GLYPH = { error:"✕", warning:"!", hint:"i" };
+
+function bandOf(score){ return score>=80 ? "ok" : score>=50 ? "warn" : "bad"; }
+function fmtDur(s){
+  s = Math.round(s||0);
+  if(s < 60) return s+"s";
+  const h=Math.floor(s/3600), m=Math.floor((s%3600)/60), ss=s%60;
+  if(h>0) return h+"h "+String(m).padStart(2,"0")+"m";
+  return m+"m"+(ss? " "+String(ss).padStart(2,"0")+"s" : "");
+}
+
+/* tasks bound to a given work-station id (for station/bottleneck targets) */
+function nodesForStation(stationId){
+  return state.nodes.filter(n=>n.kind==="task" && n.workStationId===stationId).map(n=>n.id);
+}
+
+function computeMarks(report){
+  const nodeMarks = {};   // id -> { sev, critical, bottleneck }
+  const edgeMarks = {};   // "from->to" -> critical|cycle|warn|hint
+  const ensure = id => (nodeMarks[id] ||= { sev:null, critical:false, bottleneck:false });
+  const bumpSev = (id, sev) => {
+    const m = ensure(id);
+    if(!m.sev || SEV_RANK[sev] > SEV_RANK[m.sev]) m.sev = sev;
+  };
+
+  (report.findings||[]).forEach(f=>{
+    const t = f.targets || {};
+    (t.nodeIds||[]).forEach(id=> bumpSev(id, f.severity));
+    (t.stationIds||[]).forEach(sid=> nodesForStation(sid).forEach(id=> bumpSev(id, f.severity)));
+    (t.edgeIds||[]).forEach(key=>{
+      const cls = f.severity==="error" ? "cycle" : f.severity==="warning" ? "warn" : "hint";
+      const cur = edgeMarks[key];
+      if(!cur || cls==="cycle") edgeMarks[key] = cls;
+    });
+  });
+
+  const m = report.metrics || {};
+  if(m.criticalPath && Array.isArray(m.criticalPath.nodeIds)){
+    const ids = m.criticalPath.nodeIds;
+    ids.forEach(id=> ensure(id).critical = true);
+    for(let i=0;i<ids.length-1;i++){
+      const key = ids[i]+"->"+ids[i+1];
+      if(!edgeMarks[key]) edgeMarks[key] = "critical";
+    }
+  }
+  if(m.bottleneck && m.bottleneck.stationId){
+    nodesForStation(m.bottleneck.stationId).forEach(id=> ensure(id).bottleneck = true);
+  }
+
+  return { report, nodeMarks, edgeMarks };
+}
+
+function clearNodeDecorations(){
+  world.querySelectorAll(".node").forEach(el=>{
+    el.classList.remove("v-error","v-warning","v-hint","v-pulse");
+    const d = el.querySelector(".v-deco");
+    if(d) d.remove();
+  });
+}
+
+function applyNodeDecorations(){
+  clearNodeDecorations();
+  if(!validation) return;
+  Object.entries(validation.nodeMarks).forEach(([id, mk])=>{
+    const el = world.querySelector(`.node[data-id="${CSS.escape(id)}"]`);
+    if(!el) return;
+    if(mk.sev) el.classList.add("v-"+mk.sev);
+    const deco = document.createElement("div");
+    deco.className = "v-deco";
+    let html = "";
+    if(mk.critical) html += `<span class="v-rail"></span>`;
+    if(mk.sev)      html += `<span class="v-chip v-chip-sev sev-${mk.sev}">${SEV_GLYPH[mk.sev]}</span>`;
+    if(mk.bottleneck) html += `<span class="v-chip v-chip-bot">▣</span>`;
+    deco.innerHTML = html;
+    if(html) el.appendChild(deco);
+  });
+}
+
+/* ── Report drawer rendering ───────────────────── */
+function renderReport(report){
+  const band = bandOf(report.score);
+  const s = report.summary || { errors:0, warnings:0, hints:0 };
+  const pub = !!report.publishable;
+  $("#vrHeadBody").innerHTML = `
+    <div class="vr-scorebar">
+      <div class="vr-ring band-${band}" style="--p:${report.score}"><span>${report.score}</span></div>
+      <div class="vr-score-meta">
+        <div class="vr-score-title">Workflow health</div>
+        <div class="vr-pub ${pub?"ok":"bad"}">${pub ? "✓ Publishable" : "✕ Blocked — fix errors"}</div>
+      </div>
+    </div>
+    <div class="vr-summary">
+      <span class="vr-pill err"><span class="d"></span>${s.errors} ${s.errors===1?"error":"errors"}</span>
+      <span class="vr-pill warn"><span class="d"></span>${s.warnings} ${s.warnings===1?"warning":"warnings"}</span>
+      <span class="vr-pill hint"><span class="d"></span>${s.hints} ${s.hints===1?"hint":"hints"}</span>
+    </div>`;
+
+  const m = report.metrics || {};
+  const bottleneck = m.bottleneck
+    ? `<span class="bot-tag">▣ BOTTLENECK</span> ${esc(m.bottleneck.stationName)} · ${fmtDur(m.bottleneck.loadSec)}`
+    : "—";
+
+  let html = `
+    <div class="vr-metrics">
+      <div class="vr-tile"><div class="vt-k">Lead time</div><div class="vt-v mono">${fmtDur(m.leadTimeSec)}</div></div>
+      <div class="vr-tile"><div class="vt-k">Throughput</div><div class="vt-v mono">${m.throughputPerHour||0}<span style="font-size:11px;font-weight:600;color:var(--n-500)"> /h</span></div></div>
+      <div class="vr-tile vr-tile-wide"><div class="vt-k">Bottleneck</div><div class="vt-v bot mono">${bottleneck}</div></div>
+    </div>`;
+
+  const loads = (m.lineLoads||[]).slice().sort((a,b)=>b.loadSec-a.loadSec);
+  if(loads.length){
+    const max = Math.max(1, ...loads.map(l=>l.loadSec));
+    const botId = m.bottleneck && m.bottleneck.stationId;
+    html += `<div class="vr-section"><div class="vr-sec-title">Line load</div><div class="vr-load">` +
+      loads.map(l=>`
+        <div class="vr-load-row ${l.stationId===botId?"bot":""}">
+          <span class="vr-load-name">${esc(l.stationName)}</span>
+          <span class="vr-load-track"><span class="vr-load-fill" style="width:${Math.round(l.loadSec/max*100)}%"></span></span>
+          <span class="vr-load-val">${fmtDur(l.loadSec)}</span>
+        </div>`).join("") +
+      `</div></div>`;
+  }
+
+  const findings = report.findings || [];
+  if(findings.length){
+    html += `<div class="vr-section"><div class="vr-sec-title">Findings <span class="mono" style="color:var(--n-400)">${findings.length}</span></div>` +
+      findings.map((f,i)=>`
+        <button class="vr-find sev-${f.severity}" data-find="${i}">
+          <span class="vf-ic">${SEV_GLYPH[f.severity]||"i"}</span>
+          <span class="vf-body"><span class="vf-title">${esc(f.title)}</span><span class="vf-msg">${esc(f.message)}</span></span>
+          <span class="vf-rule mono">${esc(f.ruleId)}</span>
+        </button>`).join("") +
+      `</div>`;
+  } else {
+    html += `<div class="vr-clean">
+      <div class="vc-ic"><svg viewBox="0 0 24 24" width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5"/></svg></div>
+      <div class="vc-t">All clear</div>
+      <div class="vc-d">No structural or production issues found.</div>
+    </div>`;
+  }
+
+  const body = $("#vrBody");
+  body.innerHTML = html;
+  body.querySelectorAll(".vr-find").forEach(btn=>{
+    btn.addEventListener("click", ()=> locateFinding(findings[parseInt(btn.dataset.find,10)]));
+  });
+}
+
+function openReport(){ $("#vreport").classList.add("show"); $("#vreport").setAttribute("aria-hidden","false"); }
+function closeReport(){ $("#vreport").classList.remove("show"); $("#vreport").setAttribute("aria-hidden","true"); }
+
+/* ── Click-to-locate ───────────────────────────── */
+function locateFinding(f){
+  if(!f) return;
+  const t = f.targets || {};
+  const ids = new Set();
+  (t.nodeIds||[]).forEach(id=>ids.add(id));
+  (t.stationIds||[]).forEach(sid=> nodesForStation(sid).forEach(id=>ids.add(id)));
+  (t.edgeIds||[]).forEach(key=>{ const [a,b]=key.split("->"); if(a)ids.add(a); if(b)ids.add(b); });
+  const list = [...ids];
+  if(!list.length) return;
+  vPanTo(list);
+  setTimeout(()=>vPulse(list), 240);
+}
+
+function vPanTo(ids){
+  const nodes = ids.map(id=>state.nodes.find(n=>n.id===id)).filter(Boolean);
+  if(!nodes.length) return;
+  let minX=1e9,minY=1e9,maxX=-1e9,maxY=-1e9;
+  nodes.forEach(n=>{
+    const el=world.querySelector(`.node[data-id="${CSS.escape(n.id)}"]`);
+    const w=el?el.offsetWidth:240, h=el?el.offsetHeight:140;
+    minX=Math.min(minX,n.x); minY=Math.min(minY,n.y);
+    maxX=Math.max(maxX,n.x+w); maxY=Math.max(maxY,n.y+h);
+  });
+  const rect = canvas.getBoundingClientRect();
+  const drawerW = $("#vreport").classList.contains("show") ? 362 : 0;
+  const availW = Math.max(200, rect.width - drawerW);
+  const pad=110, bw=maxX-minX+pad*2, bh=maxY-minY+pad*2;
+  const s=Math.min(availW/bw, rect.height/bh, 1.25);
+  view.scale=s;
+  view.x=(availW-(maxX+minX)*s)/2;
+  view.y=(rect.height-(maxY+minY)*s)/2;
+  world.classList.add("v-pan");
+  applyView();
+  setTimeout(()=>world.classList.remove("v-pan"), 540);
+}
+
+function vPulse(ids){
+  ids.forEach(id=>{
+    const el=world.querySelector(`.node[data-id="${CSS.escape(id)}"]`);
+    if(!el) return;
+    el.classList.remove("v-pulse"); void el.offsetWidth; el.classList.add("v-pulse");
+    setTimeout(()=>el.classList.remove("v-pulse"), 2100);
+  });
+}
+
+/* ── Validate button badge ─────────────────────── */
+function setBadge(arg){
+  const b = $("#vBadge");
+  b.classList.remove("band-ok","band-warn","band-bad","band-busy","show");
+  if(arg==="busy"){ b.classList.add("show","band-busy"); b.textContent="…"; return; }
+  if(arg==="stale"){ b.classList.add("show","band-busy"); b.textContent="•"; return; }
+  if(!arg){ b.textContent=""; return; }
+  const band = bandOf(arg.score);
+  b.classList.add("show", band==="ok"?"band-ok":band==="warn"?"band-warn":"band-bad");
+  b.textContent = arg.summary && arg.summary.errors>0 ? "✕"+arg.summary.errors : String(arg.score);
+}
+
+/* ── Validation lifecycle ──────────────────────── */
+function requestValidation(){
+  if(!state.workflowId){ toast("No workflow loaded"); return; }
+  vBusy = true;
+  setBadge("busy");
+  $("#vreport").classList.remove("stale");
+  $("#vrBody").innerHTML = `<div class="vr-loading">Validating workflow…</div>`;
+  openReport();
+  postToParent({ type:"shopfloor.workflow.validate", workflowId:state.workflowId, graph:buildGraph() });
+  toast("Validating…");
+}
+
+function onValidationReport(report){
+  vBusy = false;
+  lastReport = report;
+  validation = computeMarks(report);
+  applyNodeDecorations();
+  renderEdges();
+  renderReport(report);
+  openReport();
+  setBadge(report);
+  const s = report.summary || {};
+  toast(report.publishable
+    ? `Validated · score ${report.score} · ${s.warnings||0} warn · ${s.hints||0} hint`
+    : `Validated · ${s.errors||0} error(s) block publish`);
+}
+
+function onValidationFailed(message){
+  vBusy = false;
+  setBadge("stale");
+  $("#vrBody").innerHTML = `<div class="vr-loading">${esc(message||"Validation failed.")}</div>`;
+  toast(message||"Validation failed");
+}
+
+/* graph changed → existing report is stale; drop canvas highlights */
+function markValidationStale(){
+  if(!validation && !lastReport) return;
+  validation = null;
+  clearNodeDecorations();
+  renderEdges();
+  if($("#vreport").classList.contains("show")) $("#vreport").classList.add("stale");
+  if(!vBusy) setBadge("stale");
+}
+
+/* full reset on (re)load */
+function resetValidation(){
+  validation = null; lastReport = null; vBusy = false;
+  clearNodeDecorations();
+  closeReport();
+  $("#vreport").classList.remove("stale");
+  setBadge(null);
+}
+
+$("#btnValidate").onclick = ()=>{
+  if($("#vreport").classList.contains("show") && !$("#vreport").classList.contains("stale") && !vBusy){
+    closeReport();
+    return;
+  }
+  requestValidation();
+};
+$("#vrClose").onclick = closeReport;
 
 /* ── Boot ──────────────────────────────────────── */
 function boot(){


### PR DESCRIPTION
## Summary
- Integrate the **Validate** button, report drawer, node/edge highlights, and click-to-locate directly into the live editor iframe (`shopfloor-workflow-editor-prototype.html`) — previously these existed only in the standalone mockup, so the deployed editor showed no Validate button.
- Route validation through the existing `postMessage` bridge: editor → `WorkflowEditor.OnValidateRequested` → `POST /api/shopfloor/workflows/validate` → report posted back and rendered (score ring, metrics, per-line load, findings).
- Graph edits mark the report **stale** (highlights drop, badge greys) until re-validated.
- Adds `ShopfloorApiClient.ValidateWorkflowGraphAsync`, bridge relay for `validate` / `postValidateResult`, and updates the spec doc's implementation status.

Follows up the merged backend work in #200 (validation engine + `/validate` endpoints).

## Test plan
- [ ] Open Workflow Editor in the deployed WebUI, load a family, click **Validate** → report drawer opens with score, metrics, and findings.
- [ ] Click a finding → canvas pans to and pulses the targeted node(s).
- [ ] Edit the graph (add/delete task, link, edit fields) → report marked stale, highlights cleared.
- [ ] Publish a graph with blocking errors → 422 + report surfaced.

Made with [Cursor](https://cursor.com)