### PR TITLE
Shopfloor: self-heal workflow load in editor

### DIFF
--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/Pages/WorkflowEditor.razor
@@ -73,6 +73,7 @@
         if (_selectedId != Guid.Empty)
         {
             await LoadAndPushAsync();
+            StateHasChanged();
         }
     }
 
@@ -82,6 +83,32 @@
         if (_bridgeReady && id != Guid.Empty)
         {
             await LoadAndPushAsync();
+            StateHasChanged();
+        }
+    }
+
+    /// <summary>
+    /// The editor reports it has no workflow (initial handshake race or slow
+    /// circuit). Re-fetch the selected workflow and push it again.
+    /// </summary>
+    [JSInvokable]
+    public async Task OnLoadRequested()
+    {
+        if (!_bridgeReady)
+        {
+            return;
+        }
+
+        if (_selectedId == Guid.Empty)
+        {
+            _families ??= await Api.GetWorkflowsAsync(CancellationToken.None) ?? Array.Empty<WorkflowTemplateSummaryDto>();
+            _selectedId = _families.FirstOrDefault()?.Id ?? Guid.Empty;
+        }
+
+        if (_selectedId != Guid.Empty)
+        {
+            await LoadAndPushAsync();
+            StateHasChanged();
         }
     }
 

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/js/workflow-editor-bridge.js
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/js/workflow-editor-bridge.js
@@ -38,6 +38,19 @@ window.shopfloorWorkflowBridge = (function () {
             // Editor finished booting — (re)send the load payload if we have it.
             if (pendingLoadJson) {
                 post(JSON.parse(pendingLoadJson));
+            } else if (dotNetRef) {
+                // No payload cached yet — ask the host to fetch + push it.
+                dotNetRef.invokeMethodAsync('OnLoadRequested');
+            }
+            return;
+        }
+
+        if (data.type === 'shopfloor.workflow.request-load') {
+            // Editor has no workflow — resend cached payload or ask host to fetch.
+            if (pendingLoadJson) {
+                post(JSON.parse(pendingLoadJson));
+            } else if (dotNetRef) {
+                dotNetRef.invokeMethodAsync('OnLoadRequested');
             }
             return;
         }

--- a/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-workflow-editor-prototype.html
+++ b/src/Modules/Shopfloor/LKvitai.MES.Modules.Shopfloor.WebUI/wwwroot/prototypes/shopfloor-workflow-editor-prototype.html
@@ -1434,8 +1434,16 @@ window.addEventListener("message", ev=>{
   }
 });
 
+/* Ask the host to (re)send the selected workflow. Self-heals cases where the
+   initial load handshake didn't deliver (slow circuit, iframe boot race). */
+let loadRequestedAt = 0;
+function requestLoadFromHost(){
+  loadRequestedAt = Date.now();
+  postToParent({ type:"shopfloor.workflow.request-load" });
+}
+
 $("#btnSave").onclick=()=>{
-  if(!state.workflowId){ toast("No workflow loaded"); return; }
+  if(!state.workflowId){ requestLoadFromHost(); toast("Loading workflow… try again in a moment."); return; }
   postToParent({ type:"shopfloor.workflow.save", workflowId:state.workflowId, graph:buildGraph() });
   toast("Saving…");
 };
@@ -1668,7 +1676,7 @@ function setBadge(arg){
 
 /* ── Validation lifecycle ──────────────────────── */
 function requestValidation(){
-  if(!state.workflowId){ toast("No workflow loaded"); return; }
+  if(!state.workflowId){ requestLoadFromHost(); toast("Loading workflow… try again in a moment."); return; }
   vBusy = true;
   setBadge("busy");
   $("#vreport").classList.remove("stale");
@@ -1736,6 +1744,10 @@ function boot(){
   requestAnimationFrame(()=>{ renderEdges(); syncSidebar(); fitView(); requestAnimationFrame(renderEdges); });
   // tell the Blazor host we are ready to receive the load payload
   postToParent({ type:"shopfloor.workflow.ready" });
+  // safety net: if no workflow arrives shortly (handshake race / slow circuit),
+  // explicitly ask the host to push the selected workflow.
+  setTimeout(()=>{ if(!state.workflowId) requestLoadFromHost(); }, 1500);
+  setTimeout(()=>{ if(!state.workflowId) requestLoadFromHost(); }, 4000);
 }
 boot();
 window.addEventListener("resize", ()=>renderEdges());


### PR DESCRIPTION
## Summary
- Fixes the editor showing **"No workflow loaded"** on Save/Validate when the initial load handshake doesn't deliver (slow Blazor Server circuit / iframe boot race), leaving `state.workflowId` null even though the canvas rendered.
- The editor now **requests a (re)load** from the host whenever it lacks a `workflowId`: on Save/Validate, and via post-boot retries (1.5s / 4s).
- The bridge relays `request-load` (and `ready` when no payload is cached yet) to `WorkflowEditor.OnLoadRequested`, which re-fetches the selected workflow and pushes it to the iframe.
- Status text refreshes after pushing (`StateHasChanged`).

Follows up #200 (validation engine) and #201 (editor wiring).

## Test plan
- [ ] Open Workflow Editor on the server with a family selected.
- [ ] Without re-selecting, click **Save** / **Validate** → workflow is fetched and pushed; the action proceeds (no "No workflow loaded").
- [ ] On a slow connection, confirm the post-boot retry pulls the workflow automatically.
- [ ] If the host genuinely cannot load (API/auth), status shows "Could not load workflow."

Made with [Cursor](https://cursor.com)